### PR TITLE
fix: correct consumer telemetry outcomes and links

### DIFF
--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
@@ -267,7 +267,8 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
                 startTime,
                 startTimestamp,
                 queue.Id,
-                createActivity: messages.Count > 0);
+                createActivity: messages.Count > 0,
+                messageProperties: messages.Select(static message => message.Properties));
             if (telemetry.Activity is { } activity)
             {
                 foreach (var message in messages)

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
@@ -763,7 +763,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             try
             {
                 result = await _messageHandler(message, cancellationToken).ConfigureAwait(false);
-                telemetry.Complete(true, result.ToString());
+                telemetry.Complete(result == ConsumeResult.Success, result.ToString());
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/EventHorizon.RocketMQ.Grpc/Instrumentation/GrpcRocketMQTelemetry.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Instrumentation/GrpcRocketMQTelemetry.cs
@@ -62,7 +62,8 @@ internal sealed class GrpcRocketMQTelemetry : IGrpcRocketMQTelemetry
         DateTimeOffset startTime,
         long startTimestamp,
         int? queueId = null,
-        bool createActivity = true) =>
+        bool createActivity = true,
+        IEnumerable<IReadOnlyDictionary<string, string>>? messageProperties = null) =>
         Start(
             "receive",
             "receive",
@@ -72,7 +73,7 @@ internal sealed class GrpcRocketMQTelemetry : IGrpcRocketMQTelemetry
             messageCount,
             null,
             null,
-            null,
+            messageProperties,
             parentContext,
             (startTime, startTimestamp),
             queueId,

--- a/src/EventHorizon.RocketMQ.Grpc/Instrumentation/IGrpcRocketMQTelemetry.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Instrumentation/IGrpcRocketMQTelemetry.cs
@@ -29,7 +29,8 @@ internal interface IGrpcRocketMQTelemetry
         DateTimeOffset startTime,
         long startTimestamp,
         int? queueId = null,
-        bool createActivity = true);
+        bool createActivity = true,
+        IEnumerable<IReadOnlyDictionary<string, string>>? messageProperties = null);
 
     IGrpcRocketMQTelemetryOperation StartProcess(
         string topic,

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pop/RemotingPopConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pop/RemotingPopConsumer.cs
@@ -154,7 +154,8 @@ internal sealed class RemotingPopConsumer : IRemotingPopConsumer
                 startTime,
                 startTimestamp,
                 queue.QueueId,
-                createActivity: result.Messages.Count > 0);
+                createActivity: result.Messages.Count > 0,
+                messageProperties: result.Messages.Select(static message => message.Message.Properties));
             telemetry.Complete();
             return result;
         }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
@@ -1512,7 +1512,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         try
         {
             var result = await _messageHandler(message, cancellationToken).ConfigureAwait(false);
-            telemetry.Complete(true, result.ToString());
+            telemetry.Complete(result == ConsumeResult.Success, result.ToString());
             return result;
         }
         catch (Exception exception)

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/RemotingConsumerEngine.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/RemotingConsumerEngine.cs
@@ -212,7 +212,8 @@ internal sealed class RemotingConsumerEngine : IRemotingConsumerEngine
                 startTime,
                 startTimestamp,
                 queue.QueueId,
-                createActivity: result.Messages.Count > 0);
+                createActivity: result.Messages.Count > 0,
+                messageProperties: result.Messages.Select(static message => message.Properties));
             if (telemetry.Activity is { } activity)
             {
                 foreach (var message in result.Messages)

--- a/src/EventHorizon.RocketMQ.Remoting/Instrumentation/IRemotingRocketMQTelemetry.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Instrumentation/IRemotingRocketMQTelemetry.cs
@@ -29,7 +29,8 @@ internal interface IRemotingRocketMQTelemetry
         DateTimeOffset startTime,
         long startTimestamp,
         int? queueId = null,
-        bool createActivity = true);
+        bool createActivity = true,
+        IEnumerable<IReadOnlyDictionary<string, string>>? messageProperties = null);
 
     IRemotingRocketMQTelemetryOperation StartProcess(
         string topic,

--- a/src/EventHorizon.RocketMQ.Remoting/Instrumentation/RemotingRocketMQTelemetry.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Instrumentation/RemotingRocketMQTelemetry.cs
@@ -62,7 +62,8 @@ internal sealed class RemotingRocketMQTelemetry : IRemotingRocketMQTelemetry
         DateTimeOffset startTime,
         long startTimestamp,
         int? queueId = null,
-        bool createActivity = true) =>
+        bool createActivity = true,
+        IEnumerable<IReadOnlyDictionary<string, string>>? messageProperties = null) =>
         Start(
             "receive",
             "receive",
@@ -72,7 +73,7 @@ internal sealed class RemotingRocketMQTelemetry : IRemotingRocketMQTelemetry
             messageCount,
             null,
             null,
-            null,
+            messageProperties,
             parentContext,
             (startTime, startTimestamp),
             queueId,

--- a/tests/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
@@ -14,12 +14,14 @@
 // limitations under the License.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Channels;
 using EventHorizon.RocketMQ.Grpc.Consumer;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using EventHorizon.RocketMQ.Grpc.Consumer.Simple;
 using EventHorizon.RocketMQ.Grpc.Exceptions;
+using EventHorizon.RocketMQ.Grpc.Instrumentation;
 using EventHorizon.RocketMQ.Grpc.Protocol;
 using EventHorizon.RocketMQ.Grpc.Protocol.Route;
 using EventHorizon.RocketMQ.Grpc.Protocol.Telemetry;
@@ -715,6 +717,41 @@ public sealed class GrpcPushConsumerTests
     }
 
     [Fact]
+    public async Task Worker_RecordsRetryAsFailedProcessTelemetry()
+    {
+        var operation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete(false, ConsumeResult.Retry.ToString()));
+        operation.Setup(value => value.Dispose());
+        var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartProcess(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<ActivityContext?>()))
+            .Returns(operation.Object);
+        var client = new FakeGrpcClient();
+        await using var consumer = CreateConsumer(
+            client,
+            static (_, _) => ValueTask.FromResult(ConsumeResult.Retry),
+            out var engine,
+            telemetry: telemetry.Object);
+
+        await RunWorkerAsync(
+            consumer,
+            engine,
+            TestContext.Current.CancellationToken,
+            Message("message-1"));
+
+        operation.Verify(value => value.Complete(false, ConsumeResult.Retry.ToString()), Times.Once);
+        operation.Verify(value => value.Dispose(), Times.Once);
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
     public async Task Worker_RetriesDeadLetterAfterTransientFailureAndContinues()
     {
         var client = new FakeGrpcClient();
@@ -1022,9 +1059,10 @@ public sealed class GrpcPushConsumerTests
         Func<GrpcMessageView, CancellationToken, ValueTask<ConsumeResult>> handler,
         Action<GrpcPushConsumerOptions>? configure = null,
         IGrpcRouteService? routes = null,
-        ILogger<GrpcReceiveConsumerEngine>? engineLogger = null)
+        ILogger<GrpcReceiveConsumerEngine>? engineLogger = null,
+        IGrpcRocketMQTelemetry? telemetry = null)
     {
-        return CreateConsumer(client, handler, out _, configure, routes, engineLogger);
+        return CreateConsumer(client, handler, out _, configure, routes, engineLogger, telemetry);
     }
 
     private static GrpcPushConsumer CreateConsumer(
@@ -1033,7 +1071,8 @@ public sealed class GrpcPushConsumerTests
         out GrpcReceiveConsumerEngine engine,
         Action<GrpcPushConsumerOptions>? configure = null,
         IGrpcRouteService? routes = null,
-        ILogger<GrpcReceiveConsumerEngine>? engineLogger = null)
+        ILogger<GrpcReceiveConsumerEngine>? engineLogger = null,
+        IGrpcRocketMQTelemetry? telemetry = null)
     {
         var options = PushOptions(handler);
         configure?.Invoke(options);
@@ -1050,7 +1089,8 @@ public sealed class GrpcPushConsumerTests
         return new GrpcPushConsumer(
             Options.Create(options),
             engine,
-            NullLogger<GrpcPushConsumer>.Instance);
+            NullLogger<GrpcPushConsumer>.Instance,
+            telemetry: telemetry);
     }
 
     private static GrpcReceiveConsumerEngine CreateEngine(FakeGrpcClient client)

--- a/tests/EventHorizon.RocketMQ.Grpc.Tests/Instrumentation/GrpcRocketMQTelemetryTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.Tests/Instrumentation/GrpcRocketMQTelemetryTests.cs
@@ -164,6 +164,42 @@ public sealed class GrpcRocketMQTelemetryTests
     }
 
     [Fact]
+    public void StartReceive_LinksProducerContexts()
+    {
+        using var listener = CreateActivityListener();
+        using var provider = CreateServiceProvider();
+        var telemetry = CreateTelemetry(provider);
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var messageProperties = new IReadOnlyDictionary<string, string>[]
+        {
+            new Dictionary<string, string>
+            {
+                ["traceparent"] = $"00-{traceId}-{spanId}-01"
+            },
+            new Dictionary<string, string>
+            {
+                ["traceparent"] = "invalid"
+            }
+        };
+
+        using var receive = telemetry.StartReceive(
+            "orders",
+            "orders-consumer",
+            2,
+            null,
+            DateTimeOffset.UtcNow,
+            Stopwatch.GetTimestamp(),
+            messageProperties: messageProperties);
+        var receiveActivity = Assert.IsType<Activity>(receive.Activity);
+        receive.Complete();
+
+        var link = Assert.Single(receiveActivity.Links);
+        Assert.Equal(traceId, link.Context.TraceId);
+        Assert.Equal(spanId, link.Context.SpanId);
+    }
+
+    [Fact]
     public void StartProcess_UsesProducerContextAsParentWithoutReceiveContext()
     {
         using var listener = CreateActivityListener();

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
@@ -15,12 +15,14 @@
 
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net;
 using System.Text;
 using System.Text.Json;
 using EventHorizon.RocketMQ.Remoting.Consumer;
 using EventHorizon.RocketMQ.Remoting.Consumer.Pull;
 using EventHorizon.RocketMQ.Remoting.Consumer.Push;
+using EventHorizon.RocketMQ.Remoting.Instrumentation;
 using EventHorizon.RocketMQ.Remoting.Protocol;
 using EventHorizon.RocketMQ.Remoting.Protocol.Route;
 using Microsoft.Extensions.Logging;
@@ -846,6 +848,91 @@ public sealed class RemotingPushConsumerTests
         {
             File.Delete(offsetPath);
         }
+    }
+
+    [Theory]
+    [InlineData(ConsumeResult.Retry)]
+    [InlineData(ConsumeResult.DeadLetter)]
+    public async Task UnsuccessfulHandlerResult_RecordsFailedProcessTelemetry(ConsumeResult result)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var offsetPath = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"rocketmq-broadcast-telemetry-{Guid.NewGuid():N}.json");
+        var receiveOperation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        receiveOperation.SetupGet(value => value.Activity).Returns((Activity?)null);
+        receiveOperation.Setup(value => value.Complete());
+        receiveOperation.Setup(value => value.Dispose());
+        var processCompleted = new TaskCompletionSource<(bool Success, string? Outcome)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processOperation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        processOperation
+            .Setup(value => value.Complete(It.IsAny<bool>(), It.IsAny<string?>()))
+            .Callback<bool, string?>((success, outcome) => processCompleted.TrySetResult((success, outcome)));
+        processOperation.Setup(value => value.Dispose());
+        var telemetry = new Mock<IRemotingRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartReceive(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<ActivityContext?>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<long>(),
+                It.IsAny<int?>(),
+                It.IsAny<bool>(),
+                It.IsAny<IEnumerable<IReadOnlyDictionary<string, string>>?>()))
+            .Returns(receiveOperation.Object);
+        telemetry
+            .Setup(value => value.StartProcess(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<ActivityContext?>()))
+            .Returns(processOperation.Object);
+        var delivered = 0;
+        var remoting = new FakeRemotingClient("127.0.0.1@telemetry-test")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(CreateMessageRecord("orders", "telemetry-message", null, 0, 1_000), 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = CreateBroadcastOptions(
+            offsetPath,
+            (_, _) => ValueTask.FromResult(result));
+        try
+        {
+            await using var consumer = CreateRemotingPushConsumer(
+                options,
+                CreateRouteServiceMock().Object,
+                remoting,
+                "telemetry-test",
+                telemetry.Object);
+            await consumer.StartAsync(cancellationToken);
+            var processOutcome = await processCompleted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            Assert.False(processOutcome.Success);
+            Assert.Equal(result.ToString(), processOutcome.Outcome);
+            await consumer.StopAsync(cancellationToken);
+        }
+        finally
+        {
+            File.Delete(offsetPath);
+        }
+
+        telemetry.VerifyAll();
+        receiveOperation.VerifyAll();
+        processOperation.VerifyAll();
     }
 
     [Fact]
@@ -1740,7 +1827,8 @@ public sealed class RemotingPushConsumerTests
         RemotingPushConsumerOptions options,
         ITopicRouteService routes,
         IRemotingClient remoting,
-        string instanceName) => CreateRemotingPushConsumer(
+        string instanceName,
+        IRemotingRocketMQTelemetry? telemetry = null) => CreateRemotingPushConsumer(
             Options.Create(options),
             Options.Create(new RemotingClientOptions
             {
@@ -1752,7 +1840,8 @@ public sealed class RemotingPushConsumerTests
             routes,
             remoting,
             TimeProvider.System,
-            NullLogger<RemotingPushConsumer>.Instance);
+            NullLogger<RemotingPushConsumer>.Instance,
+            telemetry);
 
     private static RemotingPushConsumer CreateRemotingPushConsumer(
         IOptions<RemotingPushConsumerOptions> options,
@@ -1760,7 +1849,8 @@ public sealed class RemotingPushConsumerTests
         ITopicRouteService routes,
         IRemotingClient remoting,
         TimeProvider timeProvider,
-        ILogger<RemotingPushConsumer> logger)
+        ILogger<RemotingPushConsumer> logger,
+        IRemotingRocketMQTelemetry? telemetry = null)
     {
         var consumerEngine = CreateRemotingConsumerEngine(
             options.Value,
@@ -1770,7 +1860,8 @@ public sealed class RemotingPushConsumerTests
             clientOptions,
             routes,
             remoting,
-            timeProvider);
+            timeProvider,
+            telemetry);
         return new RemotingPushConsumer(
             options,
             clientOptions,
@@ -1778,7 +1869,8 @@ public sealed class RemotingPushConsumerTests
             routes,
             remoting,
             timeProvider,
-            logger);
+            logger,
+            telemetry: telemetry);
     }
 
     private static RemotingConsumerEngine CreateRemotingConsumerEngine(
@@ -1789,7 +1881,8 @@ public sealed class RemotingPushConsumerTests
         IOptions<RemotingClientOptions> clientOptions,
         ITopicRouteService routes,
         IRemotingClient remoting,
-        TimeProvider timeProvider) =>
+        TimeProvider timeProvider,
+        IRemotingRocketMQTelemetry? telemetry = null) =>
         new(
             new RemotingConsumerSettings(
                 options.GroupName,
@@ -1800,7 +1893,8 @@ public sealed class RemotingPushConsumerTests
             clientOptions,
             routes,
             remoting,
-            timeProvider);
+            timeProvider,
+            telemetry);
 
     private static Mock<ITopicRouteService> CreateRouteServiceMock(
         int queueCount = 1,

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Instrumentation/RemotingRocketMQTelemetryTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Instrumentation/RemotingRocketMQTelemetryTests.cs
@@ -165,6 +165,52 @@ public sealed class RemotingRocketMQTelemetryTests
     }
 
     [Fact]
+    public void StartReceive_LinksProducerContexts()
+    {
+        using var listener = CreateActivityListener();
+        using var provider = CreateServiceProvider();
+        var telemetry = CreateTelemetry(provider);
+        var firstTraceId = ActivityTraceId.CreateRandom();
+        var firstSpanId = ActivitySpanId.CreateRandom();
+        var secondTraceId = ActivityTraceId.CreateRandom();
+        var secondSpanId = ActivitySpanId.CreateRandom();
+        var messageProperties = new IReadOnlyDictionary<string, string>[]
+        {
+            new Dictionary<string, string>
+            {
+                ["traceparent"] = $"00-{firstTraceId}-{firstSpanId}-01"
+            },
+            new Dictionary<string, string>
+            {
+                ["traceparent"] = "invalid"
+            },
+            new Dictionary<string, string>
+            {
+                ["traceparent"] = $"00-{secondTraceId}-{secondSpanId}-01"
+            }
+        };
+
+        using var receive = telemetry.StartReceive(
+            "orders",
+            "orders-consumer",
+            3,
+            null,
+            DateTimeOffset.UtcNow,
+            Stopwatch.GetTimestamp(),
+            3,
+            messageProperties: messageProperties);
+        var receiveActivity = Assert.IsType<Activity>(receive.Activity);
+        receive.Complete();
+
+        var links = receiveActivity.Links.ToArray();
+        Assert.Equal(2, links.Length);
+        Assert.Equal(firstTraceId, links[0].Context.TraceId);
+        Assert.Equal(firstSpanId, links[0].Context.SpanId);
+        Assert.Equal(secondTraceId, links[1].Context.TraceId);
+        Assert.Equal(secondSpanId, links[1].Context.SpanId);
+    }
+
+    [Fact]
     public void StartProcess_UsesProducerContextAsParentWithoutReceiveContext()
     {
         using var listener = CreateActivityListener();


### PR DESCRIPTION
## Summary

- Record Push `Retry` and `DeadLetter` results as failed OpenTelemetry operations.
- Link gRPC Simple and Remoting Pull, Lite Pull, and POP receive spans to propagated producer contexts.
- Add focused regression coverage for receive links and failed handler outcomes.

## Validation

- `dotnet format EventHorizon.RocketMQ.sln --no-restore`
- `dotnet restore EventHorizon.RocketMQ.sln --tl:off`
- `dotnet build EventHorizon.RocketMQ.sln --no-restore --tl:off`
- gRPC, Remoting, and compatibility unit tests: 165 + 306 + 20 passed
- gRPC integration tests: 9 passed
- Remoting integration tests: 16 passed