### PR TITLE
feat: add partial remoting push batch acknowledgements

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "true"
   DOTNET_NOLOGO: "true"
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
 jobs:
   validate:
@@ -33,6 +34,14 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.*.props', '**/Directory.*.targets', 'NuGet.config') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
 
       - name: Restore
         run: dotnet restore EventHorizon.RocketMQ.sln
@@ -87,10 +96,39 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   integration:
-    name: Docker integration tests and coverage
+    name: ${{ matrix.protocol }} ${{ matrix.topology }} Docker integration tests and coverage
     needs: validate
     runs-on: ubuntu-latest
     timeout-minutes: 40
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - protocol: gRPC
+            topology: single-Broker
+            test_project: tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
+            test_filter: Topology!=MultiBroker
+            coverage_directory: grpc-single-broker-integration
+            coverage_name: dotnet-grpc-single-broker-integration-tests
+          - protocol: gRPC
+            topology: multi-Broker
+            test_project: tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
+            test_filter: Topology=MultiBroker
+            coverage_directory: grpc-multi-broker-integration
+            coverage_name: dotnet-grpc-multi-broker-integration-tests
+          - protocol: Remoting
+            topology: single-Broker
+            test_project: tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj
+            test_filter: Topology!=MultiBroker
+            coverage_directory: remoting-single-broker-integration
+            coverage_name: dotnet-remoting-single-broker-integration-tests
+          - protocol: Remoting
+            topology: multi-Broker
+            test_project: tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj
+            test_filter: Topology=MultiBroker
+            coverage_directory: remoting-multi-broker-integration
+            coverage_name: dotnet-remoting-multi-broker-integration-tests
 
     steps:
       - name: Checkout
@@ -101,32 +139,33 @@ jobs:
         with:
           global-json-file: global.json
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('global.json', '**/*.csproj', '**/Directory.*.props', '**/Directory.*.targets', 'NuGet.config') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore
-        run: dotnet restore EventHorizon.RocketMQ.sln
-
-      - name: Build
         run: >-
-          dotnet build EventHorizon.RocketMQ.sln
+          dotnet restore "${{ matrix.test_project }}"
+
+      - name: Build integration tests
+        run: >-
+          dotnet build "${{ matrix.test_project }}"
           --configuration Release
           --no-restore
 
-      - name: Test gRPC integration
+      - name: Test integration
         run: >-
-          dotnet test tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
-          --configuration Release
-          --no-build
-          --no-restore
-          --collect:"XPlat Code Coverage"
-          --results-directory "${{ runner.temp }}/coverage/grpc-integration"
-
-      - name: Test Remoting integration
-        run: >-
-          dotnet test tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj
+          dotnet test "${{ matrix.test_project }}"
           --configuration Release
           --no-build
           --no-restore
+          --filter "${{ matrix.test_filter }}"
           --collect:"XPlat Code Coverage"
-          --results-directory "${{ runner.temp }}/coverage/remoting-integration"
+          --results-directory "${{ runner.temp }}/coverage/${{ matrix.coverage_directory }}"
 
       - name: Upload integration coverage to Codecov
         uses: codecov/codecov-action@v7
@@ -134,5 +173,5 @@ jobs:
           directory: ${{ runner.temp }}/coverage
           fail_ci_if_error: true
           flags: integration-tests
-          name: dotnet-integration-tests
+          name: ${{ matrix.coverage_name }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See the [Remoting guide](src/EventHorizon.RocketMQ.Remoting/README.md) and
 | PullConsumer | ✅ | Explicit queues and offsets with tag or SQL filtering. |
 | LitePullConsumer | ✅ | Client-side polling, assignment, seek, pause/resume, and commit; clustered consumption only. |
 | POPConsumer | ✅ | Explicit queue selection, receipt acknowledgement, and invisibility renewal; normal topics only. |
-| PushConsumer | ✅ | Clustering or broadcasting, concurrent batch callbacks or singleton FIFO dispatch, runtime subscriptions, retry, and DLQ handling. |
+| PushConsumer | ✅ | Clustering or broadcasting, concurrent batch callbacks with partial prefix acknowledgement or singleton FIFO dispatch, runtime subscriptions, retry, and DLQ handling. |
 | Dependency injection, options, logging, Generic Host lifecycle, and default or keyed client registrations | ✅ | Register with `AddRocketMQRemoting`. |
 | OpenTelemetry tracing and metrics | ✅ | Register with `AddRocketMQRemotingInstrumentation`; the application selects SDK processors and exporters. |
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See the [Remoting guide](src/EventHorizon.RocketMQ.Remoting/README.md) and
 | PullConsumer | ✅ | Explicit queues and offsets with tag or SQL filtering. |
 | LitePullConsumer | ✅ | Client-side polling, assignment, seek, pause/resume, and commit; clustered consumption only. |
 | POPConsumer | ✅ | Explicit queue selection, receipt acknowledgement, and invisibility renewal; normal topics only. |
-| PushConsumer | ✅ | Clustering or broadcasting, concurrent or FIFO dispatch, runtime subscriptions, retry, and DLQ handling. |
+| PushConsumer | ✅ | Clustering or broadcasting, concurrent batch callbacks or singleton FIFO dispatch, runtime subscriptions, retry, and DLQ handling. |
 | Dependency injection, options, logging, Generic Host lifecycle, and default or keyed client registrations | ✅ | Register with `AddRocketMQRemoting`. |
 | OpenTelemetry tracing and metrics | ✅ | Register with `AddRocketMQRemotingInstrumentation`; the application selects SDK processors and exporters. |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,7 +68,7 @@ gRPC Push 和 LitePush 都依靠客户端主动查询分配结果并执行长轮
 | PullConsumer | ✅ | 可显式指定队列和位点，并支持 Tag 或 SQL 过滤。 |
 | LitePullConsumer | ✅ | 由客户端完成轮询、队列分配、seek、暂停/恢复和提交；目前仅支持集群消费。 |
 | POPConsumer | ✅ | 可显式选择队列、使用 receipt 确认消息并续期不可见时长；仅适用于普通 topic。 |
-| PushConsumer | ✅ | 支持集群或广播模式、并发批量回调或单消息 FIFO 分发、运行时订阅、重试和死信处理。 |
+| PushConsumer | ✅ | 支持集群或广播模式、可部分确认前缀的并发批量回调或单消息 FIFO 分发、运行时订阅、重试和死信处理。 |
 | Microsoft DI、Options、日志、Generic Host 生命周期，以及默认或 keyed 客户端注册 | ✅ | 使用 `AddRocketMQRemoting` 注册。 |
 | OpenTelemetry tracing 和 metrics | ✅ | 使用 `AddRocketMQRemotingInstrumentation` 注册；SDK processor 和 exporter 由应用选择。 |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,7 +68,7 @@ gRPC Push 和 LitePush 都依靠客户端主动查询分配结果并执行长轮
 | PullConsumer | ✅ | 可显式指定队列和位点，并支持 Tag 或 SQL 过滤。 |
 | LitePullConsumer | ✅ | 由客户端完成轮询、队列分配、seek、暂停/恢复和提交；目前仅支持集群消费。 |
 | POPConsumer | ✅ | 可显式选择队列、使用 receipt 确认消息并续期不可见时长；仅适用于普通 topic。 |
-| PushConsumer | ✅ | 支持集群或广播模式、并发或 FIFO 分发、运行时订阅、重试和死信处理。 |
+| PushConsumer | ✅ | 支持集群或广播模式、并发批量回调或单消息 FIFO 分发、运行时订阅、重试和死信处理。 |
 | Microsoft DI、Options、日志、Generic Host 生命周期，以及默认或 keyed 客户端注册 | ✅ | 使用 `AddRocketMQRemoting` 注册。 |
 | OpenTelemetry tracing 和 metrics | ✅ | 使用 `AddRocketMQRemotingInstrumentation` 注册；SDK processor 和 exporter 由应用选择。 |
 

--- a/docs/en-US/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/en-US/architecture/dependency-injection-and-lifetimes.md
@@ -92,14 +92,29 @@ registration is keyed to the internal role key, so handlers cannot cross client-
 | Handler lifetime | Resolution behavior |
 | --- | --- |
 | `Singleton` | The handler is resolved from the root provider and reused. It must be safe for concurrent delivery. |
-| `Scoped` | A new async scope is created for each delivered message, then disposed after handling. |
-| `Transient` | A new async scope is created for each delivered message; the transient handler and its scoped dependencies are disposed with that scope. |
+| `Scoped` | A new async scope is created for each handler invocation, then disposed after handling. |
+| `Transient` | A new async scope is created for each handler invocation; the transient handler and its scoped dependencies are disposed with that scope. |
 
 The concrete implementation is visible in the
 [gRPC handler factory](../../../src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushMessageHandlerFactory.cs)
 and [Remoting handler factory](../../../src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushMessageHandlerFactory.cs).
 Use the typed overload when a handler needs DI. The `MessageHandler` option is a direct delegate and
-does not create an application DI scope for the caller.
+does not create an application DI scope for the caller. gRPC Push and LitePush invoke their handlers for each
+message. Remoting Push invokes its one `IRemotingPushMessageHandler` API with an
+`IReadOnlyList<RemotingMessageView>` for each batch; its `ConsumeMessageBatchSize` defaults to `1`, so existing
+settings retain singleton delivery unless configured otherwise. The direct Remoting `MessageHandler` delegate uses
+the same list-based contract.
+
+For non-FIFO gRPC Push and LitePush messages, `ConsumeTimeout` cancels the handler token, stops client-side
+invisibility renewal, and requests retry when the configured limit elapses. The dispatcher ignores a late result and
+releases its worker, but it cannot terminate application code. A timed-out invocation can overlap redelivery and must
+be idempotent. Its typed-handler async scope remains alive until that invocation returns, so scoped dependencies are
+not disposed while handler code is still running. FIFO message groups are excluded to preserve ordering.
+
+For concurrent clustered non-FIFO Remoting batches, `ConsumeTimeout` cancels the handler token and requests Broker
+redelivery when the configured limit elapses. A late result is ignored and can overlap redelivery, so the handler still
+owns cancellation cooperation and must be idempotent; the runtime cannot forcibly stop application code. FIFO and
+orderly delivery remain excluded to preserve ordering guarantees.
 
 ## Trade-offs and Constraints
 

--- a/docs/en-US/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/en-US/architecture/dependency-injection-and-lifetimes.md
@@ -101,9 +101,11 @@ and [Remoting handler factory](../../../src/EventHorizon.RocketMQ.Remoting/Consu
 Use the typed overload when a handler needs DI. The `MessageHandler` option is a direct delegate and
 does not create an application DI scope for the caller. gRPC Push and LitePush invoke their handlers for each
 message. Remoting Push invokes its one `IRemotingPushMessageHandler` API with an
-`IReadOnlyList<RemotingMessageView>` for each batch; its `ConsumeMessageBatchSize` defaults to `1`, so existing
-settings retain singleton delivery unless configured otherwise. The direct Remoting `MessageHandler` delegate uses
-the same list-based contract.
+`IReadOnlyList<RemotingMessageView>` and a `RemotingPushConsumeContext` for each batch; its
+`ConsumeMessageBatchSize` defaults to `1`, so existing settings retain singleton delivery unless configured
+otherwise. For a concurrent non-FIFO batch, a handler can return `Success` with `AckIndex` set to confirm a
+contiguous prefix and retry its tail; `Retry` and `DeadLetter` remain whole-batch outcomes. The direct Remoting
+`MessageHandler` delegate uses the same list-and-context contract.
 
 For non-FIFO gRPC Push and LitePush messages, `ConsumeTimeout` cancels the handler token, stops client-side
 invisibility renewal, and requests retry when the configured limit elapses. The dispatcher ignores a late result and

--- a/docs/en-US/grpc/consumer-model.md
+++ b/docs/en-US/grpc/consumer-model.md
@@ -87,6 +87,12 @@ dispatches work according to the configured concurrency and FIFO settings. It is
 long polling from end to end. Calling it protocol-level Broker push would give the wrong operational
 model.
 
+For non-FIFO dispatch, `ConsumeTimeout` defaults to 15 minutes. When it expires, the dispatcher cancels the handler
+token, stops client-side invisibility renewal, and requests retry; a late successful result is ignored. This recovers
+worker capacity even when application code ignores cancellation, but the client cannot forcibly terminate that code.
+Retried delivery can overlap an invocation that ignored cancellation, so handlers must be idempotent. FIFO message
+groups are intentionally excluded because detaching a timed-out handler could break their ordering.
+
 ### LitePushConsumer
 
 LitePush wraps the automatic dispatcher with a

--- a/docs/en-US/remoting/transport-and-client-roles.md
+++ b/docs/en-US/remoting/transport-and-client-roles.md
@@ -74,12 +74,25 @@ The Remoting builder offers roles with semantics that belong to classic RocketMQ
 | `IRemotingPullConsumer` | Explicit route, queue, pull, offset, and commit control. |
 | `IRemotingLitePullConsumer` | Client-managed Lite Pull subscriptions, polling, and offset commits. |
 | `IRemotingPopConsumer` | POP receipt acquisition, acknowledgement, and invisibility renewal. |
-| `IRemotingPushConsumer` | Automatic long-poll dispatch with classic Remoting compatibility and Broker callback handling. |
+| `IRemotingPushConsumer` | Automatic long-poll batch dispatch with classic Remoting compatibility and Broker callback handling. |
 
 The role registrations live in
 [`RemotingRocketMQBuilderExtensions`](../../../src/EventHorizon.RocketMQ.Remoting/RemotingRocketMQBuilderExtensions.cs).
 Push is still driven by classic pull/long-poll behavior internally; it is not identical to the
 gRPC Push implementation and should not be treated as a common transport-neutral role.
+
+Remoting Push has one batch-oriented handler API: `IRemotingPushMessageHandler.HandleAsync` receives an
+`IReadOnlyList<RemotingMessageView>`. `BatchSize` limits how many messages one long poll requests from the Broker;
+`ConsumeMessageBatchSize` independently limits how many messages one handler invocation receives and defaults to
+`1`. Concurrent non-`MessageGroup` messages from the same Broker physical queue can be grouped and those batches
+can run in parallel up to `MaxConcurrency`. `MessageGroup` FIFO deliveries and `ConsumeOrderly` deliveries remain
+singleton and serialized. One `ConsumeResult` applies to every message in its batch.
+
+`ConsumeTimeout` defaults to 15 minutes and applies only to concurrent clustered non-FIFO batches. When it elapses,
+the client cancels the handler token and requests Broker redelivery for the whole batch. It cannot forcibly terminate
+application code that ignores cancellation; its late result is ignored and can overlap redelivery, so handlers must
+cooperate with the token and remain idempotent. FIFO and orderly delivery intentionally remain outside this recovery
+path to preserve ordering guarantees.
 
 ### Read-only Admin and physical message IDs
 

--- a/docs/en-US/remoting/transport-and-client-roles.md
+++ b/docs/en-US/remoting/transport-and-client-roles.md
@@ -82,11 +82,18 @@ Push is still driven by classic pull/long-poll behavior internally; it is not id
 gRPC Push implementation and should not be treated as a common transport-neutral role.
 
 Remoting Push has one batch-oriented handler API: `IRemotingPushMessageHandler.HandleAsync` receives an
-`IReadOnlyList<RemotingMessageView>`. `BatchSize` limits how many messages one long poll requests from the Broker;
-`ConsumeMessageBatchSize` independently limits how many messages one handler invocation receives and defaults to
-`1`. Concurrent non-`MessageGroup` messages from the same Broker physical queue can be grouped and those batches
-can run in parallel up to `MaxConcurrency`. `MessageGroup` FIFO deliveries and `ConsumeOrderly` deliveries remain
-singleton and serialized. One `ConsumeResult` applies to every message in its batch.
+`IReadOnlyList<RemotingMessageView>` and a `RemotingPushConsumeContext`. `BatchSize` limits how many messages one
+long poll requests from the Broker; `ConsumeMessageBatchSize` independently limits how many messages one handler
+invocation receives and defaults to `1`. Concurrent non-`MessageGroup` messages from the same Broker physical queue
+can be grouped and those batches can run in parallel up to `MaxConcurrency`. `MessageGroup` FIFO deliveries and
+`ConsumeOrderly` deliveries remain singleton and serialized.
+
+`Success` normally confirms the complete batch. A concurrent non-FIFO handler can set `AckIndex` to the zero-based
+index of the final accepted message before returning `Success`; the client confirms that contiguous prefix and retries
+only its tail. `Retry` and `DeadLetter` apply to every message regardless of `AckIndex`. The context also exposes
+`DelayLevelWhenNextConsume` for the unacknowledged tail: `0` delegates retry timing to the Broker, a positive value
+selects a RocketMQ delay level, and a negative value requests direct dead-lettering. Broadcasting does not have a
+Broker retry or dead-letter path, so an unacknowledged tail is skipped.
 
 `ConsumeTimeout` defaults to 15 minutes and applies only to concurrent clustered non-FIFO batches. When it elapses,
 the client cancels the handler token and requests Broker redelivery for the whole batch. It cannot forcibly terminate

--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -46,7 +46,7 @@ protocol Projects:
 - [`tests/EventHorizon.RocketMQ.Compatibility.Tests`](../../../tests/EventHorizon.RocketMQ.Compatibility.Tests)
 
 They validate isolated behavior such as serialization, route caching, client lifecycle, handler
-lifetimes, and public contracts without depending on a Broker. The compatibility tests compile
+lifetimes, batch-prefix acknowledgement, and public contracts without depending on a Broker. The compatibility tests compile
 against both protocol Projects to verify both public APIs, namespace separation, and dual-Package
 consumption. Replaceable collaborators normally use Moq;
 purpose-built fakes remain appropriate for stateful framing, streaming, or concurrency behavior

--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -91,12 +91,16 @@ them.
 
 ### CI coverage
 
-GitHub Actions runs the Docker-backed gRPC and Remoting integration-test projects in a separate
-`ubuntu-latest` job after formatting, build, and unit-test validation complete. The job has its own
-timeout budget because Testcontainers must pull images and start the Broker, NameServer, and Proxy
-fixtures. Both integration projects collect Cobertura reports and upload them to Codecov with the
-`integration-tests` flag. Codecov combines those reports with the `unit-tests` reports; the
-repository configuration continues to exclude `samples` from coverage.
+GitHub Actions runs the Docker-backed gRPC and Remoting integration-test projects in four parallel
+`ubuntu-latest` matrix jobs after formatting, build, and unit-test validation complete: one
+single-Broker and one multi-Broker job for each protocol. A class-level `Topology=MultiBroker` trait
+selects the multi-Broker tests; the single-Broker jobs run the complementary set. Each job restores
+and builds only its protocol-specific integration-test dependency graph, has its own timeout budget,
+and reuses the repository's NuGet package cache. Testcontainers still starts isolated Broker,
+NameServer, and Proxy fixtures for every job. All four jobs collect Cobertura reports and upload them
+to Codecov with distinct upload names under the shared `integration-tests` flag. Codecov combines
+those reports with the `unit-tests` reports; the repository configuration continues to exclude
+`samples` from coverage.
 
 ### Manual Compose environment
 

--- a/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
@@ -117,13 +117,27 @@ Push 和 LitePush 可接收委托，也可注册实现 `IGrpcPushMessageHandler`
 | handler 生命周期 | 实例与 scope 行为 |
 | --- | --- |
 | `Singleton` | 直接复用一个 handler；它只能依赖 singleton 或安全的工厂/抽象。 |
-| `Scoped` | 每次消息处理创建一个异步 DI scope，并从该 scope 解析 handler。 |
-| `Transient` | 同样为每次处理创建一个异步 DI scope，再取得新的 handler。 |
+| `Scoped` | 每次 handler 调用创建一个异步 DI scope，并从该 scope 解析 handler。 |
+| `Transient` | 同样为每次 handler 调用创建一个异步 DI scope，再取得新的 handler。 |
 
 因此，scoped handler 可以安全地依赖 scoped 服务；但 singleton handler 不能捕获 scoped 依赖。启用
 容器 scope 校验时，后者会在容器构建或解析阶段暴露为生命周期错误，而不是在长轮询运行后才随机失败。
 
-具体的 per-message scope 逻辑位于
+gRPC Push 和 LitePush 会为每条消息调用 handler。Remoting Push 则通过唯一的
+`IRemotingPushMessageHandler` API，在每次批量回调中传入 `IReadOnlyList<RemotingMessageView>`；其
+`ConsumeMessageBatchSize` 默认值为 `1`，因此除非显式配置，否则仍是单消息投递。
+直接配置的 Remoting `MessageHandler` 委托也使用相同的列表合约。
+
+对于非 FIFO 的 gRPC Push 和 LitePush 消息，`ConsumeTimeout` 到期后会取消 handler token、停止客户端不可见时间续期，并请求
+重新投递。dispatcher 会忽略延迟返回的结果并释放 worker，但无法终止应用代码。超时调用可能与重新投递重叠，因此必须保持幂等。
+对应 typed handler 的异步 scope 会一直存活到该调用返回，因此 handler 代码仍在运行时不会提前释放 scoped 依赖。FIFO message group
+为了保持顺序而不会应用此机制。
+
+对于并发集群、非 FIFO 的 Remoting 批次，`ConsumeTimeout` 到期后会取消 handler token，并请求 Broker 重新投递。
+延迟返回的结果会被忽略，并可能与重新投递重叠，因此 handler 仍需自行配合取消并保持幂等；运行时不能强制停止应用代码。
+FIFO 和顺序投递为保持顺序保证而不会应用此机制。
+
+对应的 handler scope 逻辑位于
 [`GrpcPushMessageHandlerFactory`](../../../src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushMessageHandlerFactory.cs)
 和
 [`RemotingPushMessageHandlerFactory`](../../../src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushMessageHandlerFactory.cs)。

--- a/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
@@ -124,9 +124,11 @@ Push 和 LitePush 可接收委托，也可注册实现 `IGrpcPushMessageHandler`
 容器 scope 校验时，后者会在容器构建或解析阶段暴露为生命周期错误，而不是在长轮询运行后才随机失败。
 
 gRPC Push 和 LitePush 会为每条消息调用 handler。Remoting Push 则通过唯一的
-`IRemotingPushMessageHandler` API，在每次批量回调中传入 `IReadOnlyList<RemotingMessageView>`；其
-`ConsumeMessageBatchSize` 默认值为 `1`，因此除非显式配置，否则仍是单消息投递。
-直接配置的 Remoting `MessageHandler` 委托也使用相同的列表合约。
+`IRemotingPushMessageHandler` API，在每次批量回调中传入 `IReadOnlyList<RemotingMessageView>` 和
+`RemotingPushConsumeContext`；其 `ConsumeMessageBatchSize` 默认值为 `1`，因此除非显式配置，否则仍是
+单消息投递。对于并发、非 FIFO 批次，handler 可以返回 `Success` 并设置 `AckIndex`，以确认连续前缀并重试
+尾部；`Retry` 和 `DeadLetter` 仍是整批结果。直接配置的 Remoting `MessageHandler` 委托也使用相同的列表和
+context 合约。
 
 对于非 FIFO 的 gRPC Push 和 LitePush 消息，`ConsumeTimeout` 到期后会取消 handler token、停止客户端不可见时间续期，并请求
 重新投递。dispatcher 会忽略延迟返回的结果并释放 worker，但无法终止应用代码。超时调用可能与重新投递重叠，因此必须保持幂等。

--- a/docs/zh-CN/grpc/consumer-model.md
+++ b/docs/zh-CN/grpc/consumer-model.md
@@ -93,6 +93,11 @@ PushConsumer 启动后大致执行如下循环：
 FIFO 分发时，客户端为同一消息组维持顺序尾链并阻塞同组后续消息；这是应用处理顺序的约束，不应被理解为
 跨消费组、跨队列或跨消费者的全局顺序保证。
 
+对于非 FIFO 分发，`ConsumeTimeout` 默认值为 15 分钟。到期后 dispatcher 会取消 handler token、停止客户端的
+不可见时间续期并请求重新投递；延迟返回的成功结果会被忽略。即使应用代码忽略取消，dispatcher 也会释放 worker 容量，
+但客户端无法强制终止这段代码。重新投递可能与仍在执行、但忽略取消的调用重叠，因此 handler 必须具备幂等性。FIFO message
+group 会刻意排除在此机制之外，因为脱离一个超时 handler 可能破坏顺序。
+
 通过 `AddGrpcPushConsumer<THandler>(ServiceLifetime.Scoped, ...)` 注册 typed handler 时，每次处理都会创建
 DI scope。详情见[依赖注入与生命周期](../architecture/dependency-injection-and-lifetimes.md)。
 

--- a/docs/zh-CN/remoting/transport-and-client-roles.md
+++ b/docs/zh-CN/remoting/transport-and-client-roles.md
@@ -80,11 +80,17 @@ Broker 请求签名。注册阶段强制两个值成对出现，防止“只有�
   可跨消息、跨队列复用的 token。
 - **Push**：客户端仍以拉取/长轮询为基础，但加上经典 group、心跳、Broker 回调、重平衡和可选队列锁的
   兼容流程。它支持 cluster/broadcast、并发批量或 FIFO 分发，以及队列有序消费所需的经典锁定行为。
-  唯一的 `IRemotingPushMessageHandler.HandleAsync` API 接收 `IReadOnlyList<RemotingMessageView>`。
-  `BatchSize` 限制单次长轮询向 Broker 请求的消息数；`ConsumeMessageBatchSize` 独立限制单次 handler
-  调用收到的消息数，默认值为 `1`。来自同一个 Broker 物理队列、且不带 `MessageGroup` 的并发消息可以合并为
-一批，多个批次可在 `MaxConcurrency` 范围内并行处理；带 `MessageGroup` 的 FIFO 投递和 `ConsumeOrderly`
-投递保持单消息、串行处理。一项 `ConsumeResult` 会应用于该批中的每条消息。
+  唯一的 `IRemotingPushMessageHandler.HandleAsync` API 接收 `IReadOnlyList<RemotingMessageView>` 和
+  `RemotingPushConsumeContext`。`BatchSize` 限制单次长轮询向 Broker 请求的消息数；`ConsumeMessageBatchSize`
+  独立限制单次 handler 调用收到的消息数，默认值为 `1`。来自同一个 Broker 物理队列、且不带 `MessageGroup`
+  的并发消息可以合并为一批，多个批次可在 `MaxConcurrency` 范围内并行处理；带 `MessageGroup` 的 FIFO 投递和
+  `ConsumeOrderly` 投递保持单消息、串行处理。
+
+  `Success` 默认确认整个批次。并发、非 FIFO handler 可以在返回 `Success` 前把 `AckIndex` 设为最后一条已接受
+  消息的从零开始索引；客户端会确认这个连续前缀，并只重试尾部消息。无论 `AckIndex` 为何，`Retry` 和
+  `DeadLetter` 都会应用到批次中的每条消息。context 还提供 `DelayLevelWhenNextConsume`，用于未确认的尾部：
+  `0` 交由 Broker 决定重试时间，正值选择 RocketMQ 延迟级别，负值请求直接进入死信队列。广播模式没有 Broker
+  重试或死信路径，因此未确认的尾部消息会被跳过。
 
 `ConsumeTimeout` 默认值为 15 分钟，仅适用于并发集群、非 FIFO 批次。超时后，客户端会取消 handler token，并为
 整批消息请求 Broker 重新投递。它不能强制终止忽略取消信号的应用代码，因此 handler 必须响应该 token，并保持幂等。

--- a/docs/zh-CN/remoting/transport-and-client-roles.md
+++ b/docs/zh-CN/remoting/transport-and-client-roles.md
@@ -27,7 +27,7 @@ Remoting 客户端先连接 NameServer 获取 topic route，然后对 route 中�
 | `IRemotingPullConsumer` | 应用显式选择队列和位点来拉取、确认/提交 | ✅ |
 | `IRemotingLitePullConsumer` | 订阅后的自动分配或 `AssignAsync` 手工分配、客户端位点、pause/resume/seek | ✅ |
 | `IRemotingPopConsumer` | POP receipt、确认和可见期续租 | ✅ |
-| `IRemotingPushConsumer` | 自动消费、重试、死信、重平衡与经典 Broker 兼容行为 | ✅ |
+| `IRemotingPushConsumer` | 自动批量消费、重试、死信、重平衡与经典 Broker 兼容行为 | ✅ |
 
 “后台生命周期”表示通过 Generic Host 注册时会有 hosted service 启动/停止该角色。Admin 是按需查询 API，
 不启动独立循环。
@@ -79,7 +79,16 @@ Broker 请求签名。注册阶段强制两个值成对出现，防止“只有�
 - **POP**：Broker 返回 receipt；应用使用 receipt 确认，并在长时间处理时请求更改不可见期。receipt 不是
   可跨消息、跨队列复用的 token。
 - **Push**：客户端仍以拉取/长轮询为基础，但加上经典 group、心跳、Broker 回调、重平衡和可选队列锁的
-  兼容流程。它支持 cluster/broadcast、并发或 FIFO 分发，以及队列有序消费所需的经典锁定行为。
+  兼容流程。它支持 cluster/broadcast、并发批量或 FIFO 分发，以及队列有序消费所需的经典锁定行为。
+  唯一的 `IRemotingPushMessageHandler.HandleAsync` API 接收 `IReadOnlyList<RemotingMessageView>`。
+  `BatchSize` 限制单次长轮询向 Broker 请求的消息数；`ConsumeMessageBatchSize` 独立限制单次 handler
+  调用收到的消息数，默认值为 `1`。来自同一个 Broker 物理队列、且不带 `MessageGroup` 的并发消息可以合并为
+一批，多个批次可在 `MaxConcurrency` 范围内并行处理；带 `MessageGroup` 的 FIFO 投递和 `ConsumeOrderly`
+投递保持单消息、串行处理。一项 `ConsumeResult` 会应用于该批中的每条消息。
+
+`ConsumeTimeout` 默认值为 15 分钟，仅适用于并发集群、非 FIFO 批次。超时后，客户端会取消 handler token，并为
+整批消息请求 Broker 重新投递。它不能强制终止忽略取消信号的应用代码，因此 handler 必须响应该 token，并保持幂等。
+延迟返回的结果会被忽略，并可能与重新投递重叠。FIFO 和顺序投递为保持顺序保证而不会进入此恢复路径。
 
 无论选择哪种角色，至少一次交付仍要求业务处理幂等。发送重试、连接中断、可见期到期或确认失败都可能导致
 重复投递。

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -41,7 +41,7 @@ gRPC 的行为同时受 Proxy、Broker feature 与 protobuf API 影响。任一�
 - options 验证、默认客户端注册、keyed 客户端注册与重复角色注册；
 - message 编解码、frame 长度限制、ACL 签名和 response correlation；
 - route cache、重试、取消、连接故障和 handler 生命周期；
-- Consumer 对 `Success`、`Retry`、`DeadLetter` 的处理决策。
+- Consumer 对 `Success`、部分批量确认、`Retry`、`DeadLetter` 的处理决策。
 
 这样失败信息能直接指向客户端逻辑。若测试需要真实 endpoint 才能成立，它应迁移到对应的 integration
 test 项目，而不是在 unit test 中偷偷连接本地 `localhost`。

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -119,11 +119,13 @@ Docker 不可用时，应报告没有运行哪一个 integration test 以及原�
 
 ### 4.1 CI 也采集 integration coverage
 
-GitHub Actions 在格式化、构建和单元测试验证通过后，于独立的 `ubuntu-latest` job 运行 Docker 驱动的
-gRPC 与 Remoting integration test。该 job 使用独立超时预算，因为 Testcontainers 需要拉取镜像并启动
-Broker、NameServer 与 Proxy fixture。两个 integration 项目都会生成 Cobertura 报告，并以
-`integration-tests` flag 上传至 Codecov；Codecov 会将其与 `unit-tests` 报告合并。仓库配置仍会排除
-`samples`，不会将 sample 计入覆盖率。
+GitHub Actions 在格式化、构建和单元测试验证通过后，于四个并行的 `ubuntu-latest` matrix job 运行 Docker
+驱动的 gRPC 与 Remoting integration test：每个协议各有一个 single-Broker 与一个 multi-Broker job。类级别
+的 `Topology=MultiBroker` trait 选择 multi-Broker 测试；single-Broker job 运行其余测试。每个 job 只 restore
+和 build 对应协议的 integration-test 依赖图，使用独立超时预算，并复用仓库的 NuGet 包缓存。Testcontainers
+仍会在每个 job 内独立启动隔离的 Broker、NameServer 与 Proxy fixture。四个 job 都会生成 Cobertura 报告，
+以不同的上传名称归入共享的 `integration-tests` flag；Codecov 会将其与 `unit-tests` 报告合并。仓库配置仍会
+排除 `samples`，不会将 sample 计入覆盖率。
 
 ### 5. 测试范围也体现支持边界
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -168,7 +168,7 @@ These projects use `EventHorizon.RocketMQ.Remoting` and discover Brokers through
 | Pull consumer | `IRemotingPullConsumer` | [`remoting/PullConsumer`](remoting/PullConsumer/README.md) | Explicit queue discovery, offsets, pull, and offset commit. |
 | Lite Pull consumer | `IRemotingLitePullConsumer` | [`remoting/LitePullConsumer`](remoting/LitePullConsumer/README.md) | Subscription-driven assignment, polling, and client-managed offset commit. |
 | POP consumer | `IRemotingPopConsumer` | [`remoting/PopConsumer`](remoting/PopConsumer/README.md) | Explicit physical-queue selection and receipt acknowledgement. |
-| Push consumer | `IRemotingPushConsumer` | [`remoting/PushConsumer`](remoting/PushConsumer/README.md) | Long-poll-based automatic dispatch through a message handler. |
+| Push consumer | `IRemotingPushConsumer` | [`remoting/PushConsumer`](remoting/PushConsumer/README.md) | Long-poll-based automatic batch dispatch through a message handler, with singleton FIFO delivery where required. |
 
 Run a Remoting project with its directory as the project argument, for example:
 

--- a/samples/README.zh-CN.md
+++ b/samples/README.zh-CN.md
@@ -159,7 +159,7 @@ LitePush 示例，并自动准备它所需的 LITE parent Topic 和 Consumer Gro
 | Pull consumer | `IRemotingPullConsumer` | [`remoting/PullConsumer`](remoting/PullConsumer/README.zh-CN.md) | 显式队列发现、位点、拉取和位点提交。 |
 | Lite Pull consumer | `IRemotingLitePullConsumer` | [`remoting/LitePullConsumer`](remoting/LitePullConsumer/README.zh-CN.md) | 基于订阅的分配、轮询和客户端管理的位点提交。 |
 | POP consumer | `IRemotingPopConsumer` | [`remoting/PopConsumer`](remoting/PopConsumer/README.zh-CN.md) | 显式选择物理队列并确认 receipt。 |
-| Push consumer | `IRemotingPushConsumer` | [`remoting/PushConsumer`](remoting/PushConsumer/README.zh-CN.md) | 通过 handler 进行基于长轮询的自动分发。 |
+| Push consumer | `IRemotingPushConsumer` | [`remoting/PushConsumer`](remoting/PushConsumer/README.zh-CN.md) | 通过 handler 进行基于长轮询的自动批量分发，并在需要时保持单消息 FIFO 投递。 |
 
 以项目目录作为参数运行 Remoting 项目，例如：
 

--- a/samples/grpc/LitePushConsumer/README.md
+++ b/samples/grpc/LitePushConsumer/README.md
@@ -19,6 +19,7 @@ the service through `SyncLiteSubscription`.
 | `RocketMQ:Consumer:MaxConcurrency` | `4` | Maximum concurrent handler executions. |
 | `RocketMQ:Consumer:MaxDeliveryAttempts` | `16` | Fallback delivery-attempt limit before dead-lettering. |
 | `RocketMQ:Consumer:InvisibleDuration` | `00:00:30` | Initial lease duration for a received message. |
+| `RocketMQ:Consumer:ConsumeTimeout` | `00:15:00` | Maximum non-FIFO handler time before the client cancels its token and requests retry. |
 | `RocketMQ:Consumer:LongPollingTimeout` | `00:00:15` | Maximum server wait for a receive operation. |
 | `RocketMQ:Consumer:SubscriptionSyncInterval` | `00:00:30` | Interval for reconciling the complete LiteTopic set with the service. |
 
@@ -79,6 +80,9 @@ only sends ordinary messages and does not populate a LiteTopic.
   must name the same parent topic. A spelling mismatch is a configuration error, not a way to
   subscribe to a second parent topic.
 - The handler is registered as `Scoped`, so each handling attempt gets its own async DI scope.
+- `ConsumeTimeout` has the same non-FIFO timeout behavior as standard Push: the handler token is canceled,
+  client-side invisibility renewal stops, and retry is requested. It cannot terminate code that ignores cancellation;
+  FIFO handlers stay attached to preserve ordering.
 
 For Lite message production and the complete API, see the
 [gRPC guide](../../../src/EventHorizon.RocketMQ.Grpc/README.md).

--- a/samples/grpc/LitePushConsumer/README.zh-CN.md
+++ b/samples/grpc/LitePushConsumer/README.zh-CN.md
@@ -18,6 +18,7 @@ LITE parent/bind topic 的 LiteTopic 消息，并通过 `SyncLiteSubscription` �
 | `RocketMQ:Consumer:MaxConcurrency` | `4` | 最大并发 handler 执行数。 |
 | `RocketMQ:Consumer:MaxDeliveryAttempts` | `16` | 进入死信前的回退投递次数上限。 |
 | `RocketMQ:Consumer:InvisibleDuration` | `00:00:30` | 收到消息后的初始租约时长。 |
+| `RocketMQ:Consumer:ConsumeTimeout` | `00:15:00` | 非 FIFO handler 在客户端取消其 token 并请求重新投递前允许运行的最长时间。 |
 | `RocketMQ:Consumer:LongPollingTimeout` | `00:00:15` | Receive 请求允许服务端等待的最长时间。 |
 | `RocketMQ:Consumer:SubscriptionSyncInterval` | `00:00:30` | 将完整 LiteTopic 集合与服务端协调的间隔。 |
 
@@ -69,5 +70,7 @@ Host 会持续运行直到按下 Ctrl+C，并在启动时记录固定的 LiteTop
 - `BindTopic`、Broker `message.type=LITE` 属性与 group `lite.bind.topic` 属性必须指向同一个 parent topic。拼写不一致
   是配置错误，而不是订阅第二个 parent topic 的方式。
 - handler 注册为 `Scoped`，每次处理尝试都会获得自己的异步 DI scope。
+- `ConsumeTimeout` 与标准 Push 的非 FIFO 超时行为一致：会取消 handler token、停止客户端不可见时间续期并请求重新投递。它无法
+  强制停止忽略取消的代码；FIFO handler 会继续保持关联以维护顺序。
 
 Lite 消息生产和完整 API 请参阅 [gRPC 指南](../../../src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md)。

--- a/samples/grpc/LitePushConsumer/appsettings.json
+++ b/samples/grpc/LitePushConsumer/appsettings.json
@@ -11,6 +11,7 @@
       "MaxConcurrency": 4,
       "MaxDeliveryAttempts": 16,
       "InvisibleDuration": "00:00:30",
+      "ConsumeTimeout": "00:15:00",
       "LongPollingTimeout": "00:00:15",
       "SubscriptionSyncInterval": "00:00:30"
     }

--- a/samples/grpc/PushConsumer/README.md
+++ b/samples/grpc/PushConsumer/README.md
@@ -18,6 +18,7 @@ messages to a DI-managed scoped handler; it is not a Broker-initiated network pu
 | `RocketMQ:Consumer:MaxConcurrency` | `4` | Maximum concurrent handler executions. |
 | `RocketMQ:Consumer:MaxDeliveryAttempts` | `16` | Fallback delivery-attempt limit before dead-lettering. |
 | `RocketMQ:Consumer:InvisibleDuration` | `00:00:30` | Initial lease duration; the client renews it while handling a message. |
+| `RocketMQ:Consumer:ConsumeTimeout` | `00:15:00` | Maximum non-FIFO handler time before the client cancels its token and requests retry. |
 | `RocketMQ:Consumer:LongPollingTimeout` | `00:00:15` | Maximum server wait for a receive operation. |
 | `Sample:Filter` | `sample` | Tag filter expression for the fixed standard topic. |
 
@@ -74,6 +75,9 @@ The host continues until Ctrl+C. Send a standard message tagged `sample` to
   sample returns `DeadLetter` for corrupted messages and `Success` after logging normal messages.
 - `MaxConcurrency` controls local handler parallelism, not Broker queue count. Messages in a FIFO
   message group retain their ordering constraints even when other messages run concurrently.
+- `ConsumeTimeout` applies to non-FIFO dispatch. When it expires, the handler token is canceled,
+  client-side invisibility renewal stops, and the client requests retry; a handler that ignores cancellation cannot
+  be forcibly stopped, and its late success is ignored. FIFO handlers remain attached so their ordering is preserved.
 - Running multiple instances with the same group distributes messages and shares retry state. Use a
   new group when independently observing the topic.
 

--- a/samples/grpc/PushConsumer/README.zh-CN.md
+++ b/samples/grpc/PushConsumer/README.zh-CN.md
@@ -18,6 +18,7 @@
 | `RocketMQ:Consumer:MaxConcurrency` | `4` | 最大并发 handler 执行数。 |
 | `RocketMQ:Consumer:MaxDeliveryAttempts` | `16` | 进入死信前的回退投递次数上限。 |
 | `RocketMQ:Consumer:InvisibleDuration` | `00:00:30` | 初始租约时长；处理期间客户端会续租。 |
+| `RocketMQ:Consumer:ConsumeTimeout` | `00:15:00` | 非 FIFO handler 在客户端取消其 token 并请求重新投递前允许运行的最长时间。 |
 | `RocketMQ:Consumer:LongPollingTimeout` | `00:00:15` | Receive 请求允许服务端等待的最长时间。 |
 | `Sample:Filter` | `sample` | 固定标准 topic 的 Tag 过滤表达式。 |
 
@@ -68,6 +69,8 @@ Producer 示例。
   的死信队列。本示例对损坏消息返回 `DeadLetter`，对正常消息记录日志后返回 `Success`。
 - `MaxConcurrency` 控制本地 handler 并发数，不控制 Broker 队列数量。即使其他消息可并发，FIFO message group 仍保持
   自身的顺序约束。
+- `ConsumeTimeout` 只适用于非 FIFO 分发。到期后会取消 handler token、停止客户端不可见时间续期并请求重新投递；忽略取消的
+  handler 无法被强制停止，其延迟返回的成功结果也会被忽略。为保持顺序，FIFO handler 会继续保持关联。
 - 使用同一个 group 的多个实例会分摊消息并共享重试状态。要独立观察 topic，请使用新的 group。
 
 handler 生命周期、重试行为和运行时订阅请参阅

--- a/samples/grpc/PushConsumer/appsettings.json
+++ b/samples/grpc/PushConsumer/appsettings.json
@@ -11,6 +11,7 @@
       "MaxConcurrency": 4,
       "MaxDeliveryAttempts": 16,
       "InvisibleDuration": "00:00:30",
+      "ConsumeTimeout": "00:15:00",
       "LongPollingTimeout": "00:00:15"
     }
   },

--- a/samples/opentelemetry/ConsumerWebApi/README.md
+++ b/samples/opentelemetry/ConsumerWebApi/README.md
@@ -4,7 +4,8 @@
 
 This ASP.NET Core Minimal API runs the gRPC and classic Remoting Push consumers in one host, using separate
 protocol-specific consumer groups. Both subscribe to the shared standard topic `eventhorizon-test-topic` and process
-every tag. The host uses scoped message handlers, so every delivery has its own dependency-injection scope.
+every tag. The host uses scoped message handlers, so each gRPC delivery and each Remoting batch has its own
+dependency-injection scope.
 
 The [OpenTelemetry sample overview](../README.md) covers the shared SDK, OTLP, Compose, and Grafana setup. Use the
 separate producer Web API to publish messages after this consumer host has started.
@@ -58,9 +59,12 @@ The project uses the following local defaults from `appsettings.json`:
 | `RocketMQ:Grpc:Client:Endpoint` | `localhost:8081` | RocketMQ 5 Proxy endpoint for the gRPC Push consumer. |
 | `RocketMQ:Grpc:Consumer:GroupName` | `eventhorizon-otel-grpc-consumer` | Consumer group for the gRPC Push consumer. |
 | `RocketMQ:Grpc:Consumer:MaxConcurrency` | `4` | Concurrent gRPC message-handler invocations. |
+| `RocketMQ:Grpc:Consumer:ConsumeTimeout` | `00:15:00` | Maximum non-FIFO gRPC handler time before retry is requested. |
 | `RocketMQ:Remoting:Client:NamesrvAddr` | `localhost:9876` | NameServer for the Remoting Push consumer. |
 | `RocketMQ:Remoting:Consumer:GroupName` | `eventhorizon-otel-remoting-consumer` | Consumer group for the Remoting Push consumer. |
+| `RocketMQ:Remoting:Consumer:ConsumeMessageBatchSize` | `4` | Maximum messages processed by one Remoting handler invocation. |
 | `RocketMQ:Remoting:Consumer:MaxConcurrency` | `4` | Concurrent Remoting message-handler invocations. |
+| `RocketMQ:Remoting:Consumer:ConsumeTimeout` | `00:15:00` | Maximum non-FIFO Remoting batch-handler time before retry is requested. |
 | `Sample:ServiceName` | `eventhorizon-rocketmq-otel-consumer` | OpenTelemetry `service.name` resource value. |
 | `Sample:OtlpEndpoint` | `http://127.0.0.1:4317` | OTLP/gRPC collector endpoint. |
 

--- a/samples/opentelemetry/ConsumerWebApi/README.md
+++ b/samples/opentelemetry/ConsumerWebApi/README.md
@@ -33,6 +33,15 @@ makes the `process` operation duration easy to inspect in the bundled
 [Consumer dashboard](http://127.0.0.1:3000/d/rocketmq-consumer-observability/rocketmq-consumer-opentelemetry), which
 uses sub-second duration buckets for this sample.
 
+The Remoting handler receives its message list and a `RemotingPushConsumeContext`. This sample returns `Success`
+without changing `AckIndex`, so it confirms each complete batch. A concurrent non-FIFO handler can instead return
+`Success` with `AckIndex` set to the zero-based index of the last accepted message to confirm its prefix and retry the
+remaining tail; `-1` confirms none. `Retry` and `DeadLetter` always apply to the whole batch. For retried messages,
+`DelayLevelWhenNextConsume` starts from `RetryDelay` and can be set to `0` for Broker policy, a positive RocketMQ
+delay level, or a negative value for direct dead-lettering. Broadcasting has no Broker retry/dead-letter flow, so an
+unacknowledged tail is skipped. FIFO `MessageGroup` and `ConsumeOrderly` deliveries are singleton paths and do not
+use partial batch confirmation.
+
 ## Routes
 
 | Method | Route | Success response |

--- a/samples/opentelemetry/ConsumerWebApi/README.zh-CN.md
+++ b/samples/opentelemetry/ConsumerWebApi/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 这个 ASP.NET Core Minimal API 在同一个 host 中运行 gRPC 和 classic Remoting Push Consumer，并为两个协议使用彼此独立的
 Consumer Group。两者都订阅共享的普通 Topic `eventhorizon-test-topic`，消费所有 tag。host 使用 scoped message handler，
-因此每次消息投递都有独立的依赖注入作用域。
+因此每条 gRPC 消息和每个 Remoting batch 都有独立的依赖注入作用域。
 
 共享的 SDK、OTLP、Compose 与 Grafana 配置请参阅 [OpenTelemetry 示例总览](../README.zh-CN.md)。启动本 Consumer host 后，
 可使用独立的 Producer Web API 发布消息。
@@ -57,9 +57,12 @@ operation duration；该示例为此配置了亚秒级 duration bucket。
 | `RocketMQ:Grpc:Client:Endpoint` | `localhost:8081` | gRPC Push Consumer 使用的 RocketMQ 5 Proxy 端点。 |
 | `RocketMQ:Grpc:Consumer:GroupName` | `eventhorizon-otel-grpc-consumer` | gRPC Push Consumer 的 Consumer Group。 |
 | `RocketMQ:Grpc:Consumer:MaxConcurrency` | `4` | 并发执行的 gRPC message handler 数量。 |
+| `RocketMQ:Grpc:Consumer:ConsumeTimeout` | `00:15:00` | 请求重试前，非 FIFO gRPC handler 允许运行的最长时间。 |
 | `RocketMQ:Remoting:Client:NamesrvAddr` | `localhost:9876` | Remoting Push Consumer 使用的 NameServer。 |
 | `RocketMQ:Remoting:Consumer:GroupName` | `eventhorizon-otel-remoting-consumer` | Remoting Push Consumer 的 Consumer Group。 |
+| `RocketMQ:Remoting:Consumer:ConsumeMessageBatchSize` | `4` | 单次 Remoting handler 调用处理的最大消息数量。 |
 | `RocketMQ:Remoting:Consumer:MaxConcurrency` | `4` | 并发执行的 Remoting message handler 数量。 |
+| `RocketMQ:Remoting:Consumer:ConsumeTimeout` | `00:15:00` | 请求重试前，非 FIFO Remoting batch handler 允许运行的最长时间。 |
 | `Sample:ServiceName` | `eventhorizon-rocketmq-otel-consumer` | OpenTelemetry `service.name` resource 值。 |
 | `Sample:OtlpEndpoint` | `http://127.0.0.1:4317` | OTLP/gRPC collector 端点。 |
 

--- a/samples/opentelemetry/ConsumerWebApi/README.zh-CN.md
+++ b/samples/opentelemetry/ConsumerWebApi/README.zh-CN.md
@@ -31,6 +31,13 @@ ASPNETCORE_URLS=http://127.0.0.1:5242 \
 [Consumer dashboard](http://127.0.0.1:3000/d/rocketmq-consumer-observability/rocketmq-consumer-opentelemetry) 中观察 `process`
 operation duration；该示例为此配置了亚秒级 duration bucket。
 
+Remoting handler 会收到消息列表和 `RemotingPushConsumeContext`。本示例返回 `Success` 时不修改 `AckIndex`，因此会确认
+每个完整批次。并发、非 FIFO handler 也可以返回 `Success`，同时将 `AckIndex` 设为最后一条已接受消息的从零开始索引，以确认
+其前缀并重试其后的尾部消息；`-1` 表示一条也不确认。`Retry` 和 `DeadLetter` 始终应用到整个批次。对于要重试的消息，
+`DelayLevelWhenNextConsume` 初始为 `RetryDelay`，可设为 `0` 使用 Broker 策略、设为正的 RocketMQ 延迟级别，或设为负值
+直接进入死信队列。广播模式没有 Broker 重试/死信流程，因此未确认的尾部消息会被跳过。FIFO `MessageGroup` 和
+`ConsumeOrderly` 投递均为单消息路径，不使用部分批量确认。
+
 ## 路由
 
 | 方法 | 路由 | 成功响应 |

--- a/samples/opentelemetry/ConsumerWebApi/RemotingConsumerMessageHandler.cs
+++ b/samples/opentelemetry/ConsumerWebApi/RemotingConsumerMessageHandler.cs
@@ -25,6 +25,7 @@ internal sealed class RemotingConsumerMessageHandler(
 {
     public async ValueTask<ConsumeResult> HandleAsync(
         IReadOnlyList<RemotingMessageView> messages,
+        RemotingPushConsumeContext context,
         CancellationToken cancellationToken)
     {
         foreach (var message in messages)

--- a/samples/opentelemetry/ConsumerWebApi/RemotingConsumerMessageHandler.cs
+++ b/samples/opentelemetry/ConsumerWebApi/RemotingConsumerMessageHandler.cs
@@ -23,17 +23,23 @@ namespace EventHorizon.RocketMQ.Samples.OpenTelemetry.ConsumerWebApi;
 internal sealed class RemotingConsumerMessageHandler(
     ILogger<RemotingConsumerMessageHandler> logger) : IRemotingPushMessageHandler
 {
-    public async ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken)
+    public async ValueTask<ConsumeResult> HandleAsync(
+        IReadOnlyList<RemotingMessageView> messages,
+        CancellationToken cancellationToken)
     {
-        await Task.Delay(Random.Shared.Next(250, 1001), cancellationToken);
-        logger.LogInformation(
-            "Remoting consumer received {MessageId} from {Topic}/{BrokerName}/{QueueId} at offset {QueueOffset}: {Body}",
-            message.MessageId,
-            message.Topic,
-            message.BrokerName,
-            message.QueueId,
-            message.QueueOffset,
-            Encoding.UTF8.GetString(message.Body));
+        foreach (var message in messages)
+        {
+            await Task.Delay(Random.Shared.Next(250, 1001), cancellationToken);
+            logger.LogInformation(
+                "Remoting consumer received {MessageId} from {Topic}/{BrokerName}/{QueueId} at offset {QueueOffset}: {Body}",
+                message.MessageId,
+                message.Topic,
+                message.BrokerName,
+                message.QueueId,
+                message.QueueOffset,
+                Encoding.UTF8.GetString(message.Body));
+        }
+
         return ConsumeResult.Success;
     }
 }

--- a/samples/opentelemetry/ConsumerWebApi/appsettings.json
+++ b/samples/opentelemetry/ConsumerWebApi/appsettings.json
@@ -12,6 +12,7 @@
         "MaxConcurrency": 4,
         "MaxDeliveryAttempts": 16,
         "InvisibleDuration": "00:00:30",
+        "ConsumeTimeout": "00:15:00",
         "LongPollingTimeout": "00:00:15"
       }
     },
@@ -24,7 +25,9 @@
       "Consumer": {
         "GroupName": "eventhorizon-otel-remoting-consumer",
         "BatchSize": 16,
+        "ConsumeMessageBatchSize": 4,
         "MaxConcurrency": 4,
+        "ConsumeTimeout": "00:15:00",
         "LongPollingTimeout": "00:00:05",
         "RetryDelay": "00:00:01"
       }

--- a/samples/remoting/PushConsumer/PushConsumerMessageHandler.cs
+++ b/samples/remoting/PushConsumer/PushConsumerMessageHandler.cs
@@ -25,6 +25,7 @@ internal sealed class PushConsumerMessageHandler(
 {
     public ValueTask<ConsumeResult> HandleAsync(
         IReadOnlyList<RemotingMessageView> messages,
+        RemotingPushConsumeContext context,
         CancellationToken cancellationToken)
     {
         foreach (var message in messages)

--- a/samples/remoting/PushConsumer/PushConsumerMessageHandler.cs
+++ b/samples/remoting/PushConsumer/PushConsumerMessageHandler.cs
@@ -23,16 +23,22 @@ namespace EventHorizon.RocketMQ.Samples.Remoting.PushConsumer;
 internal sealed class PushConsumerMessageHandler(
     ILogger<PushConsumerMessageHandler> logger) : IRemotingPushMessageHandler
 {
-    public ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken)
+    public ValueTask<ConsumeResult> HandleAsync(
+        IReadOnlyList<RemotingMessageView> messages,
+        CancellationToken cancellationToken)
     {
-        logger.LogInformation(
-            "Received {MessageId} from {Topic}/{BrokerName}/{QueueId} at offset {QueueOffset}: {Body}",
-            message.MessageId,
-            message.Topic,
-            message.BrokerName,
-            message.QueueId,
-            message.QueueOffset,
-            Encoding.UTF8.GetString(message.Body));
+        foreach (var message in messages)
+        {
+            logger.LogInformation(
+                "Received {MessageId} from {Topic}/{BrokerName}/{QueueId} at offset {QueueOffset}: {Body}",
+                message.MessageId,
+                message.Topic,
+                message.BrokerName,
+                message.QueueId,
+                message.QueueOffset,
+                Encoding.UTF8.GetString(message.Body));
+        }
+
         // Success advances the original queue offset. In clustering mode, Retry sends failed work back for redelivery
         // before that offset advances.
         return ValueTask.FromResult(ConsumeResult.Success);

--- a/samples/remoting/PushConsumer/README.md
+++ b/samples/remoting/PushConsumer/README.md
@@ -2,9 +2,9 @@
 
 [简体中文](README.zh-CN.md)
 
-This Generic Host registers a scoped `PushConsumerMessageHandler` through
+This Generic Host registers a scoped batch-oriented `PushConsumerMessageHandler` through
 `AddRemotingPushConsumer<PushConsumerMessageHandler>` and processes messages through `IRemotingPushConsumer`.
-It is the high-level classic Remoting consumer with automatic assignment, long polling, dispatch, retry, and
+It is the high-level classic Remoting consumer with automatic assignment, long polling, batch dispatch, retry, and
 offset handling.
 
 ## Public role and default configuration
@@ -13,15 +13,20 @@ offset handling.
 | --- | --- | --- |
 | `RocketMQ:Remoting:NamesrvAddr` | `localhost:9876` | NameServer used to discover Broker routes. |
 | `RocketMQ:PushConsumer:GroupName` | `remoting-sample-push-consumer` | Clustered consumer group. |
-| `RocketMQ:PushConsumer:MaxConcurrency` | `4` | Maximum concurrent message-handler invocations. |
-| `RocketMQ:PushConsumer:BatchSize` | `32` | Maximum messages requested by each long poll. |
+| `RocketMQ:PushConsumer:MaxConcurrency` | `4` | Maximum concurrent message-handler batch invocations. |
+| `RocketMQ:PushConsumer:BatchSize` | `32` | Maximum messages requested from the Broker by each long poll. |
+| `RocketMQ:PushConsumer:ConsumeMessageBatchSize` | `1` | Maximum messages passed to one handler invocation; it is independent of `BatchSize`. |
 | `RocketMQ:PushConsumer:LongPollingTimeout` | `00:00:05` | Maximum Broker hold time for an empty long poll. |
 | `RocketMQ:PushConsumer:RetryDelay` | `00:00:01` | Delay before retrying a failed receive or handler result. |
+| `RocketMQ:PushConsumer:ConsumeTimeout` | `00:15:00` | Time limit for a concurrent clustered non-FIFO handler batch before cancellation and Broker retry are requested. |
 | Fixed topic | `eventhorizon-test-topic` | Shared subscribed normal topic. |
 | `Sample:Filter` | `*` | Subscription filter. |
 
-The handler logs the message and returns `ConsumeResult.Success`. The typed registration lets the handler receive
-its `ILogger<PushConsumerMessageHandler>` from the application service provider with a scoped lifetime.
+The handler receives an `IReadOnlyList<RemotingMessageView>`, logs every message in the list, and returns one
+`ConsumeResult` for the complete list. The sample keeps `ConsumeMessageBatchSize` at its default of `1`; set it in
+configuration to batch concurrent non-`MessageGroup` messages from the same Broker physical queue. The typed
+registration lets the handler receive its `ILogger<PushConsumerMessageHandler>` from the application service provider
+with a scoped lifetime per batch handling attempt.
 
 ## Broker and network prerequisites
 
@@ -53,8 +58,14 @@ Remoting Producer sample or another producer after startup.
 
 - Despite its name, this is not a protocol-level Broker push to the application. The client owns queue assignment
   and repeatedly issues long-poll pull requests, then dispatches received messages to the handler.
-- `ConsumeResult.Success` advances processing. Return a retry result for a transient failure; Broker retry and
-  dead-letter behavior is consumer-group based, so handlers must be idempotent and tolerate redelivery.
+- A handler outcome applies to every message in its list. Return a retry result for a transient failure; Broker retry
+  and dead-letter behavior is consumer-group based, so handlers must be idempotent and tolerate redelivery.
+- `MessageGroup` FIFO messages and `ConsumeOrderly` dispatch always receive singleton lists, even when
+  `ConsumeMessageBatchSize` is greater than `1`.
+- For concurrent clustered non-FIFO delivery, `ConsumeTimeout` cancels the handler token and requests Broker
+  redelivery when a batch runs too long. It cannot forcibly stop application code that ignores cancellation; its
+  late result is ignored and can overlap a redelivered invocation, so handlers must honor the token and remain
+  idempotent. FIFO and orderly delivery are intentionally excluded to preserve their ordering guarantees.
 - The default is clustering mode. Instances in the same group share queue assignments. Broadcasting mode gives
   every instance every readable queue and stores offsets locally instead.
 - Broker queue locks are used only when `ConsumeOrderly` is `true` **and** `ConsumerMode` is `Clustering`.

--- a/samples/remoting/PushConsumer/README.md
+++ b/samples/remoting/PushConsumer/README.md
@@ -22,8 +22,9 @@ offset handling.
 | Fixed topic | `eventhorizon-test-topic` | Shared subscribed normal topic. |
 | `Sample:Filter` | `*` | Subscription filter. |
 
-The handler receives an `IReadOnlyList<RemotingMessageView>`, logs every message in the list, and returns one
-`ConsumeResult` for the complete list. The sample keeps `ConsumeMessageBatchSize` at its default of `1`; set it in
+The handler receives an `IReadOnlyList<RemotingMessageView>` and a `RemotingPushConsumeContext`, logs every message in
+the list, and returns one `ConsumeResult` for the complete list. This sample leaves `AckIndex` at its default, so a
+`Success` confirms the complete batch. It keeps `ConsumeMessageBatchSize` at its default of `1`; set it in
 configuration to batch concurrent non-`MessageGroup` messages from the same Broker physical queue. The typed
 registration lets the handler receive its `ILogger<PushConsumerMessageHandler>` from the application service provider
 with a scoped lifetime per batch handling attempt.
@@ -58,10 +59,16 @@ Remoting Producer sample or another producer after startup.
 
 - Despite its name, this is not a protocol-level Broker push to the application. The client owns queue assignment
   and repeatedly issues long-poll pull requests, then dispatches received messages to the handler.
-- A handler outcome applies to every message in its list. Return a retry result for a transient failure; Broker retry
-  and dead-letter behavior is consumer-group based, so handlers must be idempotent and tolerate redelivery.
+- For a concurrent non-FIFO batch, return `Success` and set `context.AckIndex` to the zero-based index of the last
+  accepted message to confirm its contiguous prefix and retry only the remaining tail. The default `int.MaxValue`
+  confirms every message; use `-1` when no message was accepted. `Retry` and `DeadLetter` ignore `AckIndex` and
+  apply to the whole batch, so handlers must be idempotent and tolerate redelivery.
+- `context.DelayLevelWhenNextConsume` starts with the delay level mapped from `RetryDelay`. Set it to `0` to let the
+  Broker choose the retry delay, a positive RocketMQ delay level to request that level, or a negative value to send
+  messages that will be retried directly to the dead-letter queue. In broadcasting mode, an unacknowledged tail is
+  skipped because there is no Broker retry or dead-letter flow.
 - `MessageGroup` FIFO messages and `ConsumeOrderly` dispatch always receive singleton lists, even when
-  `ConsumeMessageBatchSize` is greater than `1`.
+  `ConsumeMessageBatchSize` is greater than `1`; these paths do not use partial batch confirmation.
 - For concurrent clustered non-FIFO delivery, `ConsumeTimeout` cancels the handler token and requests Broker
   redelivery when a batch runs too long. It cannot forcibly stop application code that ignores cancellation; its
   late result is ignored and can overlap a redelivered invocation, so handlers must honor the token and remain

--- a/samples/remoting/PushConsumer/README.zh-CN.md
+++ b/samples/remoting/PushConsumer/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 [English](README.md) | [简体中文](README.zh-CN.md)
 
-此 Generic Host 通过 `AddRemotingPushConsumer<PushConsumerMessageHandler>` 注册具有 scoped 生命周期的
+此 Generic Host 通过 `AddRemotingPushConsumer<PushConsumerMessageHandler>` 注册具有 scoped 生命周期、支持批量回调的
 `PushConsumerMessageHandler`，并通过 `IRemotingPushConsumer` 处理消息。这是 classic Remoting 的高级 Consumer，提供
-自动分配、长轮询、分发、重试和位点处理。
+自动分配、长轮询、批量分发、重试和位点处理。
 
 ## 公共角色和默认配置
 
@@ -12,15 +12,19 @@
 | --- | --- | --- |
 | `RocketMQ:Remoting:NamesrvAddr` | `localhost:9876` | 用于发现 Broker 路由的 NameServer。 |
 | `RocketMQ:PushConsumer:GroupName` | `remoting-sample-push-consumer` | 集群 consumer group。 |
-| `RocketMQ:PushConsumer:MaxConcurrency` | `4` | 可并发运行的最大 handler 调用数。 |
-| `RocketMQ:PushConsumer:BatchSize` | `32` | 每个长轮询请求的最大消息数。 |
+| `RocketMQ:PushConsumer:MaxConcurrency` | `4` | 可并发运行的最大 handler 批量调用数。 |
+| `RocketMQ:PushConsumer:BatchSize` | `32` | 每个长轮询从 Broker 请求的最大消息数。 |
+| `RocketMQ:PushConsumer:ConsumeMessageBatchSize` | `1` | 单次 handler 调用收到的最大消息数；与 `BatchSize` 相互独立。 |
 | `RocketMQ:PushConsumer:LongPollingTimeout` | `00:00:05` | 空长轮询在 Broker 上的最大等待时间。 |
 | `RocketMQ:PushConsumer:RetryDelay` | `00:00:01` | 接收失败或 handler 返回失败结果后的重试等待时间。 |
+| `RocketMQ:PushConsumer:ConsumeTimeout` | `00:15:00` | 并发集群、非 FIFO handler 批次在请求取消并要求 Broker 重投前允许占用的最长时间。 |
 | 固定 topic | `eventhorizon-test-topic` | 共享订阅的普通 topic。 |
 | `Sample:Filter` | `*` | 订阅过滤条件。 |
 
-handler 记录消息并返回 `ConsumeResult.Success`。泛型注册会在 scoped DI scope 中解析 handler，因此它可以注入
-`ILogger<PushConsumerMessageHandler>`。
+handler 接收 `IReadOnlyList<RemotingMessageView>`，记录列表中的每条消息，并为整个列表返回一个
+`ConsumeResult`。示例保留 `ConsumeMessageBatchSize` 的默认值 `1`；可通过配置增大它，以合并来自同一个
+Broker 物理队列、且不带 `MessageGroup` 的并发消息。泛型注册会在每次批量处理尝试中创建 scoped DI scope，
+因此 handler 可以注入 `ILogger<PushConsumerMessageHandler>`。
 
 ## Broker 和网络前置条件
 
@@ -51,8 +55,13 @@ dotnet run --project samples/remoting/PushConsumer/EventHorizon.RocketMQ.Samples
 
 - 虽然名称中带有 Push，但它不是 Broker 向应用进行协议级推送。客户端负责队列分配，并反复发起长轮询拉取请求，
   然后将收到的消息分发给 handler。
-- `ConsumeResult.Success` 表示处理成功并推进消费。短暂失败时应返回 retry 结果；Broker 的重试和死信行为以 consumer
+- 一个 handler 结果会应用于其列表中的每条消息。短暂失败时应返回 retry 结果；Broker 的重试和死信行为以 consumer
   group 为基础，因此 handler 必须幂等并能容忍重复投递。
+- 带 `MessageGroup` 的 FIFO 消息和 `ConsumeOrderly` 分发始终收到只包含一条消息的列表，即使
+  `ConsumeMessageBatchSize` 大于 `1` 也是如此。
+- 对于并发集群、非 FIFO 投递，`ConsumeTimeout` 到期后会取消 handler token 并请求 Broker 重新投递。它不能强制
+  停止忽略取消信号的应用代码；其延迟返回的结果会被忽略，并可能与重新投递的调用重叠，因此 handler 必须响应该 token，
+  并保持幂等。FIFO 和顺序投递为保持顺序保证而不会应用此机制。
 - 默认是集群模式。同一 group 中的实例共享队列分配。广播模式会让每个实例获得每个可读队列，并改为本地存储位点。
 - 只有 `ConsumeOrderly` 为 `true` **且** `ConsumerMode` 为 `Clustering` 时才使用 Broker 队列锁。普通并发消费不会
   获取这些锁；广播模式下的顺序处理也仅限本地。

--- a/samples/remoting/PushConsumer/README.zh-CN.md
+++ b/samples/remoting/PushConsumer/README.zh-CN.md
@@ -21,10 +21,11 @@
 | 固定 topic | `eventhorizon-test-topic` | 共享订阅的普通 topic。 |
 | `Sample:Filter` | `*` | 订阅过滤条件。 |
 
-handler 接收 `IReadOnlyList<RemotingMessageView>`，记录列表中的每条消息，并为整个列表返回一个
-`ConsumeResult`。示例保留 `ConsumeMessageBatchSize` 的默认值 `1`；可通过配置增大它，以合并来自同一个
-Broker 物理队列、且不带 `MessageGroup` 的并发消息。泛型注册会在每次批量处理尝试中创建 scoped DI scope，
-因此 handler 可以注入 `ILogger<PushConsumerMessageHandler>`。
+handler 接收 `IReadOnlyList<RemotingMessageView>` 和 `RemotingPushConsumeContext`，记录列表中的每条消息，并为
+整个列表返回一个 `ConsumeResult`。本示例保持 `AckIndex` 的默认值，因此返回 `Success` 会确认整个批次。示例保留
+`ConsumeMessageBatchSize` 的默认值 `1`；可通过配置增大它，以合并来自同一个 Broker 物理队列、且不带
+`MessageGroup` 的并发消息。泛型注册会在每次批量处理尝试中创建 scoped DI scope，因此 handler 可以注入
+`ILogger<PushConsumerMessageHandler>`。
 
 ## Broker 和网络前置条件
 
@@ -55,10 +56,14 @@ dotnet run --project samples/remoting/PushConsumer/EventHorizon.RocketMQ.Samples
 
 - 虽然名称中带有 Push，但它不是 Broker 向应用进行协议级推送。客户端负责队列分配，并反复发起长轮询拉取请求，
   然后将收到的消息分发给 handler。
-- 一个 handler 结果会应用于其列表中的每条消息。短暂失败时应返回 retry 结果；Broker 的重试和死信行为以 consumer
-  group 为基础，因此 handler 必须幂等并能容忍重复投递。
+- 对于并发、非 FIFO 批次，可返回 `Success` 并将 `context.AckIndex` 设为最后一条已接受消息的从零开始索引，以确认
+  连续前缀并只重试其后的尾部消息。默认值 `int.MaxValue` 确认每条消息；未接受任何消息时使用 `-1`。`Retry` 和
+  `DeadLetter` 会忽略 `AckIndex` 并应用到整个批次，因此 handler 必须幂等并能容忍重复投递。
+- `context.DelayLevelWhenNextConsume` 初始为由 `RetryDelay` 映射的延迟级别。将其设为 `0` 可让 Broker 选择重试延迟，
+  设为正的 RocketMQ 延迟级别可请求该级别，设为负值会将需要重试的消息直接发送到死信队列。广播模式没有 Broker 重试或
+  死信流程，因此未确认的尾部消息会被跳过。
 - 带 `MessageGroup` 的 FIFO 消息和 `ConsumeOrderly` 分发始终收到只包含一条消息的列表，即使
-  `ConsumeMessageBatchSize` 大于 `1` 也是如此。
+  `ConsumeMessageBatchSize` 大于 `1` 也是如此；这些路径不使用部分批量确认。
 - 对于并发集群、非 FIFO 投递，`ConsumeTimeout` 到期后会取消 handler token 并请求 Broker 重新投递。它不能强制
   停止忽略取消信号的应用代码；其延迟返回的结果会被忽略，并可能与重新投递的调用重叠，因此 handler 必须响应该 token，
   并保持幂等。FIFO 和顺序投递为保持顺序保证而不会应用此机制。

--- a/samples/remoting/PushConsumer/appsettings.json
+++ b/samples/remoting/PushConsumer/appsettings.json
@@ -8,7 +8,8 @@
       "MaxConcurrency": 4,
       "BatchSize": 32,
       "LongPollingTimeout": "00:00:05",
-      "RetryDelay": "00:00:01"
+      "RetryDelay": "00:00:01",
+      "ConsumeTimeout": "00:15:00"
     }
   },
   "Sample": {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
@@ -631,6 +631,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 fifo,
                 maxDeliveryAttempts,
                 fifoRetryCancellationToken,
+                renewalCts,
                 cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -745,6 +746,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         bool fifo,
         int maxDeliveryAttempts,
         CancellationToken fifoRetryCancellationToken,
+        CancellationTokenSource renewalCts,
         CancellationToken cancellationToken)
     {
         var attempt = Math.Max(1, message.DeliveryAttempt);
@@ -762,8 +764,18 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 message.ReceiveActivityContext);
             try
             {
-                result = await _messageHandler(message, cancellationToken).ConfigureAwait(false);
-                telemetry.Complete(result == ConsumeResult.Success, result.ToString());
+                var execution = fifo
+                    ? new HandlerExecution(
+                        await _messageHandler(message, cancellationToken).ConfigureAwait(false),
+                        false)
+                    : await InvokeConcurrentMessageHandlerAsync(
+                        message,
+                        renewalCts,
+                        cancellationToken).ConfigureAwait(false);
+                result = execution.Result;
+                telemetry.Complete(
+                    result == ConsumeResult.Success,
+                    execution.TimedOut ? "timeout" : result.ToString());
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -800,6 +812,90 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 retryDelay,
                 fifoRetryCancellationToken,
                 cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask<HandlerExecution> InvokeConcurrentMessageHandlerAsync(
+        GrpcMessageView message,
+        CancellationTokenSource renewalCts,
+        CancellationToken cancellationToken)
+    {
+        CancellationTokenSource? handlerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var timeoutCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        try
+        {
+            var activeHandlerCancellation = handlerCancellation;
+            var handler = _messageHandler(message, activeHandlerCancellation.Token);
+            if (handler.IsCompletedSuccessfully)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return new HandlerExecution(handler.Result, false);
+            }
+
+            var handlerTask = handler.AsTask();
+            var timeout = Task.Delay(_options.ConsumeTimeout, timeoutCancellation.Token);
+            await Task.WhenAny(handlerTask, timeout).ConfigureAwait(false);
+            timeoutCancellation.Cancel();
+            if (handlerTask.IsCompleted)
+            {
+                return new HandlerExecution(await handlerTask.ConfigureAwait(false), false);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _ = ObserveTimedOutMessageHandlerAsync(handlerTask, message.MessageId, activeHandlerCancellation);
+                handlerCancellation = null;
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            try
+            {
+                activeHandlerCancellation.Cancel();
+            }
+            catch (AggregateException exception)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "A cancellation callback failed after a message handler exceeded the consume timeout");
+            }
+
+            _ = ObserveTimedOutMessageHandlerAsync(handlerTask, message.MessageId, activeHandlerCancellation);
+            handlerCancellation = null;
+            renewalCts.Cancel();
+            _logger.LogWarning(
+                "Message handler for message {MessageId} exceeded consume timeout {ConsumeTimeout}; cancellation was requested and the message will be retried",
+                message.MessageId,
+                _options.ConsumeTimeout);
+            return new HandlerExecution(ConsumeResult.Retry, true);
+        }
+        finally
+        {
+            handlerCancellation?.Dispose();
+        }
+    }
+
+    private async Task ObserveTimedOutMessageHandlerAsync(
+        Task<ConsumeResult> handlerTask,
+        string messageId,
+        CancellationTokenSource handlerCancellation)
+    {
+        try
+        {
+            await handlerTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            _logger.LogDebug(
+                exception,
+                "Message handler for timed-out message {MessageId} completed with an exception after timeout",
+                messageId);
+        }
+        finally
+        {
+            handlerCancellation.Dispose();
         }
     }
 
@@ -972,6 +1068,8 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         ByteCapacityGate Capacity,
         int ReservedBytes,
         int MessageBytes);
+
+    private readonly record struct HandlerExecution(ConsumeResult Result, bool TimedOut);
 
     private sealed class ByteCapacityGate
     {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumerOptions.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumerOptions.cs
@@ -23,8 +23,13 @@ namespace EventHorizon.RocketMQ.Grpc.Consumer.Push;
 public class GrpcPushConsumerOptions : ConsumerOptions
 {
     /// <summary>
-    /// Gets or sets the maximum number of messages processed concurrently.
+    /// Gets or sets the maximum number of message-handler dispatches that may run concurrently.
     /// </summary>
+    /// <remarks>
+    /// A non-FIFO handler that ignores cancellation after <see cref="ConsumeTimeout"/> expires can continue running
+    /// after its dispatch slot is released, so the setting limits scheduled dispatches rather than every in-process
+    /// application invocation in that exceptional case.
+    /// </remarks>
     public int MaxConcurrency { get; set; } = Environment.ProcessorCount;
 
     /// <summary>
@@ -51,6 +56,17 @@ public class GrpcPushConsumerOptions : ConsumerOptions
     /// Gets or sets the initial duration for which a received message remains invisible to other consumers.
     /// </summary>
     public TimeSpan InvisibleDuration { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets the maximum time a non-FIFO message handler may run before the message is made eligible for
+    /// retry.
+    /// </summary>
+    /// <remarks>
+    /// When this timeout expires, the consumer cancels the handler token, stops client-side invisibility renewal,
+    /// and requests redelivery. A handler that does not observe cancellation cannot be forcibly stopped, and a late
+    /// successful result is ignored. FIFO message groups are excluded so that their ordering is not broken.
+    /// </remarks>
+    public TimeSpan ConsumeTimeout { get; set; } = TimeSpan.FromMinutes(15);
 
     /// <summary>
     /// Gets or sets the maximum time the server may wait for messages during a long-poll request.

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/IGrpcPushMessageHandler.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/IGrpcPushMessageHandler.cs
@@ -31,7 +31,10 @@ public interface IGrpcPushMessageHandler
     /// Processes a received message and returns the requested delivery outcome.
     /// </summary>
     /// <param name="message">The message to process.</param>
-    /// <param name="cancellationToken">The token that cancels processing when the consumer stops.</param>
+    /// <param name="cancellationToken">
+    /// The token that cancels processing when the consumer stops and, for non-FIFO dispatch, when
+    /// <see cref="GrpcPushConsumerOptions.ConsumeTimeout"/> expires.
+    /// </param>
     /// <returns>The requested delivery outcome.</returns>
     ValueTask<ConsumeResult> HandleAsync(GrpcMessageView message, CancellationToken cancellationToken);
 }

--- a/src/EventHorizon.RocketMQ.Grpc/GrpcRocketMQBuilderExtensions.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/GrpcRocketMQBuilderExtensions.cs
@@ -266,6 +266,7 @@ public static class GrpcRocketMQBuilderExtensions
             .Validate(
                 static value => value.InvisibleDuration > TimeSpan.Zero,
                 "Invisible duration must be positive.")
+            .Validate(static value => value.ConsumeTimeout > TimeSpan.Zero, "Consume timeout must be positive.")
             .Validate(
                 static value => value.LongPollingTimeout > TimeSpan.Zero,
                 "Long polling timeout must be positive.")
@@ -323,6 +324,7 @@ public static class GrpcRocketMQBuilderExtensions
             .Validate(
                 static value => value.InvisibleDuration > TimeSpan.Zero,
                 "Invisible duration must be positive.")
+            .Validate(static value => value.ConsumeTimeout > TimeSpan.Zero, "Consume timeout must be positive.")
             .Validate(
                 static value => value.LongPollingTimeout > TimeSpan.Zero,
                 "Long polling timeout must be positive.")

--- a/src/EventHorizon.RocketMQ.Grpc/README.md
+++ b/src/EventHorizon.RocketMQ.Grpc/README.md
@@ -305,6 +305,7 @@ rocketMQ.AddGrpcPushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, option
     options.MaxConcurrency = 8;
     options.MaxDeliveryAttempts = 16;
     options.InvisibleDuration = TimeSpan.FromSeconds(30);
+    options.ConsumeTimeout = TimeSpan.FromMinutes(15);
     options.Subscribe("orders", new FilterExpression("created"));
 });
 
@@ -326,6 +327,10 @@ immediately. The generic registration selects the handler lifetime for the curre
 `Singleton` creates one handler per client registration/role and must be thread-safe; `Scoped` and `Transient`
 resolve a handler in a new async service scope for each handling attempt. The `MessageHandler`
 delegate remains available for small stateless callbacks, but cannot be combined with a typed handler.
+For non-FIFO dispatch, `ConsumeTimeout` defaults to 15 minutes. On expiry, the handler cancellation token is
+canceled, client invisibility renewal stops, and the message is requested for retry; a late successful handler result
+is ignored. Retried delivery can overlap code that ignored cancellation, so handlers must be idempotent. The client
+cannot forcibly stop that code. FIFO message groups are deliberately excluded so their ordering is preserved.
 
 ## LitePushConsumer
 

--- a/src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md
+++ b/src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md
@@ -293,6 +293,7 @@ rocketMQ.AddGrpcPushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, option
     options.MaxConcurrency = 8;
     options.MaxDeliveryAttempts = 16;
     options.InvisibleDuration = TimeSpan.FromSeconds(30);
+    options.ConsumeTimeout = TimeSpan.FromMinutes(15);
     options.Subscribe("orders", new FilterExpression("created"));
 });
 
@@ -312,6 +313,9 @@ public sealed class OrderMessageHandler : IGrpcPushMessageHandler
 选择 handler 生命周期：`Singleton` 会为每个客户端注册中的每个角色创建一个 handler，且必须线程安全；`Scoped` 和
 `Transient` 会在每次处理尝试中创建新的异步 DI scope，再从其中解析 handler。`MessageHandler` 委托仍适合
 简单的无状态回调，但不能与类型化 handler 同时配置。
+对于非 FIFO 分发，`ConsumeTimeout` 默认值为 15 分钟。到期后会取消 handler token、停止客户端的不可见时间续期，并请求消息
+重新投递；延迟返回的成功结果会被忽略。重新投递可能与仍在执行、但忽略取消的代码重叠，因此 handler 必须具备幂等性。
+客户端无法强制停止这段代码。FIFO message group 会刻意排除在该机制之外，以维持其顺序。
 
 ## LitePushConsumer
 

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/IRemotingPushMessageHandler.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/IRemotingPushMessageHandler.cs
@@ -19,19 +19,25 @@ using Microsoft.Extensions.DependencyInjection;
 namespace EventHorizon.RocketMQ.Remoting.Consumer.Push;
 
 /// <summary>
-/// Processes a message delivered by a classic remoting Push consumer.
+/// Processes a message batch delivered by a classic remoting Push consumer.
 /// </summary>
 /// <remarks>
 /// A handler registered with <see cref="ServiceLifetime.Singleton"/> can receive concurrent calls and must be
-/// thread-safe. Scoped and transient handlers are resolved for each message handling attempt.
+/// thread-safe. Scoped and transient handlers are resolved for each batch handling attempt. A returned
+/// <see cref="ConsumeResult"/> applies to every message in the batch.
 /// </remarks>
 public interface IRemotingPushMessageHandler
 {
     /// <summary>
-    /// Processes a received message and returns the requested delivery outcome.
+    /// Processes received messages and returns the requested delivery outcome for the complete batch.
     /// </summary>
-    /// <param name="message">The message to process.</param>
-    /// <param name="cancellationToken">The token that cancels processing when the consumer stops.</param>
-    /// <returns>The requested delivery outcome.</returns>
-    ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken);
+    /// <param name="messages">The messages to process, in their delivery order.</param>
+    /// <param name="cancellationToken">
+    /// The token that cancels processing when the consumer stops and, for concurrent clustered non-FIFO batches,
+    /// when <see cref="RemotingPushConsumerOptions.ConsumeTimeout"/> expires.
+    /// </param>
+    /// <returns>The requested delivery outcome for every message in <paramref name="messages"/>.</returns>
+    ValueTask<ConsumeResult> HandleAsync(
+        IReadOnlyList<RemotingMessageView> messages,
+        CancellationToken cancellationToken);
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/IRemotingPushMessageHandler.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/IRemotingPushMessageHandler.cs
@@ -24,20 +24,26 @@ namespace EventHorizon.RocketMQ.Remoting.Consumer.Push;
 /// <remarks>
 /// A handler registered with <see cref="ServiceLifetime.Singleton"/> can receive concurrent calls and must be
 /// thread-safe. Scoped and transient handlers are resolved for each batch handling attempt. A returned
-/// <see cref="ConsumeResult"/> applies to every message in the batch.
+/// <see cref="ConsumeResult.Success"/> can acknowledge a prefix of a concurrent non-FIFO batch through the
+/// supplied <see cref="RemotingPushConsumeContext"/>. Other outcomes apply to every message in the batch.
 /// </remarks>
 public interface IRemotingPushMessageHandler
 {
     /// <summary>
-    /// Processes received messages and returns the requested delivery outcome for the complete batch.
+    /// Processes received messages and returns the requested delivery outcome for the batch.
     /// </summary>
     /// <param name="messages">The messages to process, in their delivery order.</param>
+    /// <param name="context">
+    /// The acknowledgement settings for the current concurrent non-FIFO batch. FIFO <c>MessageGroup</c> and
+    /// orderly singleton deliveries ignore these settings.
+    /// </param>
     /// <param name="cancellationToken">
     /// The token that cancels processing when the consumer stops and, for concurrent clustered non-FIFO batches,
     /// when <see cref="RemotingPushConsumerOptions.ConsumeTimeout"/> expires.
     /// </param>
-    /// <returns>The requested delivery outcome for every message in <paramref name="messages"/>.</returns>
+    /// <returns>The requested delivery outcome for the batch.</returns>
     ValueTask<ConsumeResult> HandleAsync(
         IReadOnlyList<RemotingMessageView> messages,
+        RemotingPushConsumeContext context,
         CancellationToken cancellationToken);
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumeContext.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumeContext.cs
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using EventHorizon.RocketMQ.Remoting.Consumer;
+
+namespace EventHorizon.RocketMQ.Remoting.Consumer.Push;
+
+/// <summary>
+/// Provides acknowledgement settings for one classic remoting Push consumer batch delivery.
+/// </summary>
+/// <remarks>
+/// For a concurrent non-FIFO batch, the consumer uses this context only when the handler returns
+/// <see cref="ConsumeResult.Success"/>. The messages through <see cref="AckIndex"/> are acknowledged,
+/// while the remaining messages are retried. This mirrors RocketMQ's concurrent-consumer acknowledgement
+/// model. FIFO <c>MessageGroup</c> and orderly deliveries are singleton paths and ignore these settings.
+/// </remarks>
+public sealed class RemotingPushConsumeContext
+{
+    private int _ackIndex = int.MaxValue;
+
+    /// <summary>
+    /// Gets or sets the zero-based index of the final message acknowledged from the current batch.
+    /// </summary>
+    /// <remarks>
+    /// The default value acknowledges the complete batch. A value of <c>-1</c> acknowledges no messages.
+    /// Values greater than the last message index are treated as the last message index. This setting is
+    /// ignored when the handler returns <see cref="ConsumeResult.Retry"/> or
+    /// <see cref="ConsumeResult.DeadLetter"/>, because those outcomes apply to the complete batch.
+    /// </remarks>
+    public int AckIndex
+    {
+        get => _ackIndex;
+        set
+        {
+            if (value < -1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), value, "Acknowledgement index cannot be less than -1.");
+            }
+
+            _ackIndex = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the RocketMQ delay level used when the consumer sends unacknowledged messages back.
+    /// </summary>
+    /// <remarks>
+    /// The consumer initializes this value from <see cref="RemotingPushConsumerOptions.RetryDelay"/>. Set it to
+    /// <c>0</c> to let the Broker choose the retry interval, to a positive RocketMQ delay level to select a
+    /// Broker-defined interval, or to a negative value to request direct dead-letter delivery.
+    /// If <see cref="RemotingPushConsumerOptions.ConsumeTimeout"/> elapses first, the consumer ignores this value
+    /// and retries the complete batch using the configured <see cref="RemotingPushConsumerOptions.RetryDelay"/>.
+    /// </remarks>
+    public int DelayLevelWhenNextConsume { get; set; }
+}

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
@@ -34,7 +34,8 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
     private static readonly TimeSpan MaximumBrokerLockLiveTime = TimeSpan.FromSeconds(30);
 
     private readonly RemotingPushConsumerOptions _options;
-    private readonly Func<RemotingMessageView, CancellationToken, ValueTask<ConsumeResult>> _messageHandler;
+    private readonly Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>>
+        _messageHandler;
     private readonly RemotingClientOptions _clientOptions;
     private readonly IRemotingConsumerEngine _consumerEngine;
     private readonly ITopicRouteService _routes;
@@ -60,12 +61,13 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         IRemotingClient remotingClient,
         TimeProvider timeProvider,
         ILogger<RemotingPushConsumer> logger,
-        Func<RemotingMessageView, CancellationToken, ValueTask<ConsumeResult>>? messageHandler = null,
+        Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>>? messageHandler = null,
         IRemotingRocketMQTelemetry? telemetry = null)
     {
         _options = options.Value;
         _messageHandler = messageHandler ?? _options.MessageHandler ??
             throw new ArgumentException("A message handler is required.", nameof(options));
+
         _clientOptions = clientOptions.Value;
         _consumerEngine = consumerEngine;
         _routes = routes;
@@ -119,7 +121,8 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             var run = new RunState(
                 CreateDeliveryChannel(),
                 _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
-                _options.MaxConcurrency);
+                _options.MaxConcurrency,
+                _options.MaxCachedMessages);
             _run = run;
             try
             {
@@ -405,10 +408,9 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         }
     }
 
-    private Channel<Delivery> CreateDeliveryChannel() =>
-        Channel.CreateBounded<Delivery>(new BoundedChannelOptions(_options.MaxCachedMessages)
+    private Channel<DeliveryBatch> CreateDeliveryChannel() =>
+        Channel.CreateUnbounded<DeliveryBatch>(new UnboundedChannelOptions
         {
-            FullMode = BoundedChannelFullMode.Wait,
             SingleReader = _options.MaxConcurrency == 1,
             SingleWriter = false
         });
@@ -949,15 +951,44 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                 foreach (var delivery in pending)
                 {
                     run.ReserveFifoOrder(delivery);
-                    try
+                }
+
+                var deliveryBatches = CreateDeliveryBatches(pending);
+                try
+                {
+                    foreach (var batch in deliveryBatches)
                     {
-                        await run.Deliveries.Writer.WriteAsync(delivery, cancellationToken).ConfigureAwait(false);
+                        var slotsReserved = false;
+                        try
+                        {
+                            await run.ReserveDeliverySlotsAsync(batch.Deliveries.Count, cancellationToken)
+                                .ConfigureAwait(false);
+                            slotsReserved = true;
+                            await run.Deliveries.Writer.WriteAsync(batch, cancellationToken).ConfigureAwait(false);
+                            batch.MarkQueued();
+                        }
+                        catch
+                        {
+                            if (slotsReserved)
+                            {
+                                run.ReleaseDeliverySlots(batch.Deliveries.Count);
+                            }
+
+                            throw;
+                        }
                     }
-                    catch
+                }
+                catch
+                {
+                    foreach (var batch in deliveryBatches.Where(static batch => !batch.IsQueued))
                     {
-                        run.CompleteFifoOrder(delivery);
-                        throw;
+                        foreach (var delivery in batch.Deliveries)
+                        {
+                            run.CompleteFifoOrder(delivery);
+                        }
                     }
+
+                    throw;
                 }
 
                 var outcomes = await Task.WhenAll(pending.Select(static delivery => delivery.Completion.Task))
@@ -1028,6 +1059,41 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                     queue.QueueId);
                 await Task.Delay(_options.RetryDelay, cancellationToken).ConfigureAwait(false);
             }
+        }
+    }
+
+    private IReadOnlyList<DeliveryBatch> CreateDeliveryBatches(IReadOnlyList<Delivery> deliveries)
+    {
+        var batches = new List<DeliveryBatch>();
+        var batch = new List<Delivery>(Math.Min(_options.ConsumeMessageBatchSize, deliveries.Count));
+        foreach (var delivery in deliveries)
+        {
+            if (!string.IsNullOrEmpty(delivery.Message.MessageGroup))
+            {
+                AddBatch();
+                batches.Add(new DeliveryBatch([delivery]));
+                continue;
+            }
+
+            batch.Add(delivery);
+            if (batch.Count == _options.ConsumeMessageBatchSize)
+            {
+                AddBatch();
+            }
+        }
+
+        AddBatch();
+        return batches;
+
+        void AddBatch()
+        {
+            if (batch.Count == 0)
+            {
+                return;
+            }
+
+            batches.Add(new DeliveryBatch(batch.ToArray()));
+            batch.Clear();
         }
     }
 
@@ -1174,7 +1240,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             await run.OrderlyConcurrency.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                result = await InvokeMessageHandlerAsync(message, cancellationToken).ConfigureAwait(false);
+                result = await InvokeMessageHandlerAsync(new[] { message }, cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1405,32 +1471,49 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
     {
         try
         {
-            await foreach (var delivery in run.Deliveries.Reader.ReadAllAsync(run.Stopping.Token).ConfigureAwait(false))
+            await foreach (var batch in run.Deliveries.Reader.ReadAllAsync(run.Stopping.Token).ConfigureAwait(false))
             {
+                run.ReleaseDeliverySlots(batch.Deliveries.Count);
                 try
                 {
-                    if (delivery.QueueCancellation.IsCancellationRequested)
+                    if (batch.QueueCancellation.IsCancellationRequested)
                     {
-                        delivery.Completion.TrySetCanceled(delivery.QueueCancellation);
+                        foreach (var delivery in batch.Deliveries)
+                        {
+                            delivery.Completion.TrySetCanceled(batch.QueueCancellation);
+                        }
+
                         continue;
                     }
 
                     using var linked = CancellationTokenSource.CreateLinkedTokenSource(
                         run.Stopping.Token,
-                        delivery.QueueCancellation);
+                        batch.QueueCancellation);
                     try
                     {
-                        if (delivery.FifoOrder is { } order)
+                        foreach (var delivery in batch.Deliveries)
                         {
-                            await order.Predecessor.WaitAsync(linked.Token).ConfigureAwait(false);
+                            if (delivery.FifoOrder is { } order)
+                            {
+                                await order.Predecessor.WaitAsync(linked.Token).ConfigureAwait(false);
+                            }
                         }
 
-                        var result = await HandleMessageAsync(delivery, linked.Token).ConfigureAwait(false);
-                        delivery.Completion.TrySetResult(result);
+                        var result = UsesConcurrentTimeoutRecovery(batch)
+                            ? await InvokeConcurrentDeliveryBatchAsync(batch, linked.Token).ConfigureAwait(false)
+                            : await HandleDeliveryBatchAsync(batch, linked.Token).ConfigureAwait(false);
+                        foreach (var delivery in batch.Deliveries)
+                        {
+                            delivery.Completion.TrySetResult(result);
+                        }
                     }
                     catch (OperationCanceledException) when (linked.IsCancellationRequested)
                     {
-                        delivery.Completion.TrySetCanceled(linked.Token);
+                        foreach (var delivery in batch.Deliveries)
+                        {
+                            delivery.Completion.TrySetCanceled(linked.Token);
+                        }
+
                         if (run.Stopping.IsCancellationRequested)
                         {
                             return;
@@ -1440,20 +1523,40 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                     {
                         _logger.LogError(
                             exception,
-                            "Legacy message handler failed for message {MessageId}",
-                            delivery.Message.MessageId);
-                        delivery.Completion.TrySetResult(ConsumeResult.Retry);
+                            "Legacy message handler failed for a batch containing {MessageCount} messages",
+                            batch.Deliveries.Count);
+                        foreach (var delivery in batch.Deliveries)
+                        {
+                            delivery.Completion.TrySetResult(ConsumeResult.Retry);
+                        }
                     }
                 }
                 finally
                 {
-                    run.CompleteFifoOrder(delivery);
+                    foreach (var delivery in batch.Deliveries)
+                    {
+                        run.CompleteFifoOrder(delivery);
+                    }
                 }
             }
         }
         catch (OperationCanceledException) when (run.Stopping.IsCancellationRequested)
         {
         }
+    }
+
+    private async ValueTask<ConsumeResult> HandleDeliveryBatchAsync(
+        DeliveryBatch batch,
+        CancellationToken cancellationToken)
+    {
+        if (batch.Deliveries.Count == 1)
+        {
+            return await HandleMessageAsync(batch.Deliveries[0], cancellationToken).ConfigureAwait(false);
+        }
+
+        return await InvokeMessageHandlerAsync(
+            batch.Deliveries.Select(static delivery => delivery.Message).ToArray(),
+            cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask<ConsumeResult> HandleMessageAsync(
@@ -1466,7 +1569,9 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             ConsumeResult result;
             try
             {
-                result = await InvokeMessageHandlerAsync(delivery.Message, cancellationToken).ConfigureAwait(false);
+                result = await InvokeMessageHandlerAsync(
+                    new[] { delivery.Message },
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1497,21 +1602,28 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         }
     }
 
-    private async ValueTask<ConsumeResult> InvokeMessageHandlerAsync(
-        RemotingMessageView message,
-        CancellationToken cancellationToken)
-    {
-        using var telemetry = _telemetry.StartProcess(
-            message.Topic,
+    private ValueTask<ConsumeResult> InvokeMessageHandlerAsync(
+        IReadOnlyList<RemotingMessageView> messages,
+        CancellationToken cancellationToken) =>
+        InvokeTrackedMessageHandlerAsync(
+            messages,
+            cancellationToken,
+            StartMessageHandlerTelemetry(messages));
+
+    private MessageHandlerTelemetry StartMessageHandlerTelemetry(IReadOnlyList<RemotingMessageView> messages) =>
+        new(_telemetry.StartProcessBatch(
+            messages[0].Topic,
             _options.GroupName,
-                message.MessageId,
-                message.QueueId,
-                message.Body.LongLength,
-                message.Properties,
-                message.ReceiveActivityContext);
+            messages));
+
+    private async ValueTask<ConsumeResult> InvokeTrackedMessageHandlerAsync(
+        IReadOnlyList<RemotingMessageView> messages,
+        CancellationToken cancellationToken,
+        MessageHandlerTelemetry telemetry)
+    {
         try
         {
-            var result = await _messageHandler(message, cancellationToken).ConfigureAwait(false);
+            var result = await _messageHandler(messages, cancellationToken).ConfigureAwait(false);
             telemetry.Complete(result == ConsumeResult.Success, result.ToString());
             return result;
         }
@@ -1519,6 +1631,96 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         {
             telemetry.Complete(exception);
             throw;
+        }
+    }
+
+    private bool UsesConcurrentTimeoutRecovery(DeliveryBatch batch) =>
+        _options.ConsumerMode == ConsumerMode.Clustering &&
+        batch.Deliveries.All(static delivery => delivery.FifoOrder is null);
+
+    private async ValueTask<ConsumeResult> InvokeConcurrentDeliveryBatchAsync(
+        DeliveryBatch batch,
+        CancellationToken cancellationToken)
+    {
+        CancellationTokenSource? handlerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var timeoutCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        try
+        {
+            var activeHandlerCancellation = handlerCancellation;
+            var messages = batch.Deliveries.Select(static delivery => delivery.Message).ToArray();
+            var telemetry = StartMessageHandlerTelemetry(messages);
+            var handler = InvokeTrackedMessageHandlerAsync(messages, activeHandlerCancellation.Token, telemetry);
+            if (handler.IsCompletedSuccessfully)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return handler.Result;
+            }
+
+            var handlerTask = handler.AsTask();
+            var timeout = Task.Delay(_options.ConsumeTimeout, _timeProvider, timeoutCancellation.Token);
+            await Task.WhenAny(handlerTask, timeout).ConfigureAwait(false);
+            timeoutCancellation.Cancel();
+            if (handlerTask.IsCompleted)
+            {
+                return await handlerTask.ConfigureAwait(false);
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                telemetry.Complete(new OperationCanceledException(cancellationToken));
+                _ = ObserveTimedOutDeliveryBatchAsync(handlerTask, activeHandlerCancellation, batch.Deliveries.Count);
+                handlerCancellation = null;
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            telemetry.Complete(false, "timeout");
+            try
+            {
+                activeHandlerCancellation.Cancel();
+            }
+            catch (AggregateException exception)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "A cancellation callback failed after a legacy message handler exceeded the consume timeout");
+            }
+
+            _ = ObserveTimedOutDeliveryBatchAsync(handlerTask, activeHandlerCancellation, batch.Deliveries.Count);
+            handlerCancellation = null;
+            _logger.LogWarning(
+                "Legacy message handler exceeded the configured consume timeout of {ConsumeTimeout} for a batch containing {MessageCount} messages; cancellation was requested and the batch will be retried",
+                _options.ConsumeTimeout,
+                batch.Deliveries.Count);
+            return ConsumeResult.Retry;
+        }
+        finally
+        {
+            handlerCancellation?.Dispose();
+        }
+    }
+
+    private async Task ObserveTimedOutDeliveryBatchAsync(
+        Task<ConsumeResult> handlerTask,
+        CancellationTokenSource handlerCancellation,
+        int messageCount)
+    {
+        try
+        {
+            await handlerTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            _logger.LogDebug(
+                exception,
+                "Legacy message handler for a timed-out batch containing {MessageCount} messages completed with an exception after timeout",
+                messageCount);
+        }
+        finally
+        {
+            handlerCancellation.Dispose();
         }
     }
 
@@ -1720,19 +1922,26 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
 
     private sealed class RunState : IDisposable
     {
-        public RunState(Channel<Delivery> deliveries, long subscriptionVersion, int maxConcurrency)
+        public RunState(
+            Channel<DeliveryBatch> deliveries,
+            long subscriptionVersion,
+            int maxConcurrency,
+            int maxCachedMessages)
         {
             Deliveries = deliveries;
             _subscriptionVersion = subscriptionVersion;
             OrderlyConcurrency = new SemaphoreSlim(maxConcurrency, maxConcurrency);
+            DeliverySlots = new SemaphoreSlim(maxCachedMessages, maxCachedMessages);
         }
 
-        public Channel<Delivery> Deliveries { get; }
+        public Channel<DeliveryBatch> Deliveries { get; }
         public long SubscriptionVersion => Interlocked.Read(ref _subscriptionVersion);
         public CancellationTokenSource Stopping { get; } = new();
         public SemaphoreSlim RebalanceSignal { get; } = new(0, 1);
         public SemaphoreSlim CoordinationGate { get; } = new(1, 1);
         public SemaphoreSlim OrderlyConcurrency { get; }
+        public SemaphoreSlim DeliverySlots { get; }
+        public SemaphoreSlim DeliveryReservationGate { get; } = new(1, 1);
         public ConcurrentDictionary<QueueKey, QueueReceiver> Receivers { get; } = new();
         public ConcurrentDictionary<QueueKey, long> RetryBoundaries { get; } = new();
         public ConcurrentDictionary<string, BrokerEndpoint> KnownBrokers { get; } = new(StringComparer.Ordinal);
@@ -1744,6 +1953,35 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         private long _subscriptionVersion;
 
         public void BumpSubscriptionVersion() => Interlocked.Increment(ref _subscriptionVersion);
+
+        public async ValueTask ReserveDeliverySlotsAsync(int count, CancellationToken cancellationToken)
+        {
+            await DeliveryReservationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            var reserved = 0;
+            try
+            {
+                while (reserved < count)
+                {
+                    await DeliverySlots.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    reserved++;
+                }
+            }
+            catch
+            {
+                if (reserved > 0)
+                {
+                    DeliverySlots.Release(reserved);
+                }
+
+                throw;
+            }
+            finally
+            {
+                DeliveryReservationGate.Release();
+            }
+        }
+
+        public void ReleaseDeliverySlots(int count) => DeliverySlots.Release(count);
 
         public void ReserveFifoOrder(Delivery delivery)
         {
@@ -1789,6 +2027,8 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             RebalanceSignal.Dispose();
             CoordinationGate.Dispose();
             OrderlyConcurrency.Dispose();
+            DeliveryReservationGate.Dispose();
+            DeliverySlots.Dispose();
             Stopping.Dispose();
         }
     }
@@ -1850,6 +2090,70 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         {
             _brokerLockAvailable.Dispose();
             Stopping.Dispose();
+        }
+    }
+
+    private sealed class DeliveryBatch
+    {
+        public DeliveryBatch(IReadOnlyList<Delivery> deliveries)
+        {
+            ArgumentNullException.ThrowIfNull(deliveries);
+            if (deliveries.Count == 0)
+            {
+                throw new ArgumentException("At least one delivery is required.", nameof(deliveries));
+            }
+
+            Deliveries = deliveries;
+            QueueCancellation = deliveries[0].QueueCancellation;
+        }
+
+        public IReadOnlyList<Delivery> Deliveries { get; }
+        public CancellationToken QueueCancellation { get; }
+        public bool IsQueued { get; private set; }
+
+        public void MarkQueued() => IsQueued = true;
+    }
+
+    private sealed class MessageHandlerTelemetry(IRemotingRocketMQTelemetryOperation operation)
+    {
+        private IRemotingRocketMQTelemetryOperation? _operation = operation;
+
+        public void Complete(bool success, string? outcome = null)
+        {
+            var current = Interlocked.Exchange(ref _operation, null);
+            if (current is null)
+            {
+                return;
+            }
+
+            try
+            {
+                current.Complete(success, outcome);
+            }
+            finally
+            {
+                current.Dispose();
+            }
+        }
+
+        public void Complete(Exception exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            var current = Interlocked.Exchange(ref _operation, null);
+            if (current is null)
+            {
+                return;
+            }
+
+            try
+            {
+                current.Complete(exception);
+            }
+            finally
+            {
+                current.Dispose();
+            }
         }
     }
 

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
@@ -34,7 +34,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
     private static readonly TimeSpan MaximumBrokerLockLiveTime = TimeSpan.FromSeconds(30);
 
     private readonly RemotingPushConsumerOptions _options;
-    private readonly Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>>
+    private readonly Func<IReadOnlyList<RemotingMessageView>, RemotingPushConsumeContext, CancellationToken, ValueTask<ConsumeResult>>
         _messageHandler;
     private readonly RemotingClientOptions _clientOptions;
     private readonly IRemotingConsumerEngine _consumerEngine;
@@ -61,7 +61,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         IRemotingClient remotingClient,
         TimeProvider timeProvider,
         ILogger<RemotingPushConsumer> logger,
-        Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>>? messageHandler = null,
+        Func<IReadOnlyList<RemotingMessageView>, RemotingPushConsumeContext, CancellationToken, ValueTask<ConsumeResult>>? messageHandler = null,
         IRemotingRocketMQTelemetry? telemetry = null)
     {
         _options = options.Value;
@@ -997,12 +997,12 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                 {
                     for (var index = 0; index < outcomes.Length; index++)
                     {
-                        if (outcomes[index] != ConsumeResult.Success)
+                        if (outcomes[index].Result != ConsumeResult.Success)
                         {
                             _logger.LogWarning(
                                 "Broadcast consumer drops message {MessageId} after handler outcome {ConsumeResult}; broadcast retry and dead-letter queues are unavailable",
                                 pending[index].Message.MessageId,
-                                outcomes[index]);
+                                outcomes[index].Result);
                         }
                     }
                 }
@@ -1011,13 +1011,14 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                     for (var index = 0; index < outcomes.Length; index++)
                     {
                         var outcome = outcomes[index];
-                        if (outcome == ConsumeResult.Success)
+                        if (outcome.Result == ConsumeResult.Success)
                         {
                             continue;
                         }
 
                         var message = pending[index].Message;
-                        var deadLetter = outcome == ConsumeResult.DeadLetter ||
+                        var deadLetter = outcome.Result == ConsumeResult.DeadLetter ||
+                                         outcome.DelayLevelWhenNextConsume < 0 ||
                                          message.DeliveryAttempt >= _options.MaxDeliveryAttempts;
                         var retryOffset = deadLetter
                             ? null
@@ -1025,7 +1026,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                         await _consumerEngine.SendBackAsync(
                             queue,
                             message,
-                            deadLetter ? -1 : GetDelayLevel(_options.RetryDelay),
+                            deadLetter ? -1 : outcome.DelayLevelWhenNextConsume,
                             _options.MaxDeliveryAttempts,
                             cancellationToken).ConfigureAwait(false);
                         if (!deadLetter)
@@ -1240,7 +1241,8 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             await run.OrderlyConcurrency.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                result = await InvokeMessageHandlerAsync(new[] { message }, cancellationToken).ConfigureAwait(false);
+                result = (await InvokeMessageHandlerAsync(new[] { message }, cancellationToken).ConfigureAwait(false))
+                    .Result;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1502,9 +1504,9 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                         var result = UsesConcurrentTimeoutRecovery(batch)
                             ? await InvokeConcurrentDeliveryBatchAsync(batch, linked.Token).ConfigureAwait(false)
                             : await HandleDeliveryBatchAsync(batch, linked.Token).ConfigureAwait(false);
-                        foreach (var delivery in batch.Deliveries)
+                        for (var index = 0; index < batch.Deliveries.Count; index++)
                         {
-                            delivery.Completion.TrySetResult(result);
+                            batch.Deliveries[index].Completion.TrySetResult(result.GetOutcome(index));
                         }
                     }
                     catch (OperationCanceledException) when (linked.IsCancellationRequested)
@@ -1527,7 +1529,8 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                             batch.Deliveries.Count);
                         foreach (var delivery in batch.Deliveries)
                         {
-                            delivery.Completion.TrySetResult(ConsumeResult.Retry);
+                            delivery.Completion.TrySetResult(
+                                MessageConsumeResult.Retry(GetDelayLevel(_options.RetryDelay)));
                         }
                     }
                 }
@@ -1545,13 +1548,14 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         }
     }
 
-    private async ValueTask<ConsumeResult> HandleDeliveryBatchAsync(
+    private async ValueTask<BatchDeliveryResult> HandleDeliveryBatchAsync(
         DeliveryBatch batch,
         CancellationToken cancellationToken)
     {
         if (batch.Deliveries.Count == 1)
         {
-            return await HandleMessageAsync(batch.Deliveries[0], cancellationToken).ConfigureAwait(false);
+            var outcome = await HandleMessageAsync(batch.Deliveries[0], cancellationToken).ConfigureAwait(false);
+            return BatchDeliveryResult.All(outcome.Result, 1, outcome.DelayLevelWhenNextConsume);
         }
 
         return await InvokeMessageHandlerAsync(
@@ -1559,19 +1563,22 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             cancellationToken).ConfigureAwait(false);
     }
 
-    private async ValueTask<ConsumeResult> HandleMessageAsync(
+    private async ValueTask<MessageConsumeResult> HandleMessageAsync(
         Delivery delivery,
         CancellationToken cancellationToken)
     {
         var attempt = delivery.Message.DeliveryAttempt;
         while (true)
         {
-            ConsumeResult result;
+            MessageConsumeResult outcome;
             try
             {
-                result = await InvokeMessageHandlerAsync(
+                var batchResult = await InvokeMessageHandlerAsync(
                     new[] { delivery.Message },
                     cancellationToken).ConfigureAwait(false);
+                outcome = delivery.FifoOrder is null
+                    ? batchResult.GetOutcome(0)
+                    : new MessageConsumeResult(batchResult.Result, batchResult.DelayLevelWhenNextConsume);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1583,18 +1590,18 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                     exception,
                     "Legacy message handler failed for message {MessageId}",
                     delivery.Message.MessageId);
-                result = ConsumeResult.Retry;
+                outcome = MessageConsumeResult.Retry(GetDelayLevel(_options.RetryDelay));
             }
 
             if (_options.ConsumerMode == ConsumerMode.Broadcasting ||
-                delivery.FifoOrder is null || result != ConsumeResult.Retry)
+                delivery.FifoOrder is null || outcome.Result != ConsumeResult.Retry)
             {
-                return result;
+                return outcome;
             }
 
             if (attempt >= _options.MaxDeliveryAttempts)
             {
-                return ConsumeResult.DeadLetter;
+                return new MessageConsumeResult(ConsumeResult.DeadLetter, outcome.DelayLevelWhenNextConsume);
             }
 
             attempt++;
@@ -1602,13 +1609,17 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         }
     }
 
-    private ValueTask<ConsumeResult> InvokeMessageHandlerAsync(
+    private ValueTask<BatchDeliveryResult> InvokeMessageHandlerAsync(
         IReadOnlyList<RemotingMessageView> messages,
-        CancellationToken cancellationToken) =>
-        InvokeTrackedMessageHandlerAsync(
+        CancellationToken cancellationToken)
+    {
+        var context = CreateConsumeContext();
+        return InvokeTrackedMessageHandlerAsync(
             messages,
+            context,
             cancellationToken,
             StartMessageHandlerTelemetry(messages));
+    }
 
     private MessageHandlerTelemetry StartMessageHandlerTelemetry(IReadOnlyList<RemotingMessageView> messages) =>
         new(_telemetry.StartProcessBatch(
@@ -1616,16 +1627,22 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             _options.GroupName,
             messages));
 
-    private async ValueTask<ConsumeResult> InvokeTrackedMessageHandlerAsync(
+    private async ValueTask<BatchDeliveryResult> InvokeTrackedMessageHandlerAsync(
         IReadOnlyList<RemotingMessageView> messages,
+        RemotingPushConsumeContext context,
         CancellationToken cancellationToken,
         MessageHandlerTelemetry telemetry)
     {
         try
         {
-            var result = await _messageHandler(messages, cancellationToken).ConfigureAwait(false);
-            telemetry.Complete(result == ConsumeResult.Success, result.ToString());
-            return result;
+            var result = await _messageHandler(messages, context, cancellationToken).ConfigureAwait(false);
+            var batchResult = BatchDeliveryResult.Create(
+                result,
+                context.AckIndex,
+                context.DelayLevelWhenNextConsume,
+                messages.Count);
+            telemetry.Complete(batchResult.IsFullySuccessful, batchResult.TelemetryOutcome);
+            return batchResult;
         }
         catch (Exception exception)
         {
@@ -1634,11 +1651,16 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         }
     }
 
+    private RemotingPushConsumeContext CreateConsumeContext() => new()
+    {
+        DelayLevelWhenNextConsume = GetDelayLevel(_options.RetryDelay)
+    };
+
     private bool UsesConcurrentTimeoutRecovery(DeliveryBatch batch) =>
         _options.ConsumerMode == ConsumerMode.Clustering &&
         batch.Deliveries.All(static delivery => delivery.FifoOrder is null);
 
-    private async ValueTask<ConsumeResult> InvokeConcurrentDeliveryBatchAsync(
+    private async ValueTask<BatchDeliveryResult> InvokeConcurrentDeliveryBatchAsync(
         DeliveryBatch batch,
         CancellationToken cancellationToken)
     {
@@ -1648,8 +1670,13 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         {
             var activeHandlerCancellation = handlerCancellation;
             var messages = batch.Deliveries.Select(static delivery => delivery.Message).ToArray();
+            var context = CreateConsumeContext();
             var telemetry = StartMessageHandlerTelemetry(messages);
-            var handler = InvokeTrackedMessageHandlerAsync(messages, activeHandlerCancellation.Token, telemetry);
+            var handler = InvokeTrackedMessageHandlerAsync(
+                messages,
+                context,
+                activeHandlerCancellation.Token,
+                telemetry);
             if (handler.IsCompletedSuccessfully)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -1691,7 +1718,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                 "Legacy message handler exceeded the configured consume timeout of {ConsumeTimeout} for a batch containing {MessageCount} messages; cancellation was requested and the batch will be retried",
                 _options.ConsumeTimeout,
                 batch.Deliveries.Count);
-            return ConsumeResult.Retry;
+            return BatchDeliveryResult.Retry(batch.Deliveries.Count, GetDelayLevel(_options.RetryDelay));
         }
         finally
         {
@@ -1700,7 +1727,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
     }
 
     private async Task ObserveTimedOutDeliveryBatchAsync(
-        Task<ConsumeResult> handlerTask,
+        Task<BatchDeliveryResult> handlerTask,
         CancellationTokenSource handlerCancellation,
         int messageCount)
     {
@@ -2157,18 +2184,74 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         }
     }
 
+    private readonly record struct MessageConsumeResult(ConsumeResult Result, int DelayLevelWhenNextConsume)
+    {
+        public static MessageConsumeResult Retry(int delayLevelWhenNextConsume) =>
+            new(ConsumeResult.Retry, delayLevelWhenNextConsume);
+    }
+
+    private readonly record struct BatchDeliveryResult(
+        ConsumeResult Result,
+        int AcknowledgedCount,
+        int DelayLevelWhenNextConsume,
+        int MessageCount)
+    {
+        public bool IsFullySuccessful => Result == ConsumeResult.Success && AcknowledgedCount == MessageCount;
+
+        public string TelemetryOutcome =>
+            Result == ConsumeResult.Success && !IsFullySuccessful ? "partial_success" : Result.ToString();
+
+        public static BatchDeliveryResult Create(
+            ConsumeResult result,
+            int acknowledgementIndex,
+            int delayLevelWhenNextConsume,
+            int messageCount)
+        {
+            if (messageCount <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(messageCount), messageCount, "Message count must be positive.");
+            }
+
+            var acknowledgedCount = result == ConsumeResult.Success
+                ? Math.Min(acknowledgementIndex, messageCount - 1) + 1
+                : 0;
+            return new BatchDeliveryResult(result, acknowledgedCount, delayLevelWhenNextConsume, messageCount);
+        }
+
+        public static BatchDeliveryResult All(
+            ConsumeResult result,
+            int messageCount,
+            int delayLevelWhenNextConsume) =>
+            new(result, result == ConsumeResult.Success ? messageCount : 0, delayLevelWhenNextConsume, messageCount);
+
+        public static BatchDeliveryResult Retry(int messageCount, int delayLevelWhenNextConsume) =>
+            new(ConsumeResult.Retry, 0, delayLevelWhenNextConsume, messageCount);
+
+        public MessageConsumeResult GetOutcome(int index)
+        {
+            if ((uint)index >= (uint)MessageCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index), index, "Message index is outside the batch.");
+            }
+
+            return new MessageConsumeResult(
+                Result == ConsumeResult.Success && index >= AcknowledgedCount ? ConsumeResult.Retry : Result,
+                DelayLevelWhenNextConsume);
+        }
+    }
+
     private sealed class Delivery
     {
         public Delivery(RemotingMessageView message, CancellationToken queueCancellation)
         {
             Message = message;
             QueueCancellation = queueCancellation;
-            Completion = new TaskCompletionSource<ConsumeResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Completion = new TaskCompletionSource<MessageConsumeResult>(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
         public RemotingMessageView Message { get; }
         public CancellationToken QueueCancellation { get; }
-        public TaskCompletionSource<ConsumeResult> Completion { get; }
+        public TaskCompletionSource<MessageConsumeResult> Completion { get; }
         public FifoOrder? FifoOrder { get; set; }
     }
 

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumerOptions.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumerOptions.cs
@@ -124,10 +124,11 @@ public sealed class RemotingPushConsumerOptions : ConsumerOptions
     /// </summary>
     /// <remarks>
     /// This delegate is invoked directly. Use the generic <c>AddRemotingPushConsumer&lt;TMessageHandler&gt;</c>
-    /// overload to use a dependency-injected handler with an explicit lifetime. The returned outcome applies to
-    /// every message in the batch.
+    /// overload to use a dependency-injected handler with an explicit lifetime. When it returns
+    /// <see cref="ConsumeResult.Success"/>, use the supplied <see cref="RemotingPushConsumeContext"/> for a
+    /// concurrent non-FIFO batch to acknowledge a prefix and retry its remaining messages.
     /// </remarks>
-    public Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>>? MessageHandler
+    public Func<IReadOnlyList<RemotingMessageView>, RemotingPushConsumeContext, CancellationToken, ValueTask<ConsumeResult>>? MessageHandler
     {
         get;
         set;

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumerOptions.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumerOptions.cs
@@ -23,14 +23,30 @@ namespace EventHorizon.RocketMQ.Remoting.Consumer.Push;
 public sealed class RemotingPushConsumerOptions : ConsumerOptions
 {
     /// <summary>
-    /// Gets or sets the maximum number of message-handler invocations that may run concurrently.
+    /// Gets or sets the maximum number of message-handler batch dispatches that may run concurrently.
     /// </summary>
+    /// <remarks>
+    /// A non-FIFO handler that ignores cancellation after <see cref="ConsumeTimeout"/> expires can continue running
+    /// after its dispatch slot is released, so the setting limits scheduled dispatches rather than every in-process
+    /// application invocation in that exceptional case.
+    /// </remarks>
     public int MaxConcurrency { get; set; } = Environment.ProcessorCount;
 
     /// <summary>
     /// Gets or sets the maximum number of messages requested by each long-poll operation.
     /// </summary>
     public int BatchSize { get; set; } = 32;
+
+    /// <summary>
+    /// Gets or sets the maximum number of messages passed to one batch message-handler invocation.
+    /// </summary>
+    /// <remarks>
+    /// This setting is independent from <see cref="BatchSize"/>, which controls the maximum number of
+    /// messages requested from the Broker. Batch handling is used only for concurrent dispatch; orderly
+    /// consumption and messages with a <c>MessageGroup</c> continue to be delivered one at a time so that
+    /// their ordering and retry semantics remain intact.
+    /// </remarks>
+    public int ConsumeMessageBatchSize { get; set; } = 1;
 
     /// <summary>
     /// Gets or sets the maximum number of messages that may wait for local dispatch.
@@ -56,6 +72,19 @@ public sealed class RemotingPushConsumerOptions : ConsumerOptions
     /// Gets or sets the delay applied before retrying message handling or a failed receive operation.
     /// </summary>
     public TimeSpan RetryDelay { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Gets or sets the maximum time a concurrent clustered message batch may occupy a handler before retry is requested.
+    /// </summary>
+    /// <remarks>
+    /// When this timeout elapses, the consumer cancels the handler token and marks the complete non-FIFO batch as
+    /// <see cref="ConsumeResult.Retry"/> so it can be returned to the Broker for redelivery. Application code that
+    /// does not cooperate with cancellation cannot be forcibly stopped; its late result is ignored and can overlap
+    /// a redelivered invocation.
+    /// This recovery is intentionally not applied to <see cref="ConsumeOrderly"/> or <c>MessageGroup</c> FIFO delivery,
+    /// because automatically releasing those messages could break their ordering guarantees.
+    /// </remarks>
+    public TimeSpan ConsumeTimeout { get; set; } = TimeSpan.FromMinutes(15);
 
     /// <summary>
     /// Gets or sets whether this consumer shares queues with its group or receives every queue.
@@ -91,11 +120,16 @@ public sealed class RemotingPushConsumerOptions : ConsumerOptions
     public DateTimeOffset? ConsumeTimestamp { get; set; }
 
     /// <summary>
-    /// Gets or sets the asynchronous handler that processes each delivered message and reports its outcome.
+    /// Gets or sets the asynchronous handler that processes one delivered message batch and reports its outcome.
     /// </summary>
     /// <remarks>
     /// This delegate is invoked directly. Use the generic <c>AddRemotingPushConsumer&lt;TMessageHandler&gt;</c>
-    /// overload to use a dependency-injected handler with an explicit lifetime.
+    /// overload to use a dependency-injected handler with an explicit lifetime. The returned outcome applies to
+    /// every message in the batch.
     /// </remarks>
-    public Func<RemotingMessageView, CancellationToken, ValueTask<ConsumeResult>>? MessageHandler { get; set; }
+    public Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>>? MessageHandler
+    {
+        get;
+        set;
+    }
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushMessageHandlerFactory.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushMessageHandlerFactory.cs
@@ -44,7 +44,7 @@ internal static class RemotingPushMessageHandlerFactory
         }
     }
 
-    internal static Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>> Create(
+    internal static Func<IReadOnlyList<RemotingMessageView>, RemotingPushConsumeContext, CancellationToken, ValueTask<ConsumeResult>> Create(
         IServiceProvider provider,
         RemotingRocketMQRoleKey roleKey,
         ServiceLifetime lifetime)
@@ -61,19 +61,20 @@ internal static class RemotingPushMessageHandlerFactory
         };
     }
 
-    private static Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>> CreateScopedHandler(
+    private static Func<IReadOnlyList<RemotingMessageView>, RemotingPushConsumeContext, CancellationToken, ValueTask<ConsumeResult>> CreateScopedHandler(
         IServiceScopeFactory scopeFactory,
         RemotingRocketMQRoleKey roleKey) =>
-        (messages, cancellationToken) => HandleScopedAsync(scopeFactory, roleKey, messages, cancellationToken);
+        (messages, context, cancellationToken) => HandleScopedAsync(scopeFactory, roleKey, messages, context, cancellationToken);
 
     private static async ValueTask<ConsumeResult> HandleScopedAsync(
         IServiceScopeFactory scopeFactory,
         RemotingRocketMQRoleKey roleKey,
         IReadOnlyList<RemotingMessageView> messages,
+        RemotingPushConsumeContext context,
         CancellationToken cancellationToken)
     {
         await using var scope = scopeFactory.CreateAsyncScope();
         var handler = scope.ServiceProvider.GetRequiredKeyedService<IRemotingPushMessageHandler>(roleKey);
-        return await handler.HandleAsync(messages, cancellationToken).ConfigureAwait(false);
+        return await handler.HandleAsync(messages, context, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushMessageHandlerFactory.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushMessageHandlerFactory.cs
@@ -44,7 +44,7 @@ internal static class RemotingPushMessageHandlerFactory
         }
     }
 
-    internal static Func<RemotingMessageView, CancellationToken, ValueTask<ConsumeResult>> Create(
+    internal static Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>> Create(
         IServiceProvider provider,
         RemotingRocketMQRoleKey roleKey,
         ServiceLifetime lifetime)
@@ -61,19 +61,19 @@ internal static class RemotingPushMessageHandlerFactory
         };
     }
 
-    private static Func<RemotingMessageView, CancellationToken, ValueTask<ConsumeResult>> CreateScopedHandler(
+    private static Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>> CreateScopedHandler(
         IServiceScopeFactory scopeFactory,
         RemotingRocketMQRoleKey roleKey) =>
-        (message, cancellationToken) => HandleScopedAsync(scopeFactory, roleKey, message, cancellationToken);
+        (messages, cancellationToken) => HandleScopedAsync(scopeFactory, roleKey, messages, cancellationToken);
 
     private static async ValueTask<ConsumeResult> HandleScopedAsync(
         IServiceScopeFactory scopeFactory,
         RemotingRocketMQRoleKey roleKey,
-        RemotingMessageView message,
+        IReadOnlyList<RemotingMessageView> messages,
         CancellationToken cancellationToken)
     {
         await using var scope = scopeFactory.CreateAsyncScope();
         var handler = scope.ServiceProvider.GetRequiredKeyedService<IRemotingPushMessageHandler>(roleKey);
-        return await handler.HandleAsync(message, cancellationToken).ConfigureAwait(false);
+        return await handler.HandleAsync(messages, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Instrumentation/IRemotingRocketMQTelemetry.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Instrumentation/IRemotingRocketMQTelemetry.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Diagnostics;
+using EventHorizon.RocketMQ.Remoting.Consumer;
 
 namespace EventHorizon.RocketMQ.Remoting.Instrumentation;
 
@@ -40,6 +41,11 @@ internal interface IRemotingRocketMQTelemetry
         long bodySize,
         IReadOnlyDictionary<string, string> properties,
         ActivityContext? receiveContext);
+
+    IRemotingRocketMQTelemetryOperation StartProcessBatch(
+        string topic,
+        string consumerGroup,
+        IReadOnlyList<RemotingMessageView> messages);
 
     IRemotingRocketMQTelemetryOperation StartSettle(
         string operationName,

--- a/src/EventHorizon.RocketMQ.Remoting/Instrumentation/RemotingRocketMQTelemetry.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Instrumentation/RemotingRocketMQTelemetry.cs
@@ -153,7 +153,7 @@ internal sealed class RemotingRocketMQTelemetry : IRemotingRocketMQTelemetry
             consumerGroup,
             messages.Count,
             bodySize,
-            null,
+            messages.Count == 1 ? first.MessageId : null,
             parentMessageIndex < 0
                 ? messages.Select(static message => message.Properties)
                 : messages.Where((_, index) => index != parentMessageIndex).Select(static message => message.Properties),

--- a/src/EventHorizon.RocketMQ.Remoting/Instrumentation/RemotingRocketMQTelemetry.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Instrumentation/RemotingRocketMQTelemetry.cs
@@ -15,6 +15,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using EventHorizon.RocketMQ.Remoting.Consumer;
 
 namespace EventHorizon.RocketMQ.Remoting.Instrumentation;
 
@@ -109,6 +110,56 @@ internal sealed class RemotingRocketMQTelemetry : IRemotingRocketMQTelemetry
             parentContext,
             null,
             queueId);
+    }
+
+    public IRemotingRocketMQTelemetryOperation StartProcessBatch(
+        string topic,
+        string consumerGroup,
+        IReadOnlyList<RemotingMessageView> messages)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        if (messages.Count == 0)
+        {
+            throw new ArgumentException("At least one message is required.", nameof(messages));
+        }
+
+        long bodySize = 0;
+        foreach (var message in messages)
+        {
+            bodySize = checked(bodySize + message.Body.LongLength);
+        }
+
+        var first = messages[0];
+        var parentContext = first.ReceiveActivityContext;
+        var parentMessageIndex = -1;
+        if (!HasValidContext(parentContext))
+        {
+            for (var index = 0; index < messages.Count; index++)
+            {
+                if (TryExtractContext(messages[index].Properties, out var propagatedContext))
+                {
+                    parentContext = propagatedContext;
+                    parentMessageIndex = index;
+                    break;
+                }
+            }
+        }
+
+        return Start(
+            "process",
+            "process",
+            ActivityKind.Consumer,
+            topic,
+            consumerGroup,
+            messages.Count,
+            bodySize,
+            null,
+            parentMessageIndex < 0
+                ? messages.Select(static message => message.Properties)
+                : messages.Where((_, index) => index != parentMessageIndex).Select(static message => message.Properties),
+            parentContext,
+            null,
+            first.QueueId);
     }
 
     public IRemotingRocketMQTelemetryOperation StartSettle(

--- a/src/EventHorizon.RocketMQ.Remoting/README.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.md
@@ -99,7 +99,7 @@ enable the applicable server-side feature.
 | `IRemotingPullConsumer` | ✅ | Supports explicit queues and offsets plus tag or SQL filtering. SQL filtering requires the target Broker's filter configuration. |
 | `IRemotingLitePullConsumer` | ✅ | Supports clustered automatic or manual assignment, client-maintained positions, commits, pause, resume, and seek. It currently supports clustered consumption only. |
 | `IRemotingPopConsumer` | ✅ | Supports manually selected physical queues, receipt acknowledgement, and invisibility renewal for normal-topic POP messages; the Broker must support POP. |
-| `IRemotingPushConsumer` | ✅ | Supports clustering or broadcasting, runtime subscriptions, configurable initial offsets, concurrent or FIFO dispatch, retries, dead-letter handling, and Broker-triggered rebalance or offset reset. |
+| `IRemotingPushConsumer` | ✅ | Supports clustering or broadcasting, runtime subscriptions, configurable initial offsets, concurrent batch callbacks or singleton FIFO dispatch, retries, dead-letter handling, and Broker-triggered rebalance or offset reset. |
 | Queue-orderly Push consumption | ✅ | Uses optional Broker queue locks for ordered consumption; configure it only where the destination Broker supports the classic locking flow. |
 | Built-in socket transport | ✅ | Uses `System.IO.Pipelines` with optional TLS, multiple NameServer addresses, Broker failover, ACL signing, namespaces, and configurable frame limits. It does not depend on Bedrock Framework. |
 | Dependency injection, options, logging, Generic Host lifecycle, and default/keyed client registrations | ✅ | Add a client registration with `AddRocketMQRemoting`, then add the required roles. |
@@ -517,6 +517,10 @@ Classic `IRemotingPushConsumer` is implemented with client-initiated pulls and l
 not protocol-level Broker push, although it also handles classic Broker callbacks for rebalance and
 offset reset.
 
+There is one Remoting PushConsumer role and one list-based message-handler contract. Configuring a larger
+`ConsumeMessageBatchSize` changes the maximum messages delivered to that contract; it does not select a separate
+consumer implementation.
+
 ```csharp
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
@@ -528,32 +532,52 @@ rocketMQ.AddRemotingPushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, op
 {
     options.GroupName = "orders-push-consumer";
     options.MaxConcurrency = 8;
+    options.BatchSize = 32;
+    options.ConsumeMessageBatchSize = 16;
     options.MaxDeliveryAttempts = 16;
     options.Subscribe("orders", new FilterExpression("created"));
 });
 
 public sealed class OrderMessageHandler : IRemotingPushMessageHandler
 {
-    public ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken)
+    public ValueTask<ConsumeResult> HandleAsync(
+        IReadOnlyList<RemotingMessageView> messages,
+        CancellationToken cancellationToken)
     {
-        Console.WriteLine(Encoding.UTF8.GetString(message.Body));
+        foreach (var message in messages)
+        {
+            Console.WriteLine(Encoding.UTF8.GetString(message.Body));
+        }
+
         return ValueTask.FromResult(ConsumeResult.Success);
     }
 }
 ```
 
-Return `Success` to commit a message, `Retry` to request Broker redelivery, or `DeadLetter` to send
-it to the dead-letter queue. Runtime `SubscribeAsync` and `UnsubscribeAsync` calls update classic
-heartbeats and reconcile active queue receivers. The generic registration selects the handler lifetime
+`BatchSize` is the maximum number of messages requested from the Broker by one long poll and defaults to 32.
+`ConsumeMessageBatchSize` is the maximum number passed to one handler invocation and defaults to 1. For concurrent
+dispatch, only non-`MessageGroup` messages received from the same Broker physical queue are combined. `MessageGroup`
+FIFO messages and all `ConsumeOrderly` deliveries are passed as singleton lists to preserve ordering and retry
+semantics. Eligible concurrent batches can run in parallel up to `MaxConcurrency`.
+
+`ConsumeTimeout` defaults to 15 minutes. For a concurrent clustered non-FIFO batch that exceeds the timeout, the
+consumer cancels the handler token and requests Broker redelivery for the whole batch. It cannot forcibly terminate
+application code that ignores cancellation; its late result is ignored and can overlap a redelivered invocation, so
+handlers must honor the token and remain idempotent. FIFO and orderly delivery are excluded to preserve their ordering
+guarantees.
+
+Return `Success` to commit every message in a batch, `Retry` to request Broker redelivery for every message in the
+batch, or `DeadLetter` to send every message in the batch to the dead-letter queue. Runtime `SubscribeAsync` and
+`UnsubscribeAsync` calls update classic heartbeats and reconcile active queue receivers. The generic registration selects the handler lifetime
 for the current client registration: `Singleton` creates one handler per client registration/role and must be thread-safe;
-`Scoped` and `Transient` resolve a handler in a new async service scope for each handling attempt. The
-`MessageHandler` delegate remains available for small stateless callbacks, but cannot be combined with a
+`Scoped` and `Transient` resolve a handler in a new async service scope for each batch handling attempt. The
+`MessageHandler` delegate has the same list-based signature and remains available for small stateless callbacks, but cannot be combined with a
 typed handler.
 
 ### Queue-orderly consumption
 
 Set `ConsumeOrderly` when a classic PushConsumer must process each assigned physical queue one message
-at a time:
+at a time. It delivers singleton lists regardless of `ConsumeMessageBatchSize`:
 
 ```csharp
 rocketMQ.AddRemotingPushConsumer(options =>

--- a/src/EventHorizon.RocketMQ.Remoting/README.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.md
@@ -99,7 +99,7 @@ enable the applicable server-side feature.
 | `IRemotingPullConsumer` | ✅ | Supports explicit queues and offsets plus tag or SQL filtering. SQL filtering requires the target Broker's filter configuration. |
 | `IRemotingLitePullConsumer` | ✅ | Supports clustered automatic or manual assignment, client-maintained positions, commits, pause, resume, and seek. It currently supports clustered consumption only. |
 | `IRemotingPopConsumer` | ✅ | Supports manually selected physical queues, receipt acknowledgement, and invisibility renewal for normal-topic POP messages; the Broker must support POP. |
-| `IRemotingPushConsumer` | ✅ | Supports clustering or broadcasting, runtime subscriptions, configurable initial offsets, concurrent batch callbacks or singleton FIFO dispatch, retries, dead-letter handling, and Broker-triggered rebalance or offset reset. |
+| `IRemotingPushConsumer` | ✅ | Supports clustering or broadcasting, runtime subscriptions, configurable initial offsets, concurrent batch callbacks with partial prefix acknowledgement or singleton FIFO dispatch, retries, dead-letter handling, and Broker-triggered rebalance or offset reset. |
 | Queue-orderly Push consumption | ✅ | Uses optional Broker queue locks for ordered consumption; configure it only where the destination Broker supports the classic locking flow. |
 | Built-in socket transport | ✅ | Uses `System.IO.Pipelines` with optional TLS, multiple NameServer addresses, Broker failover, ACL signing, namespaces, and configurable frame limits. It does not depend on Bedrock Framework. |
 | Dependency injection, options, logging, Generic Host lifecycle, and default/keyed client registrations | ✅ | Add a client registration with `AddRocketMQRemoting`, then add the required roles. |
@@ -542,6 +542,7 @@ public sealed class OrderMessageHandler : IRemotingPushMessageHandler
 {
     public ValueTask<ConsumeResult> HandleAsync(
         IReadOnlyList<RemotingMessageView> messages,
+        RemotingPushConsumeContext context,
         CancellationToken cancellationToken)
     {
         foreach (var message in messages)
@@ -566,13 +567,24 @@ application code that ignores cancellation; its late result is ignored and can o
 handlers must honor the token and remain idempotent. FIFO and orderly delivery are excluded to preserve their ordering
 guarantees.
 
-Return `Success` to commit every message in a batch, `Retry` to request Broker redelivery for every message in the
-batch, or `DeadLetter` to send every message in the batch to the dead-letter queue. Runtime `SubscribeAsync` and
-`UnsubscribeAsync` calls update classic heartbeats and reconcile active queue receivers. The generic registration selects the handler lifetime
-for the current client registration: `Singleton` creates one handler per client registration/role and must be thread-safe;
-`Scoped` and `Transient` resolve a handler in a new async service scope for each batch handling attempt. The
-`MessageHandler` delegate has the same list-based signature and remains available for small stateless callbacks, but cannot be combined with a
-typed handler.
+The handler also receives a `RemotingPushConsumeContext`. Returning `Success` commits the complete batch by default.
+For a concurrent non-FIFO batch, set `context.AckIndex` to the zero-based index of the last successfully processed
+message, then return `Success`: the client commits that contiguous prefix and sends only the remaining tail for
+Broker retry. `AckIndex` defaults to `int.MaxValue` (all messages) and accepts `-1` when no message was processed.
+Returning `Retry` or `DeadLetter` ignores `AckIndex` and applies to every message in the batch.
+
+`context.DelayLevelWhenNextConsume` controls messages that will be retried. It starts with the Broker delay level
+mapped from `RetryDelay`; set it to `0` to let the Broker choose its retry policy, a positive RocketMQ delay level to
+request that level, or a negative value to send those messages directly to the dead-letter queue. Broadcasting has no
+Broker retry or dead-letter flow, so an unacknowledged batch tail is skipped while the local offset advances.
+`MessageGroup` FIFO and `ConsumeOrderly` paths always receive singleton lists and do not use partial batch
+confirmation.
+
+Runtime `SubscribeAsync` and `UnsubscribeAsync` calls update classic heartbeats and reconcile active queue receivers.
+The generic registration selects the handler lifetime for the current client registration: `Singleton` creates one
+handler per client registration/role and must be thread-safe; `Scoped` and `Transient` resolve a handler in a new
+async service scope for each batch handling attempt. The `MessageHandler` delegate has the same list-and-context
+signature and remains available for small stateless callbacks, but cannot be combined with a typed handler.
 
 ### Queue-orderly consumption
 

--- a/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
@@ -93,7 +93,7 @@ await app.RunAsync();
 | `IRemotingPullConsumer` | ✅ | 支持显式队列和位点，以及 tag 或 SQL 过滤。SQL 过滤要求目标 Broker 配置过滤能力。 |
 | `IRemotingLitePullConsumer` | ✅ | 支持订阅后的自动分配，或通过 `AssignAsync` 手动分配；客户端维护位点、提交、暂停、恢复和 seek。目前仅支持集群消费。 |
 | `IRemotingPopConsumer` | ✅ | 支持手动选择物理队列、receipt 确认以及普通 topic POP 消息的可见期续租；Broker 必须支持 POP。 |
-| `IRemotingPushConsumer` | ✅ | 支持集群或广播消费、运行时订阅、可配置起始位点、并发或 FIFO 分发、重试、死信处理，以及 Broker 触发的重平衡或位点重置。 |
+| `IRemotingPushConsumer` | ✅ | 支持集群或广播消费、运行时订阅、可配置起始位点、并发批量回调或单消息 FIFO 分发、重试、死信处理，以及 Broker 触发的重平衡或位点重置。 |
 | 队列有序 Push 消费 | ✅ | 使用可选的 Broker 队列锁实现有序消费；仅在目标 Broker 支持经典锁定流程时配置。 |
 | 内置 Socket 传输 | ✅ | 基于 `System.IO.Pipelines`，支持可选 TLS、多个 NameServer 地址、Broker 故障转移、ACL 签名、命名空间和可配置帧限制；不依赖 Bedrock Framework。 |
 | 依赖注入、Options、日志、Generic Host 生命周期以及默认客户端注册和 keyed 客户端注册 | ✅ | 使用 `AddRocketMQRemoting` 创建客户端注册，再添加所需角色。 |
@@ -493,6 +493,9 @@ POP 命令码超出了 RocketMQ 可选二进制 command-header 格式保留的�
 经典 `IRemotingPushConsumer` 由客户端主动拉取和长轮询实现，并非协议层面的 Broker Push；但它还会
 处理经典 Broker 的重平衡和位点重置回调。
 
+Remoting 只有一个 PushConsumer 角色和一套基于列表的 message-handler 合约。增大
+`ConsumeMessageBatchSize` 只会改变该合约单次收到的最大消息数，不会选择另一个 Consumer 实现。
+
 ```csharp
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
@@ -504,29 +507,47 @@ rocketMQ.AddRemotingPushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, op
 {
     options.GroupName = "orders-push-consumer";
     options.MaxConcurrency = 8;
+    options.BatchSize = 32;
+    options.ConsumeMessageBatchSize = 16;
     options.MaxDeliveryAttempts = 16;
     options.Subscribe("orders", new FilterExpression("created"));
 });
 
 public sealed class OrderMessageHandler : IRemotingPushMessageHandler
 {
-    public ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken)
+    public ValueTask<ConsumeResult> HandleAsync(
+        IReadOnlyList<RemotingMessageView> messages,
+        CancellationToken cancellationToken)
     {
-        Console.WriteLine(Encoding.UTF8.GetString(message.Body));
+        foreach (var message in messages)
+        {
+            Console.WriteLine(Encoding.UTF8.GetString(message.Body));
+        }
+
         return ValueTask.FromResult(ConsumeResult.Success);
     }
 }
 ```
 
-返回 `Success` 可提交消息，返回 `Retry` 可请求 Broker 重新投递，返回 `DeadLetter` 会将消息发送到
-死信队列。运行时调用 `SubscribeAsync` 和 `UnsubscribeAsync` 会更新经典心跳和当前队列接收器。
+`BatchSize` 是单次长轮询从 Broker 请求的最大消息数，默认值为 32。`ConsumeMessageBatchSize` 是单次
+handler 调用收到的最大消息数，默认值为 1。并发分发只会将来自同一个 Broker 物理队列、且不带
+`MessageGroup` 的消息合并为一批；带 `MessageGroup` 的 FIFO 消息以及所有 `ConsumeOrderly` 投递都会以
+只包含一条消息的列表传递，以保持顺序和重试语义。符合并发条件的批次可在 `MaxConcurrency` 范围内并行处理。
+
+`ConsumeTimeout` 默认值为 15 分钟。并发集群、非 FIFO 批次超过该时间后，Consumer 会取消 handler token，并为
+整批消息请求 Broker 重新投递。它不能强制终止忽略取消信号的应用代码，因此 handler 必须响应该 token，并保持幂等。
+延迟返回的结果会被忽略，并可能与重新投递的调用重叠。FIFO 和顺序投递为保持顺序保证而不会应用此机制。
+
+返回 `Success` 会提交一批中的每条消息，返回 `Retry` 会为一批中的每条消息请求 Broker 重新投递，返回
+`DeadLetter` 会将一批中的每条消息发送到死信队列。运行时调用 `SubscribeAsync` 和 `UnsubscribeAsync` 会更新经典心跳和当前队列接收器。
 泛型注册会为当前客户端注册选择 handler 生命周期：`Singleton` 会为每个客户端注册中的每个角色创建一个 handler，
-且必须线程安全；`Scoped` 和 `Transient` 会在每次处理尝试中创建新的异步 DI scope，再从其中解析 handler。
-`MessageHandler` 委托仍适合简单的无状态回调，但不能与类型化 handler 同时配置。
+且必须线程安全；`Scoped` 和 `Transient` 会在每次批量处理尝试中创建新的异步 DI scope，再从其中解析 handler。
+`MessageHandler` 委托使用相同的列表签名，仍适合简单的无状态回调，但不能与类型化 handler 同时配置。
 
 ### 队列有序消费
 
-当经典 PushConsumer 需要让每个已分配的物理队列一次只处理一条消息时，设置 `ConsumeOrderly`：
+当经典 PushConsumer 需要让每个已分配的物理队列一次只处理一条消息时，设置 `ConsumeOrderly`。无论
+`ConsumeMessageBatchSize` 如何配置，它都会传递只包含一条消息的列表：
 
 ```csharp
 rocketMQ.AddRemotingPushConsumer(options =>

--- a/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
@@ -93,7 +93,7 @@ await app.RunAsync();
 | `IRemotingPullConsumer` | ✅ | 支持显式队列和位点，以及 tag 或 SQL 过滤。SQL 过滤要求目标 Broker 配置过滤能力。 |
 | `IRemotingLitePullConsumer` | ✅ | 支持订阅后的自动分配，或通过 `AssignAsync` 手动分配；客户端维护位点、提交、暂停、恢复和 seek。目前仅支持集群消费。 |
 | `IRemotingPopConsumer` | ✅ | 支持手动选择物理队列、receipt 确认以及普通 topic POP 消息的可见期续租；Broker 必须支持 POP。 |
-| `IRemotingPushConsumer` | ✅ | 支持集群或广播消费、运行时订阅、可配置起始位点、并发批量回调或单消息 FIFO 分发、重试、死信处理，以及 Broker 触发的重平衡或位点重置。 |
+| `IRemotingPushConsumer` | ✅ | 支持集群或广播消费、运行时订阅、可配置起始位点、可部分确认前缀的并发批量回调或单消息 FIFO 分发、重试、死信处理，以及 Broker 触发的重平衡或位点重置。 |
 | 队列有序 Push 消费 | ✅ | 使用可选的 Broker 队列锁实现有序消费；仅在目标 Broker 支持经典锁定流程时配置。 |
 | 内置 Socket 传输 | ✅ | 基于 `System.IO.Pipelines`，支持可选 TLS、多个 NameServer 地址、Broker 故障转移、ACL 签名、命名空间和可配置帧限制；不依赖 Bedrock Framework。 |
 | 依赖注入、Options、日志、Generic Host 生命周期以及默认客户端注册和 keyed 客户端注册 | ✅ | 使用 `AddRocketMQRemoting` 创建客户端注册，再添加所需角色。 |
@@ -517,6 +517,7 @@ public sealed class OrderMessageHandler : IRemotingPushMessageHandler
 {
     public ValueTask<ConsumeResult> HandleAsync(
         IReadOnlyList<RemotingMessageView> messages,
+        RemotingPushConsumeContext context,
         CancellationToken cancellationToken)
     {
         foreach (var message in messages)
@@ -538,11 +539,20 @@ handler 调用收到的最大消息数，默认值为 1。并发分发只会将�
 整批消息请求 Broker 重新投递。它不能强制终止忽略取消信号的应用代码，因此 handler 必须响应该 token，并保持幂等。
 延迟返回的结果会被忽略，并可能与重新投递的调用重叠。FIFO 和顺序投递为保持顺序保证而不会应用此机制。
 
-返回 `Success` 会提交一批中的每条消息，返回 `Retry` 会为一批中的每条消息请求 Broker 重新投递，返回
-`DeadLetter` 会将一批中的每条消息发送到死信队列。运行时调用 `SubscribeAsync` 和 `UnsubscribeAsync` 会更新经典心跳和当前队列接收器。
-泛型注册会为当前客户端注册选择 handler 生命周期：`Singleton` 会为每个客户端注册中的每个角色创建一个 handler，
-且必须线程安全；`Scoped` 和 `Transient` 会在每次批量处理尝试中创建新的异步 DI scope，再从其中解析 handler。
-`MessageHandler` 委托使用相同的列表签名，仍适合简单的无状态回调，但不能与类型化 handler 同时配置。
+handler 还会收到 `RemotingPushConsumeContext`。默认返回 `Success` 会提交整个批次。对于并发、非 FIFO 批次，可将
+`context.AckIndex` 设为最后一条成功处理消息的从零开始索引，再返回 `Success`：客户端会提交这个连续前缀，并仅将其后的
+尾部消息交由 Broker 重试。`AckIndex` 默认是 `int.MaxValue`（全部消息），当尚未处理任何消息时可设为 `-1`。返回
+`Retry` 或 `DeadLetter` 时会忽略 `AckIndex`，并将结果应用到批次中的每条消息。
+
+`context.DelayLevelWhenNextConsume` 控制将要重试的消息。它初始为由 `RetryDelay` 映射得到的 Broker 延迟级别；可设为
+`0` 以让 Broker 选择重试策略，设为正的 RocketMQ 延迟级别以请求该级别，或设为负值以将这些消息直接发送到死信队列。
+广播模式没有 Broker 重试或死信流程，因此未确认的批次尾部会被跳过，同时推进本地位点。`MessageGroup` FIFO 与
+`ConsumeOrderly` 路径始终收到单消息列表，不使用部分批量确认。
+
+运行时调用 `SubscribeAsync` 和 `UnsubscribeAsync` 会更新经典心跳和当前队列接收器。泛型注册会为当前客户端注册选择
+handler 生命周期：`Singleton` 会为每个客户端注册中的每个角色创建一个 handler，且必须线程安全；`Scoped` 和
+`Transient` 会在每次批量处理尝试中创建新的异步 DI scope，再从其中解析 handler。`MessageHandler` 委托使用相同的
+列表和 context 签名，仍适合简单的无状态回调，但不能与类型化 handler 同时配置。
 
 ### 队列有序消费
 

--- a/src/EventHorizon.RocketMQ.Remoting/RemotingRocketMQBuilderExtensions.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/RemotingRocketMQBuilderExtensions.cs
@@ -248,11 +248,15 @@ public static class RemotingRocketMQBuilderExtensions
             .Validate(static value => !string.IsNullOrWhiteSpace(value.GroupName), "Consumer group name is required.")
             .Validate(static value => value.MaxConcurrency > 0, "Maximum concurrency must be positive.")
             .Validate(static value => value.BatchSize > 0, "Batch size must be positive.")
+            .Validate(
+                static value => value.ConsumeMessageBatchSize > 0,
+                "Consume message batch size must be positive.")
             .Validate(static value => value.MaxCachedMessages > 0, "Maximum cached message count must be positive.")
             .Validate(static value => value.MaxMessageBytes > 0, "Maximum pull response size must be positive.")
             .Validate(static value => value.MaxDeliveryAttempts > 0, "Maximum delivery attempts must be positive.")
             .Validate(static value => value.LongPollingTimeout > TimeSpan.Zero, "Long polling timeout must be positive.")
             .Validate(static value => value.RetryDelay > TimeSpan.Zero, "Retry delay must be positive.")
+            .Validate(static value => value.ConsumeTimeout > TimeSpan.Zero, "Consume timeout must be positive.")
             .Validate(static value => Enum.IsDefined(value.ConsumerMode), "Consumer mode is invalid.")
             .Validate(
                 static value => BroadcastOffsetStore.IsValidPath(value.LocalOffsetStorePath),
@@ -272,6 +276,9 @@ public static class RemotingRocketMQBuilderExtensions
         {
             options.Validate(static value => value.MessageHandler is not null, "A message handler is required.");
         }
+        options.Validate(
+            static value => value.ConsumeOrderly || value.MaxCachedMessages >= value.ConsumeMessageBatchSize,
+            "Maximum cached message count must be at least the consume message batch size.");
 
         RemotingRocketMQRegistration.AddRoleSingleton<IRemotingPushConsumer>(
             builder,

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
 [Collection(RocketMQMultiBrokerCollection.Name)]
+[Trait("Topology", "MultiBroker")]
 public sealed class RocketMQMultiBrokerIntegrationTests
 {
     private readonly RocketMQMultiBrokerGrpcContainerFixture _fixture;

--- a/tests/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
@@ -43,19 +43,22 @@ public sealed class GrpcPushConsumerTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCancellationRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var processingOrder = new ConcurrentQueue<string>();
         var client = new FakeGrpcClient();
         await using var consumer = CreateConsumer(
             client,
-            async (message, cancellationToken) =>
+            async (message, handlerCancellationToken) =>
             {
                 processingOrder.Enqueue(message.MessageId);
                 if (message.MessageId == "first")
                 {
+                    using var registration = handlerCancellationToken.Register(
+                        () => firstCancellationRequested.TrySetResult());
                     firstStarted.TrySetResult();
-                    await releaseFirst.Task.WaitAsync(cancellationToken);
+                    await releaseFirst.Task.WaitAsync(handlerCancellationToken);
                 }
                 else
                 {
@@ -65,7 +68,11 @@ public sealed class GrpcPushConsumerTests
                 return ConsumeResult.Success;
             },
             out var engine,
-            options => options.MaxConcurrency = 2);
+            options =>
+            {
+                options.MaxConcurrency = 2;
+                options.ConsumeTimeout = TimeSpan.FromMilliseconds(50);
+            });
 
         var channelField = typeof(GrpcPushConsumer).GetField("_messages", BindingFlags.Instance | BindingFlags.NonPublic);
         var processMethod = typeof(GrpcPushConsumer).GetMethod("ProcessMessagesAsync", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -85,6 +92,7 @@ public sealed class GrpcPushConsumerTests
 
         await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
         await Task.Delay(100, cancellationToken);
+        Assert.False(firstCancellationRequested.Task.IsCompleted);
         Assert.False(secondStarted.Task.IsCompleted);
         releaseFirst.TrySetResult();
         await Task.WhenAll(workers).WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
@@ -662,6 +670,81 @@ public sealed class GrpcPushConsumerTests
         Assert.Empty(client.ChangeInvisibleRequests);
         Assert.Empty(client.DeadLetterRequests);
         Assert.Equal(0, consumer.CachedMessageBytes);
+    }
+
+    [Fact]
+    public async Task ConcurrentMessageTimeout_CancelsHandlerRequestsRetryAndIgnoresLateSuccess()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerCancellationRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var operation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete(false, "timeout"));
+        operation.Setup(value => value.Dispose());
+        var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartProcess(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<ActivityContext?>()))
+            .Returns(operation.Object);
+        var client = new FakeGrpcClient();
+        await using var consumer = CreateConsumer(
+            client,
+            async (_, handlerCancellationToken) =>
+            {
+                handlerStarted.TrySetResult();
+                using var registration = handlerCancellationToken.Register(
+                    () => handlerCancellationRequested.TrySetResult());
+                using var failingRegistration = handlerCancellationToken.Register(
+                    static () => throw new InvalidOperationException("The test cancellation callback failed."));
+                await releaseHandler.Task.ConfigureAwait(false);
+                handlerFinished.TrySetResult();
+                return ConsumeResult.Success;
+            },
+            out var engine,
+            options =>
+            {
+                options.ConsumeTimeout = TimeSpan.FromMilliseconds(100);
+                options.RetryDelay = TimeSpan.FromSeconds(3);
+            },
+            telemetry: telemetry.Object);
+
+        var channelField = typeof(GrpcPushConsumer).GetField("_messages", BindingFlags.Instance | BindingFlags.NonPublic);
+        var processMethod = typeof(GrpcPushConsumer).GetMethod("ProcessMessagesAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        var channel = Assert.IsAssignableFrom<Channel<GrpcMessageView>>(channelField?.GetValue(consumer));
+        var worker = Assert.IsAssignableFrom<Task>(processMethod?.Invoke(consumer, [cancellationToken]));
+        var message = Message("timeout");
+        engine.BindMessage(message);
+        await channel.Writer.WriteAsync(message, cancellationToken);
+        channel.Writer.Complete();
+
+        try
+        {
+            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            await handlerCancellationRequested.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            await worker.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+            Assert.Empty(client.AckRequests);
+            var retry = Assert.Single(client.ChangeInvisibleRequests);
+            Assert.Equal(TimeSpan.FromSeconds(3), retry.InvisibleDuration.ToTimeSpan());
+        }
+        finally
+        {
+            releaseHandler.TrySetResult();
+        }
+
+        await handlerFinished.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        Assert.Empty(client.AckRequests);
+        operation.Verify(value => value.Complete(false, "timeout"), Times.Once);
+        operation.Verify(value => value.Dispose(), Times.Once);
+        telemetry.VerifyAll();
     }
 
     [Fact]

--- a/tests/EventHorizon.RocketMQ.Grpc.Tests/DependencyInjectionTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.Tests/DependencyInjectionTests.cs
@@ -15,6 +15,7 @@
 
 using System.Reflection;
 using EventHorizon.RocketMQ.Grpc.Consumer;
+using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using EventHorizon.RocketMQ.Grpc.Consumer.Simple;
 using EventHorizon.RocketMQ.Grpc.Instrumentation;
@@ -149,6 +150,48 @@ public sealed class DependencyInjectionTests
         Assert.IsType<GrpcPushConsumer>(consumer);
         Assert.IsType<GrpcPushConsumerHostedService>(hostedService);
         Assert.Same(consumer, provider.GetRequiredService<IGrpcPushConsumer>());
+    }
+
+    [Fact]
+    public void AddGrpcPushConsumer_RejectsNonPositiveConsumeTimeout()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQGrpc(options => options.Endpoint = "127.0.0.1:8081")
+            .AddGrpcPushConsumer(options =>
+            {
+                options.GroupName = "orders";
+                options.Subscribe("orders");
+                options.ConsumeTimeout = TimeSpan.Zero;
+                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+            });
+        using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IGrpcPushConsumer>());
+
+        Assert.Contains("Consume timeout", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddGrpcLitePushConsumer_RejectsNonPositiveConsumeTimeout()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQGrpc(options => options.Endpoint = "127.0.0.1:8081")
+            .AddGrpcLitePushConsumer(options =>
+            {
+                options.GroupName = "orders";
+                options.BindTopic = "orders";
+                options.ConsumeTimeout = TimeSpan.Zero;
+                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+            });
+        using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IGrpcLitePushConsumer>());
+
+        Assert.Contains("Consume timeout", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixture.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixture.cs
@@ -172,32 +172,6 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
         await _nameServer.StartAsync().ConfigureAwait(false);
         await _broker.StartAsync().ConfigureAwait(false);
 
-        ExecResult clusterList = default;
-        for (var attempt = 0; attempt < 60; attempt++)
-        {
-            clusterList = await _broker.ExecAsync([
-                "sh", "mqadmin", "clusterList", "-n", $"nameserver:{NameServerPort}"
-            ]).ConfigureAwait(false);
-            if (clusterList.ExitCode == 0 && clusterList.Stdout.Contains("broker-a", StringComparison.Ordinal))
-            {
-                break;
-            }
-
-            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
-        }
-
-        if (clusterList.ExitCode != 0 || !clusterList.Stdout.Contains("broker-a", StringComparison.Ordinal))
-        {
-            var actualConfiguration = await _broker.ExecAsync(["sh", "-c", "cat /tmp/broker.conf 2>&1"]).ConfigureAwait(false);
-            var environment = await _broker.ExecAsync(["sh", "-c", "echo $NAMESRV_ADDR"]).ConfigureAwait(false);
-            var logs = await _broker.ExecAsync([
-                "sh", "-c", "tail -n 80 /home/rocketmq/logs/rocketmqlogs/broker.log 2>&1"
-            ]).ConfigureAwait(false);
-            throw new InvalidOperationException(
-                $"Broker did not register with NameServer. clusterList: {clusterList.Stdout} " +
-                $"config: {actualConfiguration.Stdout} env: {environment.Stdout} logs: {logs.Stdout} {logs.Stderr}");
-        }
-
         await CreateTopicAsync(TestTopic, "NORMAL").ConfigureAwait(false);
         await CreateTopicAsync(TransactionTopic, "TRANSACTION").ConfigureAwait(false);
         await CreateTopicAsync(FifoTopic, "FIFO").ConfigureAwait(false);

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs
@@ -115,9 +115,10 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
     {
         await _network.CreateAsync().ConfigureAwait(false);
         await _nameServer.StartAsync().ConfigureAwait(false);
-        await _brokerA.StartAsync().ConfigureAwait(false);
-        await _brokerB.StartAsync().ConfigureAwait(false);
-        await _brokerC.StartAsync().ConfigureAwait(false);
+        await Task.WhenAll(
+            _brokerA.StartAsync(),
+            _brokerB.StartAsync(),
+            _brokerC.StartAsync()).ConfigureAwait(false);
 
         await WaitForClusterRegistrationAsync().ConfigureAwait(false);
         await CreateTopicAsync().ConfigureAwait(false);

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
@@ -102,9 +102,10 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
     {
         await _network.CreateAsync().ConfigureAwait(false);
         await _nameServer.StartAsync().ConfigureAwait(false);
-        await _brokerA.StartAsync().ConfigureAwait(false);
-        await _brokerB.StartAsync().ConfigureAwait(false);
-        await _brokerC.StartAsync().ConfigureAwait(false);
+        await Task.WhenAll(
+            _brokerA.StartAsync(),
+            _brokerB.StartAsync(),
+            _brokerC.StartAsync()).ConfigureAwait(false);
 
         await WaitForClusterRegistrationAsync().ConfigureAwait(false);
         await CreateTopicAsync().ConfigureAwait(false);

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
@@ -318,7 +318,7 @@ public sealed class RocketMQContainerTests
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
                 options.RetryDelay = TimeSpan.FromMilliseconds(100);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("legacy-push"));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
                     var body = Encoding.UTF8.GetString(message.Body);
@@ -407,7 +407,7 @@ public sealed class RocketMQContainerTests
                 options.ConsumeMessageBatchSize = messageCount;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var bodies = messages.Select(message => Encoding.UTF8.GetString(message.Body)).ToArray();
                     if (bodies.SequenceEqual(expectedBodies))
@@ -461,6 +461,131 @@ public sealed class RocketMQContainerTests
 
     [Fact]
     [Trait("Category", "Integration")]
+    public async Task LegacyPushConsumerAcknowledgesBatchPrefixAndRetriesRemainingMessages()
+    {
+        const int messageCount = 3;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var suffix = Guid.NewGuid().ToString("N");
+        var group = $"legacy-push-partial-ack-{suffix}";
+        var tag = $"legacy-push-partial-ack-{suffix}";
+        var expectedBodies = Enumerable.Range(0, messageCount)
+            .Select(index => $"{tag}-{index}")
+            .ToArray();
+        var expectedRetriedBodies = expectedBodies.Skip(1).ToHashSet(StringComparer.Ordinal);
+        var firstBatch = new TaskCompletionSource<(string[] Bodies, int DelayLevel)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var tailRedelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var redeliveredAttempts = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var handlerInvocations = 0;
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQRemoting(options =>
+            {
+                options.NamesrvAddr = _fixture.NameServerAddress;
+            })
+            .AddRemotingProducer(options => options.GroupName = $"legacy-push-partial-ack-producer-{suffix}")
+            .AddRemotingPushConsumer(options =>
+            {
+                options.GroupName = group;
+                options.InitialPosition = ConsumeFromPosition.Beginning;
+                options.BatchSize = messageCount;
+                options.ConsumeMessageBatchSize = messageCount;
+                options.MaxConcurrency = 1;
+                options.MaxCachedMessages = messageCount;
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+                options.RetryDelay = TimeSpan.FromSeconds(1);
+                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.MessageHandler = (messages, context, _) =>
+                {
+                    var deliveries = messages
+                        .Select(message => (Body: Encoding.UTF8.GetString(message.Body), message.DeliveryAttempt))
+                        .ToArray();
+                    if (Interlocked.Increment(ref handlerInvocations) == 1)
+                    {
+                        firstBatch.TrySetResult((deliveries.Select(static delivery => delivery.Body).ToArray(), context.DelayLevelWhenNextConsume));
+                        context.AckIndex = 0;
+                    }
+                    else
+                    {
+                        foreach (var delivery in deliveries)
+                        {
+                            redeliveredAttempts.AddOrUpdate(
+                                delivery.Body,
+                                delivery.DeliveryAttempt,
+                                (_, currentAttempt) => Math.Max(currentAttempt, delivery.DeliveryAttempt));
+                        }
+
+                        if (expectedRetriedBodies.All(body =>
+                                redeliveredAttempts.TryGetValue(body, out var attempt) && attempt >= 2))
+                        {
+                            tailRedelivered.TrySetResult();
+                        }
+                    }
+
+                    return ValueTask.FromResult(ConsumeResult.Success);
+                };
+            });
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IRemotingProducer>();
+        var consumer = provider.GetRequiredService<IRemotingPushConsumer>();
+        await producer.StartAsync(cancellationToken);
+        try
+        {
+            var queue = (await producer.GetPublishMessageQueuesAsync(
+                RocketMQContainerFixture.TestTopic,
+                cancellationToken)).First();
+            var sent = await producer.SendAsync(
+                expectedBodies.Select(body => new Message(
+                    RocketMQContainerFixture.TestTopic,
+                    Encoding.UTF8.GetBytes(body))
+                {
+                    Tag = tag
+                }).ToArray(),
+                queue,
+                cancellationToken);
+            Assert.Equal(RemotingSendStatus.SendOk, sent.Status);
+
+            await consumer.StartAsync(cancellationToken);
+            var initialDelivery = await firstBatch.Task.WaitAsync(TimeSpan.FromSeconds(20), cancellationToken);
+            Assert.Equal(expectedBodies, initialDelivery.Bodies);
+            Assert.Equal(1, initialDelivery.DelayLevel);
+
+            await tailRedelivered.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            var retryTopic = $"%RETRY%{group}";
+            var retryCommit = await _fixture.WaitForConsumerCommitAsync(
+                group,
+                retryTopic,
+                queue.BrokerName,
+                0,
+                TimeSpan.FromSeconds(10),
+                cancellationToken);
+            Assert.True(retryCommit.Committed, $"Legacy push retry offset was not committed. {retryCommit.Progress}");
+            Assert.All(
+                expectedRetriedBodies,
+                body => Assert.True(
+                    redeliveredAttempts.TryGetValue(body, out var attempt) && attempt >= 2,
+                    $"Message '{body}' was not redelivered from the retry topic."));
+            Assert.DoesNotContain(expectedBodies[0], redeliveredAttempts.Keys);
+
+            var commit = await _fixture.WaitForConsumerCommitAsync(
+                group,
+                RocketMQContainerFixture.TestTopic,
+                queue.BrokerName,
+                queue.QueueId,
+                TimeSpan.FromSeconds(10),
+                cancellationToken);
+            Assert.True(commit.Committed, $"Legacy push partial acknowledgement offset was not committed. {commit.Progress}");
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
     public async Task LegacyOrderlyPushConsumerWaitsForBrokerQueueLock()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -487,7 +612,7 @@ public sealed class RocketMQContainerTests
                 options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == expected)
@@ -635,7 +760,7 @@ public sealed class RocketMQContainerTests
                     options.MaxConcurrency = 4;
                     options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                     options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                    options.MessageHandler = (messages, _) =>
+                    options.MessageHandler = (messages, _, _) =>
                     {
                         foreach (var message in messages)
                         {
@@ -733,7 +858,7 @@ public sealed class RocketMQContainerTests
                 options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == expectedBody)
@@ -815,7 +940,7 @@ public sealed class RocketMQContainerTests
                     options.InitialPosition = ConsumeFromPosition.Beginning;
                     options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                     options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                    options.MessageHandler = (messages, _) =>
+                    options.MessageHandler = (messages, _, _) =>
                     {
                         var message = Assert.Single(messages);
                         if (Encoding.UTF8.GetString(message.Body) == expectedBody)

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
@@ -318,8 +318,9 @@ public sealed class RocketMQContainerTests
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
                 options.RetryDelay = TimeSpan.FromMilliseconds(100);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("legacy-push"));
-                options.MessageHandler = (message, _) =>
+                options.MessageHandler = (messages, _) =>
                 {
+                    var message = Assert.Single(messages);
                     var body = Encoding.UTF8.GetString(message.Body);
                     if (body == expected && Interlocked.Increment(ref handlerCalls) == 1)
                     {
@@ -380,6 +381,86 @@ public sealed class RocketMQContainerTests
 
     [Fact]
     [Trait("Category", "Integration")]
+    public async Task LegacyPushConsumerDispatchesConfiguredMessageBatch()
+    {
+        const int messageCount = 3;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var suffix = Guid.NewGuid().ToString("N");
+        var group = $"legacy-push-batch-{suffix}";
+        var tag = $"legacy-push-batch-{suffix}";
+        var expectedBodies = Enumerable.Range(0, messageCount)
+            .Select(index => $"{tag}-{index}")
+            .ToArray();
+        var consumed = new TaskCompletionSource<string[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQRemoting(options =>
+            {
+                options.NamesrvAddr = _fixture.NameServerAddress;
+            })
+            .AddRemotingProducer(options => options.GroupName = $"legacy-push-batch-producer-{suffix}")
+            .AddRemotingPushConsumer(options =>
+            {
+                options.GroupName = group;
+                options.InitialPosition = ConsumeFromPosition.Beginning;
+                options.BatchSize = messageCount;
+                options.ConsumeMessageBatchSize = messageCount;
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.MessageHandler = (messages, _) =>
+                {
+                    var bodies = messages.Select(message => Encoding.UTF8.GetString(message.Body)).ToArray();
+                    if (bodies.SequenceEqual(expectedBodies))
+                    {
+                        consumed.TrySetResult(bodies);
+                    }
+
+                    return ValueTask.FromResult(ConsumeResult.Success);
+                };
+            });
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IRemotingProducer>();
+        var consumer = provider.GetRequiredService<IRemotingPushConsumer>();
+        await producer.StartAsync(cancellationToken);
+        try
+        {
+            var queue = (await producer.GetPublishMessageQueuesAsync(
+                RocketMQContainerFixture.TestTopic,
+                cancellationToken)).First();
+            var sent = await producer.SendAsync(
+                expectedBodies.Select(body => new Message(
+                RocketMQContainerFixture.TestTopic,
+                Encoding.UTF8.GetBytes(body))
+                {
+                    Tag = tag
+                }).ToArray(),
+                queue,
+                cancellationToken);
+            Assert.Equal(RemotingSendStatus.SendOk, sent.Status);
+
+            await consumer.StartAsync(cancellationToken);
+            var actualBodies = await consumed.Task.WaitAsync(TimeSpan.FromSeconds(20), cancellationToken);
+            Assert.Equal(expectedBodies, actualBodies);
+
+            var commit = await _fixture.WaitForConsumerCommitAsync(
+                group,
+                RocketMQContainerFixture.TestTopic,
+                queue.BrokerName,
+                queue.QueueId,
+                TimeSpan.FromSeconds(10),
+                cancellationToken);
+            Assert.True(commit.Committed, $"Legacy push batch offset was not committed. {commit.Progress}");
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
     public async Task LegacyOrderlyPushConsumerWaitsForBrokerQueueLock()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -406,8 +487,9 @@ public sealed class RocketMQContainerTests
                 options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = (message, _) =>
+                options.MessageHandler = (messages, _) =>
                 {
+                    var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == expected)
                     {
                         delivered.TrySetResult();
@@ -553,16 +635,19 @@ public sealed class RocketMQContainerTests
                     options.MaxConcurrency = 4;
                     options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                     options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                    options.MessageHandler = (message, _) =>
+                    options.MessageHandler = (messages, _) =>
                     {
-                        var body = Encoding.UTF8.GetString(message.Body);
-                        if (expectedBodies.Contains(body))
+                        foreach (var message in messages)
                         {
-                            onDelivery();
-                            deliveries.AddOrUpdate(body, 1, static (_, count) => count + 1);
-                            if (deliveries.Count == messageCount)
+                            var body = Encoding.UTF8.GetString(message.Body);
+                            if (expectedBodies.Contains(body))
                             {
-                                allConsumed.TrySetResult();
+                                onDelivery();
+                                deliveries.AddOrUpdate(body, 1, static (_, count) => count + 1);
+                                if (deliveries.Count == messageCount)
+                                {
+                                    allConsumed.TrySetResult();
+                                }
                             }
                         }
 
@@ -648,8 +733,9 @@ public sealed class RocketMQContainerTests
                 options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = (message, _) =>
+                options.MessageHandler = (messages, _) =>
                 {
+                    var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == expectedBody)
                     {
                         consumed.TrySetResult();
@@ -729,8 +815,9 @@ public sealed class RocketMQContainerTests
                     options.InitialPosition = ConsumeFromPosition.Beginning;
                     options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                     options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                    options.MessageHandler = (message, _) =>
+                    options.MessageHandler = (messages, _) =>
                     {
+                        var message = Assert.Single(messages);
                         if (Encoding.UTF8.GetString(message.Body) == expectedBody)
                         {
                             completion.TrySetResult();

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -54,7 +54,7 @@ public sealed class RocketMQMessageTypesIntegrationTests
                 options.GroupName = "remoting-delay-consumer-it";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.DelayTopic, new FilterExpression(tag));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == body)

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -54,8 +54,9 @@ public sealed class RocketMQMessageTypesIntegrationTests
                 options.GroupName = "remoting-delay-consumer-it";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.DelayTopic, new FilterExpression(tag));
-                options.MessageHandler = (message, _) =>
+                options.MessageHandler = (messages, _) =>
                 {
+                    var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == body)
                     {
                         received.TrySetResult();

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
@@ -22,6 +22,7 @@ using Xunit;
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
 [Collection(RocketMQMultiBrokerCollection.Name)]
+[Trait("Topology", "MultiBroker")]
 public sealed class RocketMQMultiBrokerIntegrationTests
 {
     private readonly RocketMQMultiBrokerRemotingContainerFixture _fixture;

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
@@ -56,8 +56,9 @@ public sealed class RocketMQRequestReplyIntegrationTests
                 options.GroupName = $"request-reply-consumer-{suffix}";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = async (message, token) =>
+                options.MessageHandler = async (messages, token) =>
                 {
+                    var message = Assert.Single(messages);
                     if (!string.Equals(Encoding.UTF8.GetString(message.Body), requestBody, StringComparison.Ordinal))
                     {
                         return ConsumeResult.Success;

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
@@ -56,7 +56,7 @@ public sealed class RocketMQRequestReplyIntegrationTests
                 options.GroupName = $"request-reply-consumer-{suffix}";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = async (messages, token) =>
+                options.MessageHandler = async (messages, _, token) =>
                 {
                     var message = Assert.Single(messages);
                     if (!string.Equals(Encoding.UTF8.GetString(message.Body), requestBody, StringComparison.Ordinal))

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
@@ -46,8 +46,9 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
                 options.GroupName = "remoting-trace-propagation-consumer-it";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = (message, _) =>
+                options.MessageHandler = (messages, _) =>
                 {
+                    var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == body)
                     {
                         received.TrySetResult(new TraceObservation(

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
@@ -46,7 +46,7 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
                 options.GroupName = "remoting-trace-propagation-consumer-it";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
                     if (Encoding.UTF8.GetString(message.Body) == body)

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
@@ -63,7 +63,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests
                 options.GroupName = $"remoting-transaction-consumer-{suffix}";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TransactionTopic, new FilterExpression(tag));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
                     if (string.Equals(Encoding.UTF8.GetString(message.Body), body, StringComparison.Ordinal))
@@ -120,7 +120,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests
                 options.GroupName = $"remoting-recall-consumer-{suffix}";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.DelayTopic, new FilterExpression(tag));
-                options.MessageHandler = (messages, _) =>
+                options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
                     if (string.Equals(Encoding.UTF8.GetString(message.Body), body, StringComparison.Ordinal))

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
@@ -63,8 +63,9 @@ public sealed class RocketMQTransactionRecallIntegrationTests
                 options.GroupName = $"remoting-transaction-consumer-{suffix}";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.TransactionTopic, new FilterExpression(tag));
-                options.MessageHandler = (message, _) =>
+                options.MessageHandler = (messages, _) =>
                 {
+                    var message = Assert.Single(messages);
                     if (string.Equals(Encoding.UTF8.GetString(message.Body), body, StringComparison.Ordinal))
                     {
                         received.TrySetResult(message.MessageId);
@@ -119,8 +120,9 @@ public sealed class RocketMQTransactionRecallIntegrationTests
                 options.GroupName = $"remoting-recall-consumer-{suffix}";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(RocketMQContainerFixture.DelayTopic, new FilterExpression(tag));
-                options.MessageHandler = (message, _) =>
+                options.MessageHandler = (messages, _) =>
                 {
+                    var message = Assert.Single(messages);
                     if (string.Equals(Encoding.UTF8.GetString(message.Body), body, StringComparison.Ordinal))
                     {
                         delivered.TrySetResult(message.MessageId);

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumeContextTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumeContextTests.cs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using EventHorizon.RocketMQ.Remoting.Consumer.Push;
+using Xunit;
+
+namespace EventHorizon.RocketMQ.Remoting.Tests.Consumer.Push;
+
+public sealed class RemotingPushConsumeContextTests
+{
+    [Fact]
+    public void AckIndex_DefaultsToAcknowledgingTheCompleteBatch()
+    {
+        var context = new RemotingPushConsumeContext();
+
+        Assert.Equal(int.MaxValue, context.AckIndex);
+    }
+
+    [Fact]
+    public void AckIndex_AllowsNoAcknowledgedMessages()
+    {
+        var context = new RemotingPushConsumeContext
+        {
+            AckIndex = -1
+        };
+
+        Assert.Equal(-1, context.AckIndex);
+    }
+
+    [Theory]
+    [InlineData(-2)]
+    [InlineData(int.MinValue)]
+    public void AckIndex_RejectsValuesBelowMinusOne(int value)
+    {
+        var context = new RemotingPushConsumeContext();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => context.AckIndex = value);
+
+        Assert.Equal("value", exception.ParamName);
+    }
+}

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
@@ -128,7 +128,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         var consumer = CreateRemotingPushConsumer(
@@ -194,7 +194,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         var consumer = CreateRemotingPushConsumer(
@@ -279,7 +279,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -353,7 +353,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -432,7 +432,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -524,7 +524,7 @@ public sealed class RemotingPushConsumerTests
         };
         var options = CreateBroadcastOptions(
             offsetPath,
-            static (_, _) => ValueTask.FromResult(ConsumeResult.Success));
+            static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success));
         options.MaxConcurrency = 1;
         options.RetryDelay = TimeSpan.FromMilliseconds(20);
         var consumer = CreateRemotingPushConsumer(
@@ -616,7 +616,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders", new FilterExpression("created || paid"));
         var clientOptions = new RemotingClientOptions
@@ -702,7 +702,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -754,7 +754,7 @@ public sealed class RemotingPushConsumerTests
             var remoting = new FakeRemotingClient("127.0.0.1@broadcast-test");
             var routeTopics = new ConcurrentQueue<string>();
             var routes = CreateRouteServiceMock(3, routeTopics);
-            var options = CreateBroadcastOptions(offsetPath, static (_, _) =>
+            var options = CreateBroadcastOptions(offsetPath, static (_, _, _) =>
                 ValueTask.FromResult(ConsumeResult.Success));
             await using var consumer = CreateRemotingPushConsumer(options, routes.Object, remoting, "broadcast-test");
 
@@ -806,7 +806,7 @@ public sealed class RemotingPushConsumerTests
                     throw new InvalidOperationException("An infinite pull completed unexpectedly.");
                 }
             };
-            var firstOptions = CreateBroadcastOptions(offsetPath, static (_, _) =>
+            var firstOptions = CreateBroadcastOptions(offsetPath, static (_, _, _) =>
                 ValueTask.FromResult(ConsumeResult.Retry));
             await using (var first = CreateRemotingPushConsumer(
                              firstOptions,
@@ -824,7 +824,7 @@ public sealed class RemotingPushConsumerTests
                 RequestCode.UpdateConsumerOffset or RequestCode.ConsumerSendMsgBack);
 
             var secondRemoting = new FakeRemotingClient("127.0.0.1@broadcast-test");
-            var secondOptions = CreateBroadcastOptions(offsetPath, static (_, _) =>
+            var secondOptions = CreateBroadcastOptions(offsetPath, static (_, _, _) =>
                 ValueTask.FromResult(ConsumeResult.Success));
             await using (var second = CreateRemotingPushConsumer(
                              secondOptions,
@@ -878,7 +878,7 @@ public sealed class RemotingPushConsumerTests
         };
         var options = CreateBroadcastOptions(
             offsetPath,
-            async (_, token) =>
+            async (_, _, token) =>
             {
                 handlerStarted.TrySetResult();
                 using var registration = token.Register(() => handlerCancellationRequested.TrySetResult());
@@ -970,7 +970,7 @@ public sealed class RemotingPushConsumerTests
         };
         var options = CreateBroadcastOptions(
             offsetPath,
-            (_, _) => ValueTask.FromResult(result));
+            (_, _, _) => ValueTask.FromResult(result));
         try
         {
             await using var consumer = CreateRemotingPushConsumer(
@@ -1013,7 +1013,7 @@ public sealed class RemotingPushConsumerTests
                 MaxConcurrency = 1,
                 MaxCachedMessages = 8,
                 LongPollingTimeout = TimeSpan.FromSeconds(1),
-                MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+                MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
             };
             var remoting = new FakeRemotingClient("127.0.0.1@dynamic-test");
             await using var consumer = CreateRemotingPushConsumer(
@@ -1203,7 +1203,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = (messages, _) =>
+            MessageHandler = (messages, _, _) =>
             {
                 var message = Assert.Single(messages);
                 if (message.MessageId == "retry-after-crash")
@@ -1248,7 +1248,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         var clientOptions = new RemotingClientOptions
@@ -1314,7 +1314,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 5,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = (messages, _) =>
+            MessageHandler = (messages, _, _) =>
             {
                 batches.Enqueue(messages.Select(static message => message.MessageId).ToArray());
                 if (batches.Count == 3)
@@ -1383,7 +1383,11 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 2,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Retry)
+            MessageHandler = static (_, context, _) =>
+            {
+                context.AckIndex = 0;
+                return ValueTask.FromResult(ConsumeResult.Retry);
+            }
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -1399,6 +1403,138 @@ public sealed class RemotingPushConsumerTests
         Assert.Equal(
             2,
             remoting.Requests.Count(static request => request.Code == RequestCode.ConsumerSendMsgBack));
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_AcknowledgesBatchPrefixAndRetriesRemainingMessages()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "one", null, 0, 1_000)
+            .Concat(CreateMessageRecord("orders", "two", null, 1, 1_001))
+            .Concat(CreateMessageRecord("orders", "three", null, 2, 1_002))
+            .ToArray();
+        var remoting = new FakeRemotingClient("127.0.0.1@batch-partial-ack")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 3);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 3,
+            ConsumeMessageBatchSize = 3,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 3,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = (messages, context, _) =>
+            {
+                Assert.Equal(["one", "two", "three"], messages.Select(static message => message.MessageId));
+                context.AckIndex = 0;
+                context.DelayLevelWhenNextConsume = 7;
+                return ValueTask.FromResult(ConsumeResult.Success);
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "batch-partial-ack");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 2, cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update => update.Topic == "orders" && update.Offset == 3))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        await consumer.StopAsync(cancellationToken);
+
+        var sendBackRequests = remoting.Requests
+            .Where(static request => request.Code == RequestCode.ConsumerSendMsgBack)
+            .ToArray();
+        Assert.Equal(2, sendBackRequests.Length);
+        Assert.Equal(
+            [1_001L, 1_002L],
+            sendBackRequests.Select(static request => Convert.ToInt64(request.ExtFields["offset"])).Order());
+        Assert.All(
+            sendBackRequests,
+            static request => Assert.Equal(7, Convert.ToInt32(request.ExtFields["delayLevel"])));
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_RecordsPartialBatchAcknowledgementAsPartialSuccessTelemetry()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var processCompleted = new TaskCompletionSource<(bool Success, string? Outcome)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processOperation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        processOperation
+            .Setup(value => value.Complete(false, "partial_success"))
+            .Callback(() => processCompleted.TrySetResult((false, "partial_success")));
+        processOperation.Setup(value => value.Dispose());
+        var telemetry = new ProcessTelemetry(processOperation.Object);
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "one", null, 0, 1_000)
+            .Concat(CreateMessageRecord("orders", "two", null, 1, 1_001))
+            .ToArray();
+        var remoting = new FakeRemotingClient("127.0.0.1@batch-partial-telemetry")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 2);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 2,
+            ConsumeMessageBatchSize = 2,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 2,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, context, _) =>
+            {
+                context.AckIndex = 0;
+                return ValueTask.FromResult(ConsumeResult.Success);
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "batch-partial-telemetry",
+            telemetry);
+
+        await consumer.StartAsync(cancellationToken);
+        var outcome = await processCompleted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 1, cancellationToken);
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.False(outcome.Success);
+        Assert.Equal("partial_success", outcome.Outcome);
+        Assert.Equal(1, telemetry.ProcessBatchCalls);
+        processOperation.VerifyAll();
     }
 
     [Fact]
@@ -1453,7 +1589,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = queueCount,
             MaxCachedMessages = messagesPerBatch,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = (messages, _) =>
+            MessageHandler = (messages, _, _) =>
             {
                 Assert.Equal(messagesPerBatch, messages.Count);
                 handledBatches.Enqueue(messages.Select(static message => message.MessageId).ToArray());
@@ -1525,7 +1661,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 2,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (messages, token) =>
+            MessageHandler = async (messages, _, token) =>
             {
                 var message = Assert.Single(messages);
                 if (message.MessageId == "first")
@@ -1608,7 +1744,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 1,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (_, _) =>
+            MessageHandler = async (_, _, _) =>
             {
                 handlerStarted.TrySetResult();
                 await releaseHandler.Task;
@@ -1676,12 +1812,14 @@ public sealed class RemotingPushConsumerTests
             BatchSize = 2,
             ConsumeMessageBatchSize = 2,
             ConsumeTimeout = TimeSpan.FromMilliseconds(50),
+            RetryDelay = TimeSpan.FromSeconds(5),
             MaxConcurrency = 1,
             MaxCachedMessages = 2,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (messages, _) =>
+            MessageHandler = async (messages, context, _) =>
             {
                 Assert.Equal(2, messages.Count);
+                context.DelayLevelWhenNextConsume = -1;
                 handlerStarted.TrySetResult();
                 await releaseHandler.Task;
                 handlerFinished.TrySetResult();
@@ -1710,6 +1848,9 @@ public sealed class RemotingPushConsumerTests
         Assert.Equal(
             2,
             remoting.Requests.Count(static request => request.Code == RequestCode.ConsumerSendMsgBack));
+        Assert.All(
+            remoting.Requests.Where(static request => request.Code == RequestCode.ConsumerSendMsgBack),
+            static request => Assert.Equal(2, Convert.ToInt32(request.ExtFields["delayLevel"])));
     }
 
     [Fact]
@@ -1749,7 +1890,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 3,
             MaxCachedMessages = 5,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (_, token) =>
+            MessageHandler = async (_, _, token) =>
             {
                 if (Interlocked.Increment(ref handlerCalls) == 3)
                 {
@@ -1785,7 +1926,7 @@ public sealed class RemotingPushConsumerTests
     }
 
     [Fact]
-    public async Task FifoRetryKeepsSameGroupSuccessorBlockedUntilPredecessorSucceeds()
+    public async Task FifoRetryKeepsSameGroupSuccessorBlockedUntilPredecessorSucceedsAndIgnoresBatchAcknowledgementContext()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var firstSecondAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1821,7 +1962,7 @@ public sealed class RemotingPushConsumerTests
             MaxDeliveryAttempts = 3,
             RetryDelay = TimeSpan.FromMilliseconds(10),
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (messages, token) =>
+            MessageHandler = async (messages, context, token) =>
             {
                 var message = Assert.Single(messages);
                 if (message.MessageId == "first")
@@ -1834,6 +1975,7 @@ public sealed class RemotingPushConsumerTests
                     firstSecondAttempt.TrySetResult();
                     using var registration = token.Register(() => firstCancellationRequested.TrySetResult());
                     await releaseFirst.Task.WaitAsync(token);
+                    context.AckIndex = -1;
                     return ConsumeResult.Success;
                 }
 
@@ -1883,7 +2025,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 2,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -1952,7 +2094,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -2020,7 +2162,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
         };
         options.Subscribe("orders");
         await using var consumer = CreateRemotingPushConsumer(
@@ -2079,7 +2221,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 2,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (messages, token) =>
+            MessageHandler = async (messages, _, token) =>
             {
                 var message = Assert.Single(messages);
                 if (message.MessageId == "first")
@@ -2122,6 +2264,64 @@ public sealed class RemotingPushConsumerTests
     }
 
     [Fact]
+    public async Task OrderlyConsumer_IgnoresBatchAcknowledgementContext()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var handled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "order", null, 0, 1_000);
+        var remoting = new FakeRemotingClient("127.0.0.1@orderly-context")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            ConsumeOrderly = true,
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            MaxDeliveryAttempts = 1,
+            RetryDelay = TimeSpan.FromMilliseconds(1),
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = (messages, context, _) =>
+            {
+                Assert.Single(messages);
+                context.AckIndex = -1;
+                handled.TrySetResult();
+                return ValueTask.FromResult(ConsumeResult.Success);
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "orderly-context");
+
+        await consumer.StartAsync(cancellationToken);
+        await handled.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update => update.Topic == "orders" && update.Offset == 1))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.DoesNotContain(remoting.Requests, static request => request.Code == RequestCode.ConsumerSendMsgBack);
+    }
+
+    [Fact]
     public async Task OrderlyConsumer_ReleasesQueueLockAfterUnsubscribeDrainsHandler()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -2151,7 +2351,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (_, _) =>
+            MessageHandler = async (_, _, _) =>
             {
                 firstStarted.TrySetResult();
                 await releaseFirst.Task;
@@ -2375,7 +2575,7 @@ public sealed class RemotingPushConsumerTests
 
     private static RemotingPushConsumerOptions CreateBroadcastOptions(
         string offsetPath,
-        Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>> handler)
+        Func<IReadOnlyList<RemotingMessageView>, RemotingPushConsumeContext, CancellationToken, ValueTask<ConsumeResult>> handler)
     {
         var options = new RemotingPushConsumerOptions
         {
@@ -2398,7 +2598,7 @@ public sealed class RemotingPushConsumerTests
         MaxConcurrency = 2,
         MaxCachedMessages = 8,
         LongPollingTimeout = TimeSpan.FromSeconds(1),
-        MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success)
+        MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
     };
 
     private static RemotingPushConsumer CreateRemotingPushConsumer(

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
@@ -850,6 +850,70 @@ public sealed class RemotingPushConsumerTests
         }
     }
 
+    [Fact]
+    public async Task BroadcastingConsumer_DoesNotApplyConsumeTimeout()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var offsetPath = System.IO.Path.Combine(
+            System.IO.Path.GetTempPath(),
+            $"rocketmq-broadcast-timeout-{Guid.NewGuid():N}.json");
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerCancellationRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivered = 0;
+        var remoting = new FakeRemotingClient("127.0.0.1@broadcast-timeout")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(CreateMessageRecord("orders", "broadcast", null, 0, 1_000), 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = CreateBroadcastOptions(
+            offsetPath,
+            async (_, token) =>
+            {
+                handlerStarted.TrySetResult();
+                using var registration = token.Register(() => handlerCancellationRequested.TrySetResult());
+                await releaseHandler.Task.WaitAsync(token);
+                handlerFinished.TrySetResult();
+                return ConsumeResult.Success;
+            });
+        options.ConsumeTimeout = TimeSpan.FromMilliseconds(50);
+        options.MaxConcurrency = 1;
+        options.MaxCachedMessages = 1;
+        try
+        {
+            await using var consumer = CreateRemotingPushConsumer(
+                options,
+                CreateRouteServiceMock().Object,
+                remoting,
+                "broadcast-timeout");
+
+            await consumer.StartAsync(cancellationToken);
+            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            await Task.Delay(100, cancellationToken);
+            Assert.False(handlerCancellationRequested.Task.IsCompleted);
+
+            releaseHandler.TrySetResult();
+            await handlerFinished.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            await consumer.StopAsync(cancellationToken);
+
+            Assert.DoesNotContain(remoting.Requests, static request => request.Code == RequestCode.ConsumerSendMsgBack);
+        }
+        finally
+        {
+            File.Delete(offsetPath);
+        }
+    }
+
     [Theory]
     [InlineData(ConsumeResult.Retry)]
     [InlineData(ConsumeResult.DeadLetter)]
@@ -884,14 +948,10 @@ public sealed class RemotingPushConsumerTests
                 It.IsAny<IEnumerable<IReadOnlyDictionary<string, string>>?>()))
             .Returns(receiveOperation.Object);
         telemetry
-            .Setup(value => value.StartProcess(
+            .Setup(value => value.StartProcessBatch(
                 It.IsAny<string>(),
                 It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<int>(),
-                It.IsAny<long>(),
-                It.IsAny<IReadOnlyDictionary<string, string>>(),
-                It.IsAny<ActivityContext?>()))
+                It.Is<IReadOnlyList<RemotingMessageView>>(messages => messages.Count == 1)))
             .Returns(processOperation.Object);
         var delivered = 0;
         var remoting = new FakeRemotingClient("127.0.0.1@telemetry-test")
@@ -1143,8 +1203,9 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = (message, _) =>
+            MessageHandler = (messages, _) =>
             {
+                var message = Assert.Single(messages);
                 if (message.MessageId == "retry-after-crash")
                 {
                     retryDelivered.TrySetResult();
@@ -1218,10 +1279,517 @@ public sealed class RemotingPushConsumerTests
     }
 
     [Fact]
+    public async Task ConcurrentPushConsumer_DispatchesMessagesInConfiguredBatches()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var batches = new ConcurrentQueue<string[]>();
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "one", null, 0, 1_000)
+            .Concat(CreateMessageRecord("orders", "two", null, 1, 1_001))
+            .Concat(CreateMessageRecord("orders", "three", null, 2, 1_002))
+            .Concat(CreateMessageRecord("orders", "four", null, 3, 1_003))
+            .Concat(CreateMessageRecord("orders", "five", null, 4, 1_004))
+            .ToArray();
+        var remoting = new FakeRemotingClient("127.0.0.1@batch-dispatch")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 5);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 5,
+            ConsumeMessageBatchSize = 2,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 5,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = (messages, _) =>
+            {
+                batches.Enqueue(messages.Select(static message => message.MessageId).ToArray());
+                if (batches.Count == 3)
+                {
+                    completed.TrySetResult();
+                }
+
+                return ValueTask.FromResult(ConsumeResult.Success);
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "batch-dispatch");
+
+        await consumer.StartAsync(cancellationToken);
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update => update.Topic == "orders" && update.Offset == 5))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.Collection(
+            batches.ToArray(),
+            batch => Assert.Equal(["one", "two"], batch),
+            batch => Assert.Equal(["three", "four"], batch),
+            batch => Assert.Equal(["five"], batch));
+        var pull = remoting.Requests.First(request =>
+            request.Code == RequestCode.PullMessage &&
+            string.Equals(request.ExtFields["topic"] as string, "orders", StringComparison.Ordinal));
+        Assert.Equal(5, Convert.ToInt32(pull.ExtFields["maxMsgNums"]));
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_BatchRetrySendsEveryMessageBack()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "one", null, 0, 1_000)
+            .Concat(CreateMessageRecord("orders", "two", null, 1, 1_001))
+            .ToArray();
+        var remoting = new FakeRemotingClient("127.0.0.1@batch-retry")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 2);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 2,
+            ConsumeMessageBatchSize = 2,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 2,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Retry)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "batch-retry");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 2, cancellationToken);
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.Equal(
+            2,
+            remoting.Requests.Count(static request => request.Code == RequestCode.ConsumerSendMsgBack));
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_AdmitsFullBatchesFromMultipleQueuesWhenCacheMatchesOneBatch()
+    {
+        const int queueCount = 4;
+        const int messagesPerBatch = 2;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var readyPulls = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePulls = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allBatchesHandled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deliveredQueues = new ConcurrentDictionary<int, byte>();
+        var handledBatches = new ConcurrentQueue<string[]>();
+        var waitingPulls = 0;
+        var handledBatchCount = 0;
+        var remoting = new FakeRemotingClient("127.0.0.1@batch-admission")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (!string.Equals(request.ExtFields["topic"] as string, "orders", StringComparison.Ordinal))
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+                }
+
+                var queueId = Convert.ToInt32(request.ExtFields["queueId"]);
+                if (!deliveredQueues.TryAdd(queueId, 0))
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+                }
+
+                if (Interlocked.Increment(ref waitingPulls) == queueCount)
+                {
+                    readyPulls.TrySetResult();
+                }
+
+                await releasePulls.Task.WaitAsync(token);
+                return PullSuccess(
+                    CreateMessageRecord("orders", $"queue-{queueId}-first", null, 0, 1_000 + queueId)
+                        .Concat(CreateMessageRecord("orders", $"queue-{queueId}-second", null, 1, 2_000 + queueId))
+                        .ToArray(),
+                    messagesPerBatch);
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = messagesPerBatch,
+            ConsumeMessageBatchSize = messagesPerBatch,
+            MaxConcurrency = queueCount,
+            MaxCachedMessages = messagesPerBatch,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = (messages, _) =>
+            {
+                Assert.Equal(messagesPerBatch, messages.Count);
+                handledBatches.Enqueue(messages.Select(static message => message.MessageId).ToArray());
+                if (Interlocked.Increment(ref handledBatchCount) == queueCount)
+                {
+                    allBatchesHandled.TrySetResult();
+                }
+
+                return ValueTask.FromResult(ConsumeResult.Success);
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock(queueCount).Object,
+            remoting,
+            "batch-admission");
+
+        await consumer.StartAsync(cancellationToken);
+        await readyPulls.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        releasePulls.TrySetResult();
+        await allBatchesHandled.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.Equal(queueCount, deliveredQueues.Count);
+        Assert.Equal(
+            Enumerable.Range(0, queueCount).Select(static queueId => $"queue-{queueId}-first").Order(),
+            handledBatches.Select(static batch => batch[0]).Order());
+        Assert.All(
+            handledBatches,
+            batch =>
+            {
+                var prefix = batch[0][..^"-first".Length];
+                Assert.Equal(new[] { $"{prefix}-first", $"{prefix}-second" }, batch);
+            });
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_CancelsTimedOutHandlerAndContinuesWithQueuedMessages()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var firstHandlerCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondHandled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "first", null, 0, 1_000)
+            .Concat(CreateMessageRecord("orders", "second", null, 1, 1_001))
+            .ToArray();
+        var remoting = new FakeRemotingClient("127.0.0.1@consume-timeout")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 2);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 2,
+            ConsumeMessageBatchSize = 1,
+            ConsumeTimeout = TimeSpan.FromMilliseconds(50),
+            MaxConcurrency = 1,
+            MaxCachedMessages = 2,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = async (messages, token) =>
+            {
+                var message = Assert.Single(messages);
+                if (message.MessageId == "first")
+                {
+                    using var failingRegistration = token.Register(
+                        static () => throw new InvalidOperationException("The test cancellation callback failed."));
+                    try
+                    {
+                        await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    }
+                    catch (OperationCanceledException) when (token.IsCancellationRequested)
+                    {
+                        firstHandlerCanceled.TrySetResult();
+                        throw;
+                    }
+                }
+
+                secondHandled.TrySetResult();
+                return ConsumeResult.Success;
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "consume-timeout");
+
+        await consumer.StartAsync(cancellationToken);
+        await firstHandlerCanceled.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await secondHandled.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 1, cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update => update.Topic == "orders" && update.Offset == 2))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.Single(remoting.Requests, static request => request.Code == RequestCode.ConsumerSendMsgBack);
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_RetriesTimedOutHandlerThatDoesNotHonorCancellation()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processCompleted = new TaskCompletionSource<(bool Success, string? Outcome)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processOperation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        processOperation
+            .Setup(value => value.Complete(false, "timeout"))
+            .Callback(() => processCompleted.TrySetResult((false, "timeout")));
+        processOperation.Setup(value => value.Dispose());
+        var telemetry = new ProcessTelemetry(processOperation.Object);
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "stuck", null, 0, 1_000);
+        var remoting = new FakeRemotingClient("127.0.0.1@consume-timeout-uncooperative")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 1,
+            ConsumeTimeout = TimeSpan.FromMilliseconds(50),
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = async (_, _) =>
+            {
+                handlerStarted.TrySetResult();
+                await releaseHandler.Task;
+                handlerFinished.TrySetResult();
+                return ConsumeResult.Success;
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "consume-timeout-uncooperative",
+            telemetry);
+
+        await consumer.StartAsync(cancellationToken);
+        await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        var processOutcome = await processCompleted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        Assert.False(processOutcome.Success);
+        Assert.Equal("timeout", processOutcome.Outcome);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 1, cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update => update.Topic == "orders" && update.Offset == 1))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        await consumer.StopAsync(cancellationToken).AsTask().WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        releaseHandler.TrySetResult();
+        await handlerFinished.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+        Assert.Single(remoting.Requests, static request => request.Code == RequestCode.ConsumerSendMsgBack);
+        Assert.Equal(1, telemetry.ProcessBatchCalls);
+        processOperation.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_RetriesEveryMessageInTimedOutBatch()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "first", null, 0, 1_000)
+            .Concat(CreateMessageRecord("orders", "second", null, 1, 1_001))
+            .ToArray();
+        var remoting = new FakeRemotingClient("127.0.0.1@consume-timeout-batch")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 2);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 2,
+            ConsumeMessageBatchSize = 2,
+            ConsumeTimeout = TimeSpan.FromMilliseconds(50),
+            MaxConcurrency = 1,
+            MaxCachedMessages = 2,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = async (messages, _) =>
+            {
+                Assert.Equal(2, messages.Count);
+                handlerStarted.TrySetResult();
+                await releaseHandler.Task;
+                handlerFinished.TrySetResult();
+                return ConsumeResult.Success;
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "consume-timeout-batch");
+
+        await consumer.StartAsync(cancellationToken);
+        await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 2, cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update => update.Topic == "orders" && update.Offset == 2))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        await consumer.StopAsync(cancellationToken).AsTask().WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        releaseHandler.TrySetResult();
+        await handlerFinished.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+        Assert.Equal(
+            2,
+            remoting.Requests.Count(static request => request.Code == RequestCode.ConsumerSendMsgBack));
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_WaitsForEveryBatchBeforeCommittingOffset()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var allBatchesStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseBatches = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var delivered = 0;
+        var handlerCalls = 0;
+        var body = CreateMessageRecord("orders", "one", null, 0, 1_000)
+            .Concat(CreateMessageRecord("orders", "two", null, 1, 1_001))
+            .Concat(CreateMessageRecord("orders", "three", null, 2, 1_002))
+            .Concat(CreateMessageRecord("orders", "four", null, 3, 1_003))
+            .Concat(CreateMessageRecord("orders", "five", null, 4, 1_004))
+            .ToArray();
+        var remoting = new FakeRemotingClient("127.0.0.1@batch-completion")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 5);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            BatchSize = 5,
+            ConsumeMessageBatchSize = 2,
+            MaxConcurrency = 3,
+            MaxCachedMessages = 5,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = async (_, token) =>
+            {
+                if (Interlocked.Increment(ref handlerCalls) == 3)
+                {
+                    allBatchesStarted.TrySetResult();
+                }
+
+                await releaseBatches.Task.WaitAsync(token);
+                return ConsumeResult.Success;
+            }
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "batch-completion");
+
+        await consumer.StartAsync(cancellationToken);
+        await allBatchesStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        Assert.DoesNotContain(
+            remoting.UpdatedOffsets,
+            static update => update.Topic == "orders" && update.Offset == 5);
+
+        releaseBatches.TrySetResult();
+        while (!remoting.UpdatedOffsets.Any(static update => update.Topic == "orders" && update.Offset == 5))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.Equal(3, handlerCalls);
+    }
+
+    [Fact]
     public async Task FifoRetryKeepsSameGroupSuccessorBlockedUntilPredecessorSucceeds()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var firstSecondAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCancellationRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var secondHandled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var firstCalls = 0;
@@ -1246,13 +1814,16 @@ public sealed class RemotingPushConsumerTests
         var options = new RemotingPushConsumerOptions
         {
             GroupName = "legacy-group",
+            ConsumeMessageBatchSize = 2,
+            ConsumeTimeout = TimeSpan.FromMilliseconds(50),
             MaxConcurrency = 2,
             MaxCachedMessages = 8,
             MaxDeliveryAttempts = 3,
             RetryDelay = TimeSpan.FromMilliseconds(10),
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (message, token) =>
+            MessageHandler = async (messages, token) =>
             {
+                var message = Assert.Single(messages);
                 if (message.MessageId == "first")
                 {
                     if (Interlocked.Increment(ref firstCalls) == 1)
@@ -1261,6 +1832,7 @@ public sealed class RemotingPushConsumerTests
                     }
 
                     firstSecondAttempt.TrySetResult();
+                    using var registration = token.Register(() => firstCancellationRequested.TrySetResult());
                     await releaseFirst.Task.WaitAsync(token);
                     return ConsumeResult.Success;
                 }
@@ -1287,6 +1859,7 @@ public sealed class RemotingPushConsumerTests
         await consumer.StartAsync(cancellationToken);
         await firstSecondAttempt.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
         await Task.Delay(100, cancellationToken);
+        Assert.False(firstCancellationRequested.Task.IsCompleted);
         Assert.False(secondHandled.Task.IsCompleted);
 
         releaseFirst.TrySetResult();
@@ -1476,6 +2049,7 @@ public sealed class RemotingPushConsumerTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCancellationRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var delivered = 0;
@@ -1501,14 +2075,17 @@ public sealed class RemotingPushConsumerTests
             GroupName = "legacy-group",
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
+            ConsumeTimeout = TimeSpan.FromMilliseconds(50),
             MaxConcurrency = 2,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (message, token) =>
+            MessageHandler = async (messages, token) =>
             {
+                var message = Assert.Single(messages);
                 if (message.MessageId == "first")
                 {
                     firstStarted.TrySetResult();
+                    using var registration = token.Register(() => firstCancellationRequested.TrySetResult());
                     await releaseFirst.Task.WaitAsync(token);
                 }
                 else
@@ -1529,6 +2106,7 @@ public sealed class RemotingPushConsumerTests
         await consumer.StartAsync(cancellationToken);
         await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
         await Task.Delay(100, cancellationToken);
+        Assert.False(firstCancellationRequested.Task.IsCompleted);
         Assert.False(secondStarted.Task.IsCompleted);
 
         releaseFirst.TrySetResult();
@@ -1573,7 +2151,7 @@ public sealed class RemotingPushConsumerTests
             MaxConcurrency = 1,
             MaxCachedMessages = 8,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
-            MessageHandler = async (message, _) =>
+            MessageHandler = async (_, _) =>
             {
                 firstStarted.TrySetResult();
                 await releaseFirst.Task;
@@ -1797,7 +2375,7 @@ public sealed class RemotingPushConsumerTests
 
     private static RemotingPushConsumerOptions CreateBroadcastOptions(
         string offsetPath,
-        Func<RemotingMessageView, CancellationToken, ValueTask<ConsumeResult>> handler)
+        Func<IReadOnlyList<RemotingMessageView>, CancellationToken, ValueTask<ConsumeResult>> handler)
     {
         var options = new RemotingPushConsumerOptions
         {
@@ -1912,6 +2490,60 @@ public sealed class RemotingPushConsumerTests
                 return Task.FromResult(Route(queueCount));
             });
         return routes;
+    }
+
+    private sealed class ProcessTelemetry(IRemotingRocketMQTelemetryOperation processOperation) : IRemotingRocketMQTelemetry
+    {
+        private int _processBatchCalls;
+
+        public int ProcessBatchCalls => Volatile.Read(ref _processBatchCalls);
+
+        public IRemotingRocketMQTelemetryOperation StartSend(string topic, int messageCount, long bodySize) =>
+            RemotingRocketMQTelemetry.Operation.Disabled;
+
+        public IRemotingRocketMQTelemetryOperation StartReceive(
+            string topic,
+            string consumerGroup,
+            int messageCount,
+            ActivityContext? parentContext,
+            DateTimeOffset startTime,
+            long startTimestamp,
+            int? queueId = null,
+            bool createActivity = true,
+            IEnumerable<IReadOnlyDictionary<string, string>>? messageProperties = null) =>
+            RemotingRocketMQTelemetry.Operation.Disabled;
+
+        public IRemotingRocketMQTelemetryOperation StartProcess(
+            string topic,
+            string consumerGroup,
+            string messageId,
+            int queueId,
+            long bodySize,
+            IReadOnlyDictionary<string, string> properties,
+            ActivityContext? receiveContext) =>
+            RemotingRocketMQTelemetry.Operation.Disabled;
+
+        public IRemotingRocketMQTelemetryOperation StartProcessBatch(
+            string topic,
+            string consumerGroup,
+            IReadOnlyList<RemotingMessageView> messages)
+        {
+            Interlocked.Increment(ref _processBatchCalls);
+            return processOperation;
+        }
+
+        public IRemotingRocketMQTelemetryOperation StartSettle(
+            string operationName,
+            string topic,
+            string consumerGroup,
+            string? messageId,
+            int? queueId,
+            IReadOnlyDictionary<string, string>? properties) =>
+            RemotingRocketMQTelemetry.Operation.Disabled;
+
+        public void InjectContext(Activity? activity, IDictionary<string, string> properties)
+        {
+        }
     }
 
     private sealed class FakeRemotingClient(string clientId) : IRemotingClient, IRemotingRequestHandlerRegistry

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushMessageHandlerFactoryTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushMessageHandlerFactoryTests.cs
@@ -48,10 +48,16 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
             Assert.Equal(
                 ConsumeResult.Success,
-                await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
+                await handleAsync(
+                    new[] { CreateMessage() },
+                    new RemotingPushConsumeContext(),
+                    TestContext.Current.CancellationToken));
             Assert.Equal(
                 ConsumeResult.Success,
-                await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
+                await handleAsync(
+                    new[] { CreateMessage() },
+                    new RemotingPushConsumeContext(),
+                    TestContext.Current.CancellationToken));
 
             Assert.Equal(expectedCreatedCount, tracker.Created.Count);
             Assert.Equal(expectedDisposedBeforeProviderDisposal, tracker.Disposed.Count);
@@ -91,7 +97,10 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
         Assert.Equal(
             ConsumeResult.Success,
-            await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
+            await handleAsync(
+                new[] { CreateMessage() },
+                new RemotingPushConsumeContext(),
+                TestContext.Current.CancellationToken));
         Assert.Single(tracker.Created);
         Assert.Single(tracker.Handled);
         Assert.Single(tracker.Disposed);
@@ -162,7 +171,10 @@ public sealed class RemotingPushMessageHandlerFactoryTests
         Assert.Empty(tracker.Created);
         Assert.Equal(
             ConsumeResult.Success,
-            await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
+            await handleAsync(
+                new[] { CreateMessage() },
+                new RemotingPushConsumeContext(),
+                TestContext.Current.CancellationToken));
         var dependency = Assert.Single(tracker.Created);
         Assert.Same(dependency, Assert.Single(tracker.Injected));
         Assert.Same(dependency, Assert.Single(tracker.Handled));
@@ -180,7 +192,7 @@ public sealed class RemotingPushMessageHandlerFactoryTests
                 options =>
                 {
                     ConfigurePushConsumer(options);
-                    options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+                    options.MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success);
                 });
         await using var provider = services.BuildServiceProvider();
 
@@ -263,6 +275,7 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
         public ValueTask<ConsumeResult> HandleAsync(
             IReadOnlyList<RemotingMessageView> messages,
+            RemotingPushConsumeContext context,
             CancellationToken cancellationToken)
         {
             _tracker.Handled.Add(this);
@@ -287,6 +300,7 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
         public ValueTask<ConsumeResult> HandleAsync(
             IReadOnlyList<RemotingMessageView> messages,
+            RemotingPushConsumeContext context,
             CancellationToken cancellationToken) =>
             ValueTask.FromResult(ConsumeResult.Success);
     }
@@ -300,6 +314,7 @@ public sealed class RemotingPushMessageHandlerFactoryTests
     {
         public ValueTask<ConsumeResult> HandleAsync(
             IReadOnlyList<RemotingMessageView> messages,
+            RemotingPushConsumeContext context,
             CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(dependency);
@@ -321,6 +336,7 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
         public ValueTask<ConsumeResult> HandleAsync(
             IReadOnlyList<RemotingMessageView> messages,
+            RemotingPushConsumeContext context,
             CancellationToken cancellationToken)
         {
             _tracker.Handled.Add(_dependency);

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushMessageHandlerFactoryTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushMessageHandlerFactoryTests.cs
@@ -46,8 +46,12 @@ public sealed class RemotingPushMessageHandlerFactoryTests
         {
             var handleAsync = RemotingPushMessageHandlerFactory.Create(provider, roleKey, lifetime);
 
-            Assert.Equal(ConsumeResult.Success, await handleAsync(CreateMessage(), TestContext.Current.CancellationToken));
-            Assert.Equal(ConsumeResult.Success, await handleAsync(CreateMessage(), TestContext.Current.CancellationToken));
+            Assert.Equal(
+                ConsumeResult.Success,
+                await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
+            Assert.Equal(
+                ConsumeResult.Success,
+                await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
 
             Assert.Equal(expectedCreatedCount, tracker.Created.Count);
             Assert.Equal(expectedDisposedBeforeProviderDisposal, tracker.Disposed.Count);
@@ -85,7 +89,9 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
         var handleAsync = RemotingPushMessageHandlerFactory.Create(provider, roleKey, ServiceLifetime.Transient);
 
-        Assert.Equal(ConsumeResult.Success, await handleAsync(CreateMessage(), TestContext.Current.CancellationToken));
+        Assert.Equal(
+            ConsumeResult.Success,
+            await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
         Assert.Single(tracker.Created);
         Assert.Single(tracker.Handled);
         Assert.Single(tracker.Disposed);
@@ -154,7 +160,9 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
         Assert.IsType<RemotingPushConsumer>(consumer);
         Assert.Empty(tracker.Created);
-        Assert.Equal(ConsumeResult.Success, await handleAsync(CreateMessage(), TestContext.Current.CancellationToken));
+        Assert.Equal(
+            ConsumeResult.Success,
+            await handleAsync(new[] { CreateMessage() }, TestContext.Current.CancellationToken));
         var dependency = Assert.Single(tracker.Created);
         Assert.Same(dependency, Assert.Single(tracker.Injected));
         Assert.Same(dependency, Assert.Single(tracker.Handled));
@@ -253,7 +261,9 @@ public sealed class RemotingPushMessageHandlerFactoryTests
             _tracker.Created.Add(this);
         }
 
-        public ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken)
+        public ValueTask<ConsumeResult> HandleAsync(
+            IReadOnlyList<RemotingMessageView> messages,
+            CancellationToken cancellationToken)
         {
             _tracker.Handled.Add(this);
             return ValueTask.FromResult(ConsumeResult.Success);
@@ -275,7 +285,9 @@ public sealed class RemotingPushMessageHandlerFactoryTests
             tracker.Logger = logger;
         }
 
-        public ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken) =>
+        public ValueTask<ConsumeResult> HandleAsync(
+            IReadOnlyList<RemotingMessageView> messages,
+            CancellationToken cancellationToken) =>
             ValueTask.FromResult(ConsumeResult.Success);
     }
 
@@ -286,7 +298,9 @@ public sealed class RemotingPushMessageHandlerFactoryTests
 
     private sealed class SingletonHandlerWithScopedDependency(ScopedDependency dependency) : IRemotingPushMessageHandler
     {
-        public ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken)
+        public ValueTask<ConsumeResult> HandleAsync(
+            IReadOnlyList<RemotingMessageView> messages,
+            CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(dependency);
             return ValueTask.FromResult(ConsumeResult.Success);
@@ -305,7 +319,9 @@ public sealed class RemotingPushMessageHandlerFactoryTests
             _tracker.Injected.Add(_dependency);
         }
 
-        public ValueTask<ConsumeResult> HandleAsync(RemotingMessageView message, CancellationToken cancellationToken)
+        public ValueTask<ConsumeResult> HandleAsync(
+            IReadOnlyList<RemotingMessageView> messages,
+            CancellationToken cancellationToken)
         {
             _tracker.Handled.Add(_dependency);
             return ValueTask.FromResult(ConsumeResult.Success);

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/DependencyInjectionTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/DependencyInjectionTests.cs
@@ -241,7 +241,7 @@ public sealed class DependencyInjectionTests
             {
                 options.GroupName = "orders";
                 options.Subscribe("orders");
-                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+                options.MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success);
             });
         await using var provider = services.BuildServiceProvider();
 
@@ -326,7 +326,7 @@ public sealed class DependencyInjectionTests
                 options.GroupName = "orders";
                 options.InitialPosition = ConsumeFromPosition.Timestamp;
                 options.Subscribe("orders");
-                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+                options.MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success);
             });
 
         await using var provider = services.BuildServiceProvider();
@@ -350,7 +350,7 @@ public sealed class DependencyInjectionTests
                 options.GroupName = "orders";
                 options.ConsumeTimeout = TimeSpan.Zero;
                 options.Subscribe("orders");
-                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+                options.MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success);
             });
 
         await using var provider = services.BuildServiceProvider();
@@ -374,7 +374,7 @@ public sealed class DependencyInjectionTests
                 options.GroupName = "orders";
                 options.InitialPosition = (ConsumeFromPosition)int.MaxValue;
                 options.Subscribe("orders");
-                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+                options.MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success);
             });
 
         await using var provider = services.BuildServiceProvider();
@@ -398,7 +398,7 @@ public sealed class DependencyInjectionTests
                 options.GroupName = "orders";
                 options.ConsumerMode = (ConsumerMode)int.MaxValue;
                 options.Subscribe("orders");
-                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+                options.MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success);
             });
 
         await using var provider = services.BuildServiceProvider();
@@ -423,7 +423,7 @@ public sealed class DependencyInjectionTests
                 options.ConsumerMode = ConsumerMode.Broadcasting;
                 options.LocalOffsetStorePath = "invalid\0path";
                 options.Subscribe("orders");
-                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+                options.MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success);
             });
 
         await using var provider = services.BuildServiceProvider();

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/DependencyInjectionTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/DependencyInjectionTests.cs
@@ -337,6 +337,30 @@ public sealed class DependencyInjectionTests
     }
 
     [Fact]
+    public async Task AddRemotingPushConsumer_RejectsNonPositiveConsumeTimeout()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQRemoting(options =>
+            {
+                options.NamesrvAddr = "127.0.0.1:9876";
+            })
+            .AddRemotingPushConsumer(options =>
+            {
+                options.GroupName = "orders";
+                options.ConsumeTimeout = TimeSpan.Zero;
+                options.Subscribe("orders");
+                options.MessageHandler = static (_, _) => ValueTask.FromResult(ConsumeResult.Success);
+            });
+
+        await using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            provider.GetRequiredService<IRemotingPushConsumer>);
+        Assert.Contains("consume timeout", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task AddRemotingPushConsumer_RejectsUnknownInitialPosition()
     {
         var services = new ServiceCollection();

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Instrumentation/RemotingRocketMQTelemetryTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Instrumentation/RemotingRocketMQTelemetryTests.cs
@@ -15,6 +15,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using EventHorizon.RocketMQ.Remoting.Consumer;
 using EventHorizon.RocketMQ.Remoting.Instrumentation;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
@@ -240,6 +241,95 @@ public sealed class RemotingRocketMQTelemetryTests
     }
 
     [Fact]
+    public void StartProcessBatch_UsesReceiveContextAndLinksEveryProducerContext()
+    {
+        using var listener = CreateActivityListener();
+        using var provider = CreateServiceProvider();
+        var telemetry = CreateTelemetry(provider);
+        var receiveContext = new ActivityContext(
+            ActivityTraceId.CreateRandom(),
+            ActivitySpanId.CreateRandom(),
+            ActivityTraceFlags.Recorded);
+        var firstTraceId = ActivityTraceId.CreateRandom();
+        var firstSpanId = ActivitySpanId.CreateRandom();
+        var secondTraceId = ActivityTraceId.CreateRandom();
+        var secondSpanId = ActivitySpanId.CreateRandom();
+        var messages = new[]
+        {
+            CreateMessage(
+                "message-1",
+                [1, 2],
+                new Dictionary<string, string>
+                {
+                    ["traceparent"] = $"00-{firstTraceId}-{firstSpanId}-01"
+                },
+                receiveContext),
+            CreateMessage(
+                "message-2",
+                [3, 4, 5],
+                new Dictionary<string, string>
+                {
+                    ["traceparent"] = $"00-{secondTraceId}-{secondSpanId}-01"
+                },
+                receiveContext)
+        };
+
+        using var process = telemetry.StartProcessBatch("orders", "orders-consumer", messages);
+        var processActivity = Assert.IsType<Activity>(process.Activity);
+        process.Complete();
+
+        var links = processActivity.Links.ToArray();
+        Assert.Equal(receiveContext.TraceId, processActivity.TraceId);
+        Assert.Equal(receiveContext.SpanId, processActivity.ParentSpanId);
+        Assert.Equal(2, processActivity.GetTagItem("messaging.batch.message_count"));
+        Assert.Equal(5L, processActivity.GetTagItem("messaging.message.body.size"));
+        Assert.Equal(2, links.Length);
+        Assert.Equal(firstTraceId, links[0].Context.TraceId);
+        Assert.Equal(secondTraceId, links[1].Context.TraceId);
+    }
+
+    [Fact]
+    public void StartProcessBatch_UsesProducerContextAsParentWithoutReceiveContext()
+    {
+        using var listener = CreateActivityListener();
+        using var provider = CreateServiceProvider();
+        var telemetry = CreateTelemetry(provider);
+        var firstTraceId = ActivityTraceId.CreateRandom();
+        var firstSpanId = ActivitySpanId.CreateRandom();
+        var secondTraceId = ActivityTraceId.CreateRandom();
+        var secondSpanId = ActivitySpanId.CreateRandom();
+        var messages = new[]
+        {
+            CreateMessage(
+                "message-1",
+                [1, 2],
+                new Dictionary<string, string>
+                {
+                    ["traceparent"] = $"00-{firstTraceId}-{firstSpanId}-01"
+                },
+                default),
+            CreateMessage(
+                "message-2",
+                [3, 4],
+                new Dictionary<string, string>
+                {
+                    ["traceparent"] = $"00-{secondTraceId}-{secondSpanId}-01"
+                },
+                default)
+        };
+
+        using var process = telemetry.StartProcessBatch("orders", "orders-consumer", messages);
+        var processActivity = Assert.IsType<Activity>(process.Activity);
+        process.Complete();
+
+        var link = Assert.Single(processActivity.Links);
+        Assert.Equal(firstTraceId, processActivity.TraceId);
+        Assert.Equal(firstSpanId, processActivity.ParentSpanId);
+        Assert.Equal(secondTraceId, link.Context.TraceId);
+        Assert.Equal(secondSpanId, link.Context.SpanId);
+    }
+
+    [Fact]
     public void Complete_RecordsMetricsForFailedOperation()
     {
         var measurements = new List<(string InstrumentName, long Value, KeyValuePair<string, object?>[] Tags)>();
@@ -314,6 +404,34 @@ public sealed class RemotingRocketMQTelemetryTests
 
     private static RemotingRocketMQTelemetry CreateTelemetry(ServiceProvider provider) =>
         new(provider.GetRequiredService<IMeterFactory>());
+
+    private static RemotingMessageView CreateMessage(
+        string messageId,
+        byte[] body,
+        IReadOnlyDictionary<string, string> properties,
+        ActivityContext receiveActivityContext)
+    {
+        var message = new RemotingMessageView(
+            "orders",
+            body,
+            messageId,
+            $"offset-{messageId}",
+            null,
+            [],
+            properties,
+            1,
+            null,
+            3,
+            "broker-a",
+            0,
+            0,
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch)
+        {
+            ReceiveActivityContext = receiveActivityContext
+        };
+        return message;
+    }
 
     private static ActivityListener CreateActivityListener()
     {

--- a/tests/EventHorizon.RocketMQ.Remoting.Tests/Instrumentation/RemotingRocketMQTelemetryTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.Tests/Instrumentation/RemotingRocketMQTelemetryTests.cs
@@ -330,6 +330,29 @@ public sealed class RemotingRocketMQTelemetryTests
     }
 
     [Fact]
+    public void StartProcessBatch_PreservesMessageIdForSingleMessage()
+    {
+        using var listener = CreateActivityListener();
+        using var provider = CreateServiceProvider();
+        var telemetry = CreateTelemetry(provider);
+        var messages = new[]
+        {
+            CreateMessage(
+                "message-1",
+                [1, 2],
+                new Dictionary<string, string>(),
+                default)
+        };
+
+        using var process = telemetry.StartProcessBatch("orders", "orders-consumer", messages);
+        var processActivity = Assert.IsType<Activity>(process.Activity);
+        process.Complete();
+
+        Assert.Equal("message-1", processActivity.GetTagItem("messaging.message.id"));
+        Assert.Equal(1, processActivity.GetTagItem("messaging.batch.message_count"));
+    }
+
+    [Fact]
     public void Complete_RecordsMetricsForFailedOperation()
     {
         var measurements = new List<(string InstrumentName, long Value, KeyValuePair<string, object?>[] Tags)>();


### PR DESCRIPTION
## Summary

- add batch dispatch and partial prefix acknowledgement through RemotingPushConsumeContext
- preserve FIFO and orderly semantics; timeout recovery retries the full batch independently of handler acknowledgement state
- add unit and Docker integration coverage for partial acknowledgement and retry behavior
- update Remoting, sample, architecture, and testing documentation in English and Chinese

## Validation

- dotnet format EventHorizon.RocketMQ.sln --no-restore --verify-no-changes
- dotnet build EventHorizon.RocketMQ.sln --no-restore
- gRPC unit tests: 168 passed
- Remoting unit tests: 325 passed
- compatibility tests: 20 passed
- Remoting Docker integration tests: 18 passed