### PR TITLE
perf: parallelize isolated integration tests

### DIFF
--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -56,9 +56,18 @@ that would be less clear with a mock.
 
 [`RocketMQContainerFixture`](../../../tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixture.cs)
 creates an isolated Docker network, starts an Apache RocketMQ 5.5.0 NameServer and Broker, then
-starts a cluster-mode Proxy after the Broker registers. It creates the normal, FIFO, delayed,
-transactional, and Lite topic resources used by integration tests and prepares the required
-consumer groups.
+starts a cluster-mode Proxy after the Broker registers. A lazy xUnit v3 assembly-fixture registry
+owns one baseline fixture per integration-test assembly, so independent test classes can share the
+same Docker stack without serializing the whole project. The runner permits up to four parallel test
+collections; a filtered multi-Broker job does not initialize the baseline fixture.
+
+Each ordinary test scope receives a unique normal topic and consumer group. The fixture explicitly
+creates the topic before use because gRPC route lookup requires an existing route, while the Broker
+auto-creates ordinary subscription groups. Transactional, FIFO, delayed, and Lite topics remain
+preconfigured because their Broker semantics require that configuration; their tests use unique
+groups and message identifiers. The legacy Remoting container suite deliberately retains its
+dedicated topic and serial method execution because its cases exercise shared admin and offset
+semantics.
 
 The fixture obtains host ports dynamically, so parallel or repeated test runs are not tied to the
 manual Compose ports. The protocol-specific test projects are:
@@ -96,11 +105,12 @@ GitHub Actions runs the Docker-backed gRPC and Remoting integration-test project
 single-Broker and one multi-Broker job for each protocol. A class-level `Topology=MultiBroker` trait
 selects the multi-Broker tests; the single-Broker jobs run the complementary set. Each job restores
 and builds only its protocol-specific integration-test dependency graph, has its own timeout budget,
-and reuses the repository's NuGet package cache. Testcontainers still starts isolated Broker,
-NameServer, and Proxy fixtures for every job. All four jobs collect Cobertura reports and upload them
-to Codecov with distinct upload names under the shared `integration-tests` flag. Codecov combines
-those reports with the `unit-tests` reports; the repository configuration continues to exclude
-`samples` from coverage.
+and reuses the repository's NuGet package cache. Within a single-Broker job, isolated test classes
+run concurrently up to the runner limit; the legacy Remoting suite remains serial by design.
+Testcontainers still starts isolated Broker, NameServer, and Proxy fixtures for every job. All four
+jobs collect Cobertura reports and upload them to Codecov with distinct upload names under the shared
+`integration-tests` flag. Codecov combines those reports with the `unit-tests` reports; the repository
+configuration continues to exclude `samples` from coverage.
 
 ### Manual Compose environment
 

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -61,8 +61,16 @@ test 项目，而不是在 unit test 中偷偷连接本地 `localhost`。
             └── gRPC Proxy 端口
 ```
 
-基础 fixture 创建隔离 Docker network，等待 NameServer 与 Broker 就绪，确认 Broker 已注册，然后准备标准、事务、
-FIFO、延迟和 Lite parent topic 以及测试 group。
+基础 fixture 创建隔离 Docker network，等待 NameServer 与 Broker 就绪，确认 Broker 已注册。每个 integration-test
+assembly 通过惰性的 xUnit v3 assembly-fixture registry 共享一套基础容器，因此独立测试类可以复用 Docker stack，
+而不必让整个项目串行。runner 最多并行四个 test collection；被筛选出的 multi-Broker job 不会初始化这套基础
+fixture。
+
+普通测试 scope 会生成唯一的 normal topic 和 consumer group。fixture 会在使用前显式创建 topic，因为 gRPC 的
+route lookup 需要已有 route；普通 subscription group 则由 Broker 自动创建。事务、FIFO、延迟和 Lite topic 因为
+依赖相应的 Broker 语义而保持预配置，测试通过唯一 group 和 message identifier 隔离。保留的 legacy Remoting
+container suite 刻意继续使用专用 topic，且类内方法串行执行，因为这些 case 验证的是共享的 Admin 与 offset
+语义。
 
 端口由 Testcontainers 动态映射，测试不会依赖手工环境的固定端口。
 
@@ -123,9 +131,10 @@ GitHub Actions 在格式化、构建和单元测试验证通过后，于四个�
 驱动的 gRPC 与 Remoting integration test：每个协议各有一个 single-Broker 与一个 multi-Broker job。类级别
 的 `Topology=MultiBroker` trait 选择 multi-Broker 测试；single-Broker job 运行其余测试。每个 job 只 restore
 和 build 对应协议的 integration-test 依赖图，使用独立超时预算，并复用仓库的 NuGet 包缓存。Testcontainers
-仍会在每个 job 内独立启动隔离的 Broker、NameServer 与 Proxy fixture。四个 job 都会生成 Cobertura 报告，
-以不同的上传名称归入共享的 `integration-tests` flag；Codecov 会将其与 `unit-tests` 报告合并。仓库配置仍会
-排除 `samples`，不会将 sample 计入覆盖率。
+仍会在每个 job 内独立启动隔离的 Broker、NameServer 与 Proxy fixture。single-Broker job 内，已经隔离的测试类
+会在 runner 上限内并发执行；legacy Remoting suite 则按设计保持串行。四个 job 都会生成 Cobertura 报告，以不同
+的上传名称归入共享的 `integration-tests` flag；Codecov 会将其与 `unit-tests` 报告合并。仓库配置仍会排除
+`samples`，不会将 sample 计入覆盖率。
 
 ### 5. 测试范围也体现支持边界
 

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/AssemblyInfo.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/AssemblyInfo.cs
@@ -16,10 +16,4 @@
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 using Xunit;
 
-namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
-
-[CollectionDefinition(Name, DisableParallelization = true)]
-public sealed class RocketMQCollection : ICollectionFixture<RocketMQContainerFixture>
-{
-    public const string Name = "RocketMQ Remoting integration";
-}
+[assembly: AssemblyFixture(typeof(RocketMQContainerFixtureRegistry))]

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
@@ -27,4 +27,10 @@
         <ProjectReference Include="../EventHorizon.RocketMQ.IntegrationTestInfrastructure/EventHorizon.RocketMQ.IntegrationTestInfrastructure.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Update="xunit.runner.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
 </Project>

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQContainerTests.cs
@@ -25,30 +25,26 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQContainerTests
+public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry registry)
 {
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQContainerTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
 
     [Fact]
     [Trait("Category", "Integration")]
     public async Task GrpcProducerAndSimpleConsumerRoundTrip()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("grpc-simple-consumer");
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
             .AddGrpcProducer()
             .AddGrpcSimpleConsumer(options =>
             {
-                options.GroupName = "grpc-simple-consumer-it";
+                options.GroupName = consumerGroup;
                 options.AwaitDuration = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("grpc-simple"));
+                options.Subscribe(scope.Topic, new FilterExpression("grpc-simple"));
             });
 
         await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
@@ -60,7 +56,7 @@ public sealed class RocketMQContainerTests
         {
             var body = $"grpc-simple-{Guid.NewGuid():N}";
             var receipt = await producer.SendAsync(new Message(
-                RocketMQContainerFixture.TestTopic,
+                scope.Topic,
                 Encoding.UTF8.GetBytes(body))
             {
                 Tag = "grpc-simple"
@@ -94,20 +90,23 @@ public sealed class RocketMQContainerTests
     public async Task GrpcTransactionCommitMakesMessageVisible()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Transaction, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("grpc-transaction-consumer");
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
             .AddGrpcProducer(options =>
             {
-                options.Topics.Add(RocketMQContainerFixture.TransactionTopic);
+                options.Topics.Add(scope.Topic);
                 options.TransactionChecker = static (_, _) =>
                     ValueTask.FromResult(TransactionResolution.Unknown);
             })
             .AddGrpcSimpleConsumer(options =>
             {
-                options.GroupName = "grpc-transaction-consumer-it";
+                options.GroupName = consumerGroup;
                 options.AwaitDuration = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TransactionTopic, new FilterExpression("transaction"));
+                options.Subscribe(scope.Topic, new FilterExpression("transaction"));
             });
 
         await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
@@ -119,7 +118,7 @@ public sealed class RocketMQContainerTests
         {
             var body = $"transaction-{Guid.NewGuid():N}";
             var transaction = await producer.SendTransactionAsync(new Message(
-                RocketMQContainerFixture.TransactionTopic,
+                scope.Topic,
                 Encoding.UTF8.GetBytes(body))
             {
                 Tag = "transaction"
@@ -152,17 +151,20 @@ public sealed class RocketMQContainerTests
     public async Task GrpcPushConsumerDispatchesAndAcknowledgesMessage()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("grpc-push-consumer");
         var consumed = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         var expected = $"grpc-push-{Guid.NewGuid():N}";
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
             .AddGrpcProducer()
             .AddGrpcPushConsumer(options =>
             {
-                options.GroupName = "grpc-push-consumer-it";
+                options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("grpc-push"));
+                options.Subscribe(scope.Topic, new FilterExpression("grpc-push"));
                 options.MessageHandler = (message, _) =>
                 {
                     var body = Encoding.UTF8.GetString(message.Body);
@@ -183,7 +185,7 @@ public sealed class RocketMQContainerTests
         try
         {
             var sent = await producer.SendAsync(new Message(
-                RocketMQContainerFixture.TestTopic,
+                scope.Topic,
                 Encoding.UTF8.GetBytes(expected))
             {
                 Tag = "grpc-push"

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
@@ -24,32 +24,27 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQDeadLetterIntegrationTests
+public sealed class RocketMQDeadLetterIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private const string ConsumerGroup = "grpc-push-dlq-consumer-it";
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQDeadLetterIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
 
     [Fact]
     [Trait("Category", "Integration")]
     public async Task GrpcPushConsumerForwardsMessageToDeadLetterQueue()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("grpc-push-dlq-consumer");
         var handled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var expected = $"grpc-dlq-{Guid.NewGuid():N}";
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
             .AddGrpcProducer()
             .AddGrpcPushConsumer(options =>
             {
-                options.GroupName = ConsumerGroup;
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("grpc-dlq"));
+                options.GroupName = consumerGroup;
+                options.Subscribe(scope.Topic, new FilterExpression("grpc-dlq"));
                 options.MessageHandler = (message, _) =>
                 {
                     if (Encoding.UTF8.GetString(message.Body) == expected)
@@ -70,18 +65,18 @@ public sealed class RocketMQDeadLetterIntegrationTests
         try
         {
             await producer.SendAsync(new Message(
-                RocketMQContainerFixture.TestTopic,
+                scope.Topic,
                 Encoding.UTF8.GetBytes(expected))
             {
                 Tag = "grpc-dlq"
             }, cancellationToken);
             await handled.Task.WaitAsync(TimeSpan.FromSeconds(20), cancellationToken);
 
-            var deadLetterTopic = $"%DLQ%{ConsumerGroup}";
+            var deadLetterTopic = $"%DLQ%{consumerGroup}";
             var status = string.Empty;
             for (var attempt = 0; attempt < 20; attempt++)
             {
-                status = await _fixture.GetTopicStatusAsync(deadLetterTopic, cancellationToken);
+                status = await fixture.GetTopicStatusAsync(deadLetterTopic, cancellationToken);
                 if (HasMessage(status))
                 {
                     return;

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
@@ -23,33 +23,28 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQLiteIntegrationTests
+public sealed class RocketMQLiteIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private const string ConsumerGroup = "grpc-lite-push-consumer-it";
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQLiteIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
 
     [Fact]
     [Trait("Category", "Integration")]
     public async Task GrpcLitePushConsumerDispatchesLiteMessages()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Lite, cancellationToken);
+        var consumerGroup = await scope.CreateLiteConsumerGroupAsync("grpc-lite-push-consumer", cancellationToken);
         var liteTopic = $"lite-{Guid.NewGuid():N}";
         var expected = $"grpc-lite-{Guid.NewGuid():N}";
         var consumed = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
-            .AddGrpcProducer(options => options.Topics.Add(RocketMQContainerFixture.LiteParentTopic))
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
+            .AddGrpcProducer(options => options.Topics.Add(scope.Topic))
             .AddGrpcLitePushConsumer(options =>
             {
-                options.GroupName = ConsumerGroup;
-                options.BindTopic = RocketMQContainerFixture.LiteParentTopic;
+                options.GroupName = consumerGroup;
+                options.BindTopic = scope.Topic;
                 options.LiteTopics.Add(liteTopic);
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
                 options.MessageHandler = (message, _) =>
@@ -71,7 +66,7 @@ public sealed class RocketMQLiteIntegrationTests
         try
         {
             var receipt = await producer.SendAsync(new Message(
-                RocketMQContainerFixture.LiteParentTopic,
+                scope.Topic,
                 Encoding.UTF8.GetBytes(expected))
             {
                 LiteTopic = liteTopic

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -24,15 +24,8 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQMessageTypesIntegrationTests
+public sealed class RocketMQMessageTypesIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQMessageTypesIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
 
     [Fact]
     [Trait("Category", "Integration")]
@@ -40,19 +33,22 @@ public sealed class RocketMQMessageTypesIntegrationTests
     {
         const int messageCount = 8;
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Fifo, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("grpc-fifo-consumer");
         var tag = $"fifo-{Guid.NewGuid():N}";
         var messageGroup = $"account-{Guid.NewGuid():N}";
         var received = new ConcurrentQueue<int>();
         var allReceived = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
-            .AddGrpcProducer(options => options.Topics.Add(RocketMQContainerFixture.FifoTopic))
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
+            .AddGrpcProducer(options => options.Topics.Add(scope.Topic))
             .AddGrpcPushConsumer(options =>
             {
-                options.GroupName = "grpc-fifo-consumer-it";
+                options.GroupName = consumerGroup;
                 options.MaxConcurrency = 4;
-                options.Subscribe(RocketMQContainerFixture.FifoTopic, new FilterExpression(tag));
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
                 options.MessageHandler = (message, _) =>
                 {
                     if (message.Tag == tag && int.TryParse(Encoding.UTF8.GetString(message.Body), out var sequence))
@@ -78,7 +74,7 @@ public sealed class RocketMQMessageTypesIntegrationTests
             for (var sequence = 0; sequence < messageCount; sequence++)
             {
                 await producer.SendAsync(new Message(
-                    RocketMQContainerFixture.FifoTopic,
+                    scope.Topic,
                     Encoding.UTF8.GetBytes(sequence.ToString()))
                 {
                     Tag = tag,

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerCollection.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerCollection.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-[CollectionDefinition(Name, DisableParallelization = true)]
+[CollectionDefinition(Name)]
 public sealed class RocketMQMultiBrokerCollection : ICollectionFixture<RocketMQMultiBrokerGrpcContainerFixture>
 {
     public const string Name = "RocketMQ gRPC multi-Broker integration";

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
@@ -25,8 +25,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFixture fixture)
+public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]
@@ -34,6 +33,9 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
     {
         using var listener = CreateActivityListener();
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("grpc-trace-propagation-consumer");
         var tag = $"grpc-trace-propagation-{Guid.NewGuid():N}";
         var body = $"grpc-trace-propagation-{Guid.NewGuid():N}";
         var received = new TaskCompletionSource<TraceObservation>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -43,9 +45,9 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
             .AddGrpcProducer()
             .AddGrpcPushConsumer(options =>
             {
-                options.GroupName = "grpc-trace-propagation-consumer-it";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.GroupName = consumerGroup;
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
                 options.MessageHandler = (message, _) =>
                 {
                     if (Encoding.UTF8.GetString(message.Body) == body)
@@ -68,7 +70,7 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
             using var producerActivity = new Activity("grpc-trace-propagation-test").Start();
             var producerTraceId = producerActivity.TraceId;
             await producer.SendAsync(
-                new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
+                new Message(scope.Topic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
                 cancellationToken);
 
             var observed = await received.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTransactionIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTransactionIntegrationTests.cs
@@ -24,36 +24,32 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQTransactionIntegrationTests
+public sealed class RocketMQTransactionIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQTransactionIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
 
     [Fact]
     [Trait("Category", "Integration")]
     public async Task GrpcTransactionRollbackKeepsMessageInvisible()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Transaction, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("grpc-transaction-rollback-consumer");
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
             .AddGrpcProducer(options =>
             {
-                options.Topics.Add(RocketMQContainerFixture.TransactionTopic);
+                options.Topics.Add(scope.Topic);
                 options.TransactionChecker = static (_, _) =>
                     ValueTask.FromResult(TransactionResolution.Rollback);
             })
             .AddGrpcSimpleConsumer(options =>
             {
-                options.GroupName = "grpc-transaction-rollback-consumer-it";
+                options.GroupName = consumerGroup;
                 options.AwaitDuration = TimeSpan.FromSeconds(5);
                 options.Subscribe(
-                    RocketMQContainerFixture.TransactionTopic,
+                    scope.Topic,
                     new FilterExpression("transaction-rollback"));
             });
 
@@ -66,7 +62,7 @@ public sealed class RocketMQTransactionIntegrationTests
         {
             var body = $"transaction-rollback-{Guid.NewGuid():N}";
             var transaction = await producer.SendTransactionAsync(new Message(
-                RocketMQContainerFixture.TransactionTopic,
+                scope.Topic,
                 Encoding.UTF8.GetBytes(body))
             {
                 Tag = "transaction-rollback"

--- a/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/xunit.runner.json
+++ b/tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 4,
+  "parallelizeTestCollections": true
+}

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixture.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixture.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Net;
-using System.Net.Sockets;
 using System.Text;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -27,30 +25,51 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
 {
     private const string Image = "apache/rocketmq:5.5.0";
     private const int NameServerPort = 9876;
+
+    /// <summary>
+    /// Gets the shared topic used only by the legacy serial Remoting integration-test suite.
+    /// </summary>
     public const string TestTopic = "rocketmq-dotnet-it";
+
+    /// <summary>
+    /// Gets the shared transaction topic used by isolated transaction tests.
+    /// </summary>
     public const string TransactionTopic = "rocketmq-dotnet-transaction-it";
+
+    /// <summary>
+    /// Gets the shared FIFO topic used by isolated FIFO tests.
+    /// </summary>
     public const string FifoTopic = "rocketmq-dotnet-fifo-it";
+
+    /// <summary>
+    /// Gets the shared delay topic used by isolated delay tests.
+    /// </summary>
     public const string DelayTopic = "rocketmq-dotnet-delay-it";
+
+    /// <summary>
+    /// Gets the shared LitePush parent topic used by isolated LitePush tests.
+    /// </summary>
     public const string LiteParentTopic = "rocketmq-dotnet-lite-parent-it";
 
+    private readonly SemaphoreSlim _administrationGate = new(4, 4);
     private readonly INetwork _network = new NetworkBuilder().Build();
     private readonly IContainer _nameServer;
     private readonly IContainer _broker;
+    private readonly RocketMQHostPortReservation _portReservation;
+    private readonly int _nameServerHostPort;
     private readonly int _brokerPort;
     private readonly int _grpcPort;
 
     public RocketMQContainerFixture()
     {
-        _brokerPort = GetAvailablePort();
-        do
-        {
-            _grpcPort = GetAvailablePort();
-        }
-        while (Math.Abs(_grpcPort - _brokerPort) <= 10);
+        _portReservation = RocketMQHostPortReservation.Reserve(3, minimumPortDistance: 10);
+        _nameServerHostPort = _portReservation[0];
+        _brokerPort = _portReservation[1];
+        _grpcPort = _portReservation[2];
         _nameServer = new ContainerBuilder(Image)
             .WithNetwork(_network)
             .WithNetworkAliases("nameserver")
-            .WithPortBinding(NameServerPort, true)
+            .WithPortBinding(_nameServerHostPort, NameServerPort)
             .WithEnvironment("JAVA_OPT_EXT", "-Duser.home=/home/rocketmq -Xms256m -Xmx256m")
             .WithCommand("sh", "mqnamesrv")
             .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(NameServerPort))
@@ -64,6 +83,7 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
             $"namesrvAddr=nameserver:{NameServerPort}\n" +
             $"listenPort={_brokerPort}\n" +
             "autoCreateTopicEnable=true\n" +
+            "autoCreateSubscriptionGroup=true\n" +
             "enableLmq=true\n" +
             "enableMultiDispatch=true\n" +
             "recallMessageEnable=true\n");
@@ -105,6 +125,41 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
     public string BrokerAddress => $"{_broker.Hostname}:{_broker.GetMappedPublicPort(_brokerPort)}";
 
     public string GrpcEndpoint => $"{_broker.Hostname}:{_broker.GetMappedPublicPort(_grpcPort)}";
+
+    /// <summary>
+    /// Creates a test-specific topic and group-name scope for one integration test.
+    /// </summary>
+    /// <param name="topicType">The message type configured for the topic.</param>
+    /// <param name="cancellationToken">The token used to cancel Broker administration requests.</param>
+    /// <returns>The isolated integration-test scope.</returns>
+    public Task<RocketMQTestScope> CreateTestScopeAsync(
+        RocketMQTestTopicType topicType,
+        CancellationToken cancellationToken = default)
+    {
+        return CreateTestScopeCoreAsync(topicType, cancellationToken);
+    }
+
+    private async Task<RocketMQTestScope> CreateTestScopeCoreAsync(
+        RocketMQTestTopicType topicType,
+        CancellationToken cancellationToken)
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var topic = topicType switch
+        {
+            RocketMQTestTopicType.Normal => $"rocketmq-dotnet-it-{suffix}",
+            RocketMQTestTopicType.Transaction => TransactionTopic,
+            RocketMQTestTopicType.Fifo => FifoTopic,
+            RocketMQTestTopicType.Delay => DelayTopic,
+            RocketMQTestTopicType.Lite => LiteParentTopic,
+            _ => throw new ArgumentOutOfRangeException(nameof(topicType), topicType, null)
+        };
+        if (topicType == RocketMQTestTopicType.Normal)
+        {
+            await CreateTopicAsync(topic, GetMessageType(topicType), cancellationToken).ConfigureAwait(false);
+        }
+
+        return new RocketMQTestScope(this, topic, suffix);
+    }
 
     public async Task<string> GetTopicListAsync(CancellationToken cancellationToken)
     {
@@ -172,28 +227,45 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
         await _nameServer.StartAsync().ConfigureAwait(false);
         await _broker.StartAsync().ConfigureAwait(false);
 
-        await CreateTopicAsync(TestTopic, "NORMAL").ConfigureAwait(false);
-        await CreateTopicAsync(TransactionTopic, "TRANSACTION").ConfigureAwait(false);
-        await CreateTopicAsync(FifoTopic, "FIFO").ConfigureAwait(false);
-        await CreateTopicAsync(DelayTopic, "DELAY").ConfigureAwait(false);
-        await CreateTopicAsync(LiteParentTopic, "LITE").ConfigureAwait(false);
-
+        await Task.WhenAll(
+            CreateTopicAsync(TestTopic, "NORMAL", CancellationToken.None),
+            CreateTopicAsync(TransactionTopic, "TRANSACTION", CancellationToken.None),
+            CreateTopicAsync(FifoTopic, "FIFO", CancellationToken.None),
+            CreateTopicAsync(DelayTopic, "DELAY", CancellationToken.None),
+            CreateTopicAsync(LiteParentTopic, "LITE", CancellationToken.None)).ConfigureAwait(false);
         foreach (var group in new[]
                  {
-                     "grpc-simple-consumer-it",
                      "remoting-pull-consumer-it",
-                     "grpc-push-consumer-it",
-                     "grpc-trace-propagation-consumer-it",
                      "legacy-push-consumer-it",
-                     "remoting-trace-propagation-consumer-it",
-                     "legacy-push-cluster-it",
-                     "grpc-transaction-consumer-it",
-                     "grpc-transaction-rollback-consumer-it",
-                     "grpc-push-dlq-consumer-it",
-                     "grpc-fifo-consumer-it",
-                     "grpc-lite-push-consumer-it",
-                     "remoting-delay-consumer-it"
+                     "legacy-push-cluster-it"
                  })
+        {
+            await CreateConsumerGroupAsync(group, null, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _broker.DisposeAsync().ConfigureAwait(false);
+            await _nameServer.DisposeAsync().ConfigureAwait(false);
+            await _network.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _administrationGate.Dispose();
+            _portReservation.Dispose();
+        }
+    }
+
+    internal async Task CreateConsumerGroupAsync(
+        string group,
+        string? liteParentTopic,
+        CancellationToken cancellationToken)
+    {
+        await _administrationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
             var createGroupCommand = new List<string>
             {
@@ -202,33 +274,23 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
                 "-c", "DefaultCluster",
                 "-g", group
             };
-            if (string.Equals(group, "grpc-lite-push-consumer-it", StringComparison.Ordinal))
+            if (liteParentTopic is not null)
             {
                 createGroupCommand.Add("--attributes");
-                createGroupCommand.Add($"+lite.bind.topic={LiteParentTopic}");
+                createGroupCommand.Add($"+lite.bind.topic={liteParentTopic}");
             }
 
-            var createGroup = await _broker.ExecAsync(createGroupCommand).ConfigureAwait(false);
+            var createGroup = await _broker.ExecAsync(createGroupCommand, cancellationToken).ConfigureAwait(false);
             if (createGroup.ExitCode != 0)
             {
                 throw new InvalidOperationException(
                     $"Unable to create integration-test consumer group '{group}'. stdout: {createGroup.Stdout} stderr: {createGroup.Stderr}");
             }
         }
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _broker.DisposeAsync().ConfigureAwait(false);
-        await _nameServer.DisposeAsync().ConfigureAwait(false);
-        await _network.DisposeAsync().ConfigureAwait(false);
-    }
-
-    private static int GetAvailablePort()
-    {
-        using var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        return ((IPEndPoint)listener.LocalEndpoint).Port;
+        finally
+        {
+            _administrationGate.Release();
+        }
     }
 
     private static bool HasZeroLag(string progress, string topic, string brokerName, int queueId)
@@ -254,30 +316,51 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
         return false;
     }
 
-    private async Task CreateTopicAsync(string topic, string messageType)
+    private async Task CreateTopicAsync(string topic, string messageType, CancellationToken cancellationToken)
     {
-        var createTopic = await _broker.ExecAsync([
-            "sh", "mqadmin", "updateTopic",
-            "-n", $"nameserver:{NameServerPort}",
-            "-c", "DefaultCluster",
-            "-t", topic,
-            "-a", $"+message.type={messageType}"
-        ]).ConfigureAwait(false);
-        if (createTopic.ExitCode != 0)
+        await _administrationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            throw new InvalidOperationException(
-                $"Unable to create integration-test topic '{topic}'. stdout: {createTopic.Stdout} stderr: {createTopic.Stderr}");
-        }
+            var createTopic = await _broker.ExecAsync([
+                "sh", "mqadmin", "updateTopic",
+                "-n", $"nameserver:{NameServerPort}",
+                "-c", "DefaultCluster",
+                "-t", topic,
+                "-a", $"+message.type={messageType}"
+            ], cancellationToken).ConfigureAwait(false);
+            if (createTopic.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Unable to create integration-test topic '{topic}'. stdout: {createTopic.Stdout} stderr: {createTopic.Stderr}");
+            }
 
-        var topicRoute = await _broker.ExecAsync([
-            "sh", "mqadmin", "topicRoute",
-            "-n", $"nameserver:{NameServerPort}",
-            "-t", topic
-        ]).ConfigureAwait(false);
-        if (topicRoute.ExitCode != 0 || !topicRoute.Stdout.Contains("broker-a", StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(
-                $"Test topic '{topic}' has no route. stdout: {topicRoute.Stdout} stderr: {topicRoute.Stderr}");
+            var topicRoute = await _broker.ExecAsync([
+                "sh", "mqadmin", "topicRoute",
+                "-n", $"nameserver:{NameServerPort}",
+                "-t", topic
+            ], cancellationToken).ConfigureAwait(false);
+            if (topicRoute.ExitCode != 0 || !topicRoute.Stdout.Contains("broker-a", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Test topic '{topic}' has no route. stdout: {topicRoute.Stdout} stderr: {topicRoute.Stderr}");
+            }
         }
+        finally
+        {
+            _administrationGate.Release();
+        }
+    }
+
+    private static string GetMessageType(RocketMQTestTopicType topicType)
+    {
+        return topicType switch
+        {
+            RocketMQTestTopicType.Normal => "NORMAL",
+            RocketMQTestTopicType.Transaction => "TRANSACTION",
+            RocketMQTestTopicType.Fifo => "FIFO",
+            RocketMQTestTopicType.Delay => "DELAY",
+            RocketMQTestTopicType.Lite => "LITE",
+            _ => throw new ArgumentOutOfRangeException(nameof(topicType), topicType, null)
+        };
     }
 }

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixtureRegistry.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixtureRegistry.cs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
+
+/// <summary>
+/// Lazily creates one single-Broker fixture for an integration-test assembly.
+/// </summary>
+public sealed class RocketMQContainerFixtureRegistry : IAsyncLifetime
+{
+    private readonly SemaphoreSlim _initializationGate = new(1, 1);
+    private RocketMQContainerFixture? _fixture;
+
+    /// <inheritdoc />
+    public ValueTask InitializeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Gets the shared single-Broker fixture, starting it on first use.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel waiting for fixture initialization.</param>
+    /// <returns>The initialized fixture.</returns>
+    public async Task<RocketMQContainerFixture> GetFixtureAsync(CancellationToken cancellationToken = default)
+    {
+        if (Volatile.Read(ref _fixture) is { } fixture)
+        {
+            return fixture;
+        }
+
+        await _initializationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_fixture is { } existingFixture)
+            {
+                return existingFixture;
+            }
+
+            var createdFixture = new RocketMQContainerFixture();
+            try
+            {
+                await createdFixture.InitializeAsync().ConfigureAwait(false);
+                _fixture = createdFixture;
+                return createdFixture;
+            }
+            catch
+            {
+                await createdFixture.DisposeAsync().ConfigureAwait(false);
+                throw;
+            }
+        }
+        finally
+        {
+            _initializationGate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _initializationGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_fixture is { } fixture)
+            {
+                _fixture = null;
+                await fixture.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _initializationGate.Release();
+            _initializationGate.Dispose();
+        }
+    }
+}

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQHostPortReservation.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQHostPortReservation.cs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
+
+internal sealed class RocketMQHostPortReservation : IDisposable
+{
+    private static readonly object SyncRoot = new();
+    private static readonly HashSet<int> ReservedPorts = [];
+    private readonly IReadOnlyList<int> _ports;
+    private int _disposed;
+
+    private RocketMQHostPortReservation(IReadOnlyList<int> ports)
+    {
+        _ports = ports;
+    }
+
+    public int this[int index] => _ports[index];
+
+    public static RocketMQHostPortReservation Reserve(int count, int minimumPortDistance = 0)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(count, 0);
+        ArgumentOutOfRangeException.ThrowIfNegative(minimumPortDistance);
+
+        lock (SyncRoot)
+        {
+            var ports = new List<int>(count);
+            while (ports.Count < count)
+            {
+                var port = GetAvailablePort();
+                if (ReservedPorts.Contains(port) ||
+                    ports.Any(existingPort => Math.Abs(existingPort - port) <= minimumPortDistance))
+                {
+                    continue;
+                }
+
+                ReservedPorts.Add(port);
+                ports.Add(port);
+            }
+
+            return new RocketMQHostPortReservation(ports);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        lock (SyncRoot)
+        {
+            foreach (var port in _ports)
+            {
+                ReservedPorts.Remove(port);
+            }
+        }
+    }
+
+    private static int GetAvailablePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+}

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs
@@ -58,12 +58,16 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
     private readonly IContainer _brokerB;
     private readonly IContainer _brokerC;
     private readonly IContainer _proxy;
+    private readonly RocketMQHostPortReservation _portReservation;
+    private readonly int _proxyHostPort;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RocketMQMultiBrokerGrpcContainerFixture"/> class.
     /// </summary>
     public RocketMQMultiBrokerGrpcContainerFixture()
     {
+        _portReservation = RocketMQHostPortReservation.Reserve(1);
+        _proxyHostPort = _portReservation[0];
         _nameServer = new ContainerBuilder(Image)
             .WithNetwork(_network)
             .WithNetworkAliases("nameserver")
@@ -86,7 +90,7 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
         _proxy = new ContainerBuilder(Image)
             .WithNetwork(_network)
             .WithNetworkAliases("proxy")
-            .WithPortBinding(GrpcPort, true)
+            .WithPortBinding(_proxyHostPort, GrpcPort)
             .WithEnvironment("NAMESRV_ADDR", $"nameserver:{NameServerPort}")
             .WithEnvironment("JAVA_OPT_EXT", "-Duser.home=/home/rocketmq -Xms512m -Xmx512m")
             .WithResourceMapping(proxyConfiguration, "/home/rocketmq/rocketmq-5.5.0/conf/rmq-proxy.json")
@@ -128,12 +132,19 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        await _proxy.DisposeAsync().ConfigureAwait(false);
-        await _brokerC.DisposeAsync().ConfigureAwait(false);
-        await _brokerB.DisposeAsync().ConfigureAwait(false);
-        await _brokerA.DisposeAsync().ConfigureAwait(false);
-        await _nameServer.DisposeAsync().ConfigureAwait(false);
-        await _network.DisposeAsync().ConfigureAwait(false);
+        try
+        {
+            await _proxy.DisposeAsync().ConfigureAwait(false);
+            await _brokerC.DisposeAsync().ConfigureAwait(false);
+            await _brokerB.DisposeAsync().ConfigureAwait(false);
+            await _brokerA.DisposeAsync().ConfigureAwait(false);
+            await _nameServer.DisposeAsync().ConfigureAwait(false);
+            await _network.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _portReservation.Dispose();
+        }
     }
 
     /// <summary>

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Net;
-using System.Net.Sockets;
 using System.Text;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -56,6 +54,8 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
     private readonly IContainer _brokerA;
     private readonly IContainer _brokerB;
     private readonly IContainer _brokerC;
+    private readonly RocketMQHostPortReservation _portReservation;
+    private readonly int _nameServerHostPort;
     private readonly int _brokerAPort;
     private readonly int _brokerBPort;
     private readonly int _brokerCPort;
@@ -65,23 +65,16 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
     /// </summary>
     public RocketMQMultiBrokerRemotingContainerFixture()
     {
-        _brokerAPort = GetAvailablePort();
-        do
-        {
-            _brokerBPort = GetAvailablePort();
-        }
-        while (_brokerBPort == _brokerAPort);
-
-        do
-        {
-            _brokerCPort = GetAvailablePort();
-        }
-        while (_brokerCPort == _brokerAPort || _brokerCPort == _brokerBPort);
+        _portReservation = RocketMQHostPortReservation.Reserve(4);
+        _nameServerHostPort = _portReservation[0];
+        _brokerAPort = _portReservation[1];
+        _brokerBPort = _portReservation[2];
+        _brokerCPort = _portReservation[3];
 
         _nameServer = new ContainerBuilder(Image)
             .WithNetwork(_network)
             .WithNetworkAliases("nameserver")
-            .WithPortBinding(NameServerPort, true)
+            .WithPortBinding(_nameServerHostPort, NameServerPort)
             .WithEnvironment("JAVA_OPT_EXT", "-Duser.home=/home/rocketmq -Xms256m -Xmx256m")
             .WithCommand("sh", "mqnamesrv")
             .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(NameServerPort))
@@ -114,11 +107,18 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        await _brokerC.DisposeAsync().ConfigureAwait(false);
-        await _brokerB.DisposeAsync().ConfigureAwait(false);
-        await _brokerA.DisposeAsync().ConfigureAwait(false);
-        await _nameServer.DisposeAsync().ConfigureAwait(false);
-        await _network.DisposeAsync().ConfigureAwait(false);
+        try
+        {
+            await _brokerC.DisposeAsync().ConfigureAwait(false);
+            await _brokerB.DisposeAsync().ConfigureAwait(false);
+            await _brokerA.DisposeAsync().ConfigureAwait(false);
+            await _nameServer.DisposeAsync().ConfigureAwait(false);
+            await _network.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _portReservation.Dispose();
+        }
     }
 
     private IContainer CreateBroker(string brokerName, int port)
@@ -215,10 +215,4 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
             $"Multi-Broker test topic has an incomplete route. stdout: {topicRoute.Stdout} stderr: {topicRoute.Stderr}");
     }
 
-    private static int GetAvailablePort()
-    {
-        using var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        return ((IPEndPoint)listener.LocalEndpoint).Port;
-    }
 }

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
+
+/// <summary>
+/// Provides test-specific Broker resource names for one integration test.
+/// </summary>
+public sealed class RocketMQTestScope
+{
+    private readonly RocketMQContainerFixture _fixture;
+    private readonly string _suffix;
+
+    internal RocketMQTestScope(RocketMQContainerFixture fixture, string topic, string suffix)
+    {
+        _fixture = fixture;
+        Topic = topic;
+        _suffix = suffix;
+    }
+
+    /// <summary>
+    /// Gets the unique normal topic or preconfigured special topic selected for the test.
+    /// </summary>
+    public string Topic { get; }
+
+    /// <summary>
+    /// Creates an isolated producer group name.
+    /// </summary>
+    /// <param name="role">The role label included in the group name.</param>
+    /// <returns>A producer group name unique to this test scope.</returns>
+    public string CreateProducerGroupName(string role)
+    {
+        return CreateGroupName(role);
+    }
+
+    /// <summary>
+    /// Creates an isolated consumer group name.
+    /// </summary>
+    /// <param name="role">The role label included in the group name.</param>
+    /// <returns>A consumer group name unique to this test scope.</returns>
+    public string CreateConsumerGroupName(string role)
+    {
+        return CreateGroupName(role);
+    }
+
+    /// <summary>
+    /// Creates and configures an isolated LitePush consumer group bound to this scope's parent topic.
+    /// </summary>
+    /// <param name="role">The role label included in the group name.</param>
+    /// <param name="cancellationToken">The token used to cancel the Broker administration request.</param>
+    /// <returns>A LitePush consumer group name unique to this test scope.</returns>
+    public async Task<string> CreateLiteConsumerGroupAsync(string role, CancellationToken cancellationToken = default)
+    {
+        var group = CreateGroupName(role);
+        await _fixture.CreateConsumerGroupAsync(group, Topic, cancellationToken).ConfigureAwait(false);
+        return group;
+    }
+
+    private string CreateGroupName(string role)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(role);
+        return $"rocketmq-dotnet-it-{role}-{_suffix}";
+    }
+}

--- a/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestTopicType.cs
+++ b/tests/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestTopicType.cs
@@ -13,13 +13,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
-using Xunit;
+namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 
-namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
-
-[CollectionDefinition(Name)]
-public sealed class RocketMQMultiBrokerCollection : ICollectionFixture<RocketMQMultiBrokerRemotingContainerFixture>
+/// <summary>
+/// Specifies the RocketMQ message type configured for an isolated integration-test topic.
+/// </summary>
+public enum RocketMQTestTopicType
 {
-    public const string Name = "RocketMQ Remoting multi-Broker integration";
+    /// <summary>
+    /// A standard message topic.
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// A transactional message topic.
+    /// </summary>
+    Transaction,
+
+    /// <summary>
+    /// A FIFO message topic.
+    /// </summary>
+    Fifo,
+
+    /// <summary>
+    /// A delay message topic.
+    /// </summary>
+    Delay,
+
+    /// <summary>
+    /// A LitePush parent topic.
+    /// </summary>
+    Lite
 }

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/AssemblyInfo.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/AssemblyInfo.cs
@@ -16,10 +16,4 @@
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 using Xunit;
 
-namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
-
-[CollectionDefinition(Name, DisableParallelization = true)]
-public sealed class RocketMQCollection : ICollectionFixture<RocketMQContainerFixture>
-{
-    public const string Name = "RocketMQ gRPC integration";
-}
+[assembly: AssemblyFixture(typeof(RocketMQContainerFixtureRegistry))]

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj
@@ -27,4 +27,10 @@
         <ProjectReference Include="../EventHorizon.RocketMQ.IntegrationTestInfrastructure/EventHorizon.RocketMQ.IntegrationTestInfrastructure.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Update="xunit.runner.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
 </Project>

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQAdminIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQAdminIntegrationTests.cs
@@ -24,38 +24,32 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQAdminIntegrationTests
+public sealed class RocketMQAdminIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQAdminIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
-
     [Fact]
     [Trait("Category", "Integration")]
     public async Task AdminReadsQueueOffsetsAndConsumerCommit()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
         var suffix = Guid.NewGuid().ToString("N");
-        var group = $"remoting-admin-consumer-{suffix}";
+        var group = scope.CreateConsumerGroupName("remoting-admin-consumer");
         var tag = $"remoting-admin-{suffix}";
         var body = $"admin-offset-{suffix}";
         var services = new ServiceCollection();
         services
             .AddRocketMQRemoting(options =>
             {
-                options.NamesrvAddr = _fixture.NameServerAddress;
+                options.NamesrvAddr = fixture.NameServerAddress;
             })
             .AddRemotingAdmin()
-            .AddRemotingProducer(options => options.GroupName = $"remoting-admin-producer-{suffix}")
+            .AddRemotingProducer(options => options.GroupName = scope.CreateProducerGroupName("remoting-admin-producer"))
             .AddRemotingPullConsumer(options =>
             {
                 options.GroupName = group;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
             });
 
         await using var provider = services.BuildServiceProvider(
@@ -68,12 +62,12 @@ public sealed class RocketMQAdminIntegrationTests
         try
         {
             var adminQueues = await admin.GetMessageQueuesAsync(
-                RocketMQContainerFixture.TestTopic,
+                scope.Topic,
                 cancellationToken);
             Assert.NotEmpty(adminQueues);
 
             var pullQueues = await consumer.GetMessageQueuesAsync(
-                RocketMQContainerFixture.TestTopic,
+                scope.Topic,
                 cancellationToken);
             var initialOffsets = new Dictionary<(string BrokerName, int QueueId), long>();
             foreach (var queue in pullQueues)
@@ -85,14 +79,14 @@ public sealed class RocketMQAdminIntegrationTests
             }
 
             var sent = await producer.SendAsync(
-                new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
+                new Message(scope.Topic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
                 cancellationToken);
             var viewed = await admin.ViewMessageAsync(
-                RocketMQContainerFixture.TestTopic,
+                scope.Topic,
                 sent.OffsetMessageId,
                 cancellationToken);
 
-            Assert.Equal(RocketMQContainerFixture.TestTopic, viewed.Topic);
+            Assert.Equal(scope.Topic, viewed.Topic);
             Assert.Equal(body, Encoding.UTF8.GetString(viewed.Body));
             Assert.Equal(tag, viewed.Tag);
             Assert.Equal(sent.OffsetMessageId, viewed.OffsetMessageId);

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
@@ -33,14 +33,18 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQContainerTests
+public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry registry) : IAsyncLifetime
 {
-    private readonly RocketMQContainerFixture _fixture;
+    private RocketMQContainerFixture _fixture = null!;
 
-    public RocketMQContainerTests(RocketMQContainerFixture fixture)
+    public async ValueTask InitializeAsync()
     {
-        _fixture = fixture;
+        _fixture = await registry.GetFixtureAsync(TestContext.Current.CancellationToken);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
     }
 
     [Fact]

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
@@ -319,6 +319,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
             .AddRemotingPushConsumer(options =>
             {
                 options.GroupName = "legacy-push-consumer-it";
+                options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
                 options.RetryDelay = TimeSpan.FromMilliseconds(100);
                 options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("legacy-push"));

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -24,21 +24,16 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQMessageTypesIntegrationTests
+public sealed class RocketMQMessageTypesIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQMessageTypesIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
-
     [Fact]
     [Trait("Category", "Integration")]
     public async Task KeyedClientRegistrationCombinesRemotingDelayProducerAndConsumer()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Delay, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("remoting-delay-consumer");
         var tag = $"delay-{Guid.NewGuid():N}";
         var body = $"remoting-delay-{Guid.NewGuid():N}";
         var received = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -46,14 +41,14 @@ public sealed class RocketMQMessageTypesIntegrationTests
         services
             .AddRocketMQRemoting("remoting-delay", options =>
             {
-                options.NamesrvAddr = _fixture.NameServerAddress;
+                options.NamesrvAddr = fixture.NameServerAddress;
             })
-            .AddRemotingProducer(options => options.GroupName = "remoting-delay-producer-it")
+            .AddRemotingProducer(options => options.GroupName = scope.CreateProducerGroupName("remoting-delay-producer"))
             .AddRemotingPushConsumer(options =>
             {
-                options.GroupName = "remoting-delay-consumer-it";
+                options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.DelayTopic, new FilterExpression(tag));
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
                 options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
@@ -75,7 +70,7 @@ public sealed class RocketMQMessageTypesIntegrationTests
         {
             var stopwatch = Stopwatch.StartNew();
             await producer.SendAsync(new Message(
-                RocketMQContainerFixture.DelayTopic,
+                scope.Topic,
                 Encoding.UTF8.GetBytes(body))
             {
                 Tag = tag,

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
@@ -23,21 +23,16 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQRequestReplyIntegrationTests
+public sealed class RocketMQRequestReplyIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQRequestReplyIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
-
     [Fact]
     [Trait("Category", "Integration")]
     public async Task ProducerReceivesReplyFromPushConsumer()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("request-reply-consumer");
         var suffix = Guid.NewGuid().ToString("N");
         var requestBody = $"request-{suffix}";
         var replyBody = $"reply-{suffix}";
@@ -47,15 +42,15 @@ public sealed class RocketMQRequestReplyIntegrationTests
         services
             .AddRocketMQRemoting(options =>
             {
-                options.NamesrvAddr = _fixture.NameServerAddress;
+                options.NamesrvAddr = fixture.NameServerAddress;
                 options.InstanceName = $"request-reply-{suffix}";
             })
-            .AddRemotingProducer(options => options.GroupName = $"request-reply-producer-{suffix}")
+            .AddRemotingProducer(options => options.GroupName = scope.CreateProducerGroupName("request-reply-producer"))
             .AddRemotingPushConsumer(options =>
             {
-                options.GroupName = $"request-reply-consumer-{suffix}";
+                options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
                 options.MessageHandler = async (messages, _, token) =>
                 {
                     var message = Assert.Single(messages);
@@ -79,7 +74,7 @@ public sealed class RocketMQRequestReplyIntegrationTests
         try
         {
             var reply = await producer.RequestAsync(
-                new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(requestBody)) { Tag = tag },
+                new Message(scope.Topic, Encoding.UTF8.GetBytes(requestBody)) { Tag = tag },
                 TimeSpan.FromSeconds(30),
                 cancellationToken);
 

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
@@ -25,8 +25,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFixture fixture)
+public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]
@@ -34,18 +33,22 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
     {
         using var listener = CreateActivityListener();
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("remoting-trace-propagation-consumer");
+        var producerGroup = scope.CreateProducerGroupName("remoting-trace-propagation-producer");
         var tag = $"remoting-trace-propagation-{Guid.NewGuid():N}";
         var body = $"remoting-trace-propagation-{Guid.NewGuid():N}";
         var received = new TaskCompletionSource<TraceObservation>(TaskCreationOptions.RunContinuationsAsynchronously);
         var services = new ServiceCollection();
         services
             .AddRocketMQRemoting(options => options.NamesrvAddr = fixture.NameServerAddress)
-            .AddRemotingProducer(options => options.GroupName = "remoting-trace-propagation-producer-it")
+            .AddRemotingProducer(options => options.GroupName = producerGroup)
             .AddRemotingPushConsumer(options =>
             {
-                options.GroupName = "remoting-trace-propagation-consumer-it";
+                options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
                 options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
@@ -69,7 +72,7 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
             using var producerActivity = new Activity("remoting-trace-propagation-test").Start();
             var producerTraceId = producerActivity.TraceId;
             await producer.SendAsync(
-                new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
+                new Message(scope.Topic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
                 cancellationToken);
 
             var observed = await received.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
@@ -24,21 +24,16 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-[Collection(RocketMQCollection.Name)]
-public sealed class RocketMQTransactionRecallIntegrationTests
+public sealed class RocketMQTransactionRecallIntegrationTests(RocketMQContainerFixtureRegistry registry)
 {
-    private readonly RocketMQContainerFixture _fixture;
-
-    public RocketMQTransactionRecallIntegrationTests(RocketMQContainerFixture fixture)
-    {
-        _fixture = fixture;
-    }
-
     [Fact]
     [Trait("Category", "Integration")]
     public async Task CommittedTransactionBecomesVisibleToPushConsumer()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Transaction, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("remoting-transaction-consumer");
         var suffix = Guid.NewGuid().ToString("N");
         var tag = $"remoting-transaction-{suffix}";
         var body = $"transaction-{suffix}";
@@ -47,12 +42,12 @@ public sealed class RocketMQTransactionRecallIntegrationTests
         services
             .AddRocketMQRemoting(options =>
             {
-                options.NamesrvAddr = _fixture.NameServerAddress;
+                options.NamesrvAddr = fixture.NameServerAddress;
                 options.InstanceName = $"remoting-transaction-{suffix}";
             })
             .AddRemotingProducer(options =>
             {
-                options.GroupName = $"remoting-transaction-producer-{suffix}";
+                options.GroupName = scope.CreateProducerGroupName("remoting-transaction-producer");
                 options.LocalTransactionExecutor = static (_, _, _) =>
                     ValueTask.FromResult(RemotingTransactionResolution.Commit);
                 options.TransactionChecker = static (_, _) =>
@@ -60,9 +55,9 @@ public sealed class RocketMQTransactionRecallIntegrationTests
             })
             .AddRemotingPushConsumer(options =>
             {
-                options.GroupName = $"remoting-transaction-consumer-{suffix}";
+                options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.TransactionTopic, new FilterExpression(tag));
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
                 options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
@@ -83,7 +78,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests
         try
         {
             var transaction = await producer.SendTransactionAsync(
-                new Message(RocketMQContainerFixture.TransactionTopic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
+                new Message(scope.Topic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
                 cancellationToken: cancellationToken);
 
             Assert.Equal(RemotingTransactionResolution.Commit, transaction.LocalTransactionResolution);
@@ -102,6 +97,9 @@ public sealed class RocketMQTransactionRecallIntegrationTests
     public async Task RecallHandleCancelsDelayedMessageBeforeDelivery()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Delay, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName("remoting-recall-consumer");
         var suffix = Guid.NewGuid().ToString("N");
         var tag = $"remoting-recall-{suffix}";
         var body = $"recall-{suffix}";
@@ -111,15 +109,15 @@ public sealed class RocketMQTransactionRecallIntegrationTests
         services
             .AddRocketMQRemoting(options =>
             {
-                options.NamesrvAddr = _fixture.NameServerAddress;
+                options.NamesrvAddr = fixture.NameServerAddress;
                 options.InstanceName = $"remoting-recall-{suffix}";
             })
-            .AddRemotingProducer(options => options.GroupName = $"remoting-recall-producer-{suffix}")
+            .AddRemotingProducer(options => options.GroupName = scope.CreateProducerGroupName("remoting-recall-producer"))
             .AddRemotingPushConsumer(options =>
             {
-                options.GroupName = $"remoting-recall-consumer-{suffix}";
+                options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.DelayTopic, new FilterExpression(tag));
+                options.Subscribe(scope.Topic, new FilterExpression(tag));
                 options.MessageHandler = (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
@@ -140,7 +138,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests
         try
         {
             var sent = await producer.SendAsync(
-                new Message(RocketMQContainerFixture.DelayTopic, Encoding.UTF8.GetBytes(body))
+                new Message(scope.Topic, Encoding.UTF8.GetBytes(body))
                 {
                     Tag = tag,
                     DeliveryTimestamp = deliveryTimestamp
@@ -150,7 +148,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests
             Assert.Equal(RemotingSendStatus.SendOk, sent.Status);
             var recallHandle = Assert.IsType<string>(sent.RecallHandle);
             var recalledMessageId = await producer.RecallAsync(
-                RocketMQContainerFixture.DelayTopic,
+                scope.Topic,
                 recallHandle,
                 cancellationToken);
 

--- a/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/xunit.runner.json
+++ b/tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 4,
+  "parallelizeTestCollections": true
+}


### PR DESCRIPTION
## Summary
- Run isolated single-Broker test classes in parallel, capped at four collections per integration-test assembly.
- Use unique normal topics and consumer/producer group names while retaining preconfigured special-topic semantics.
- Coordinate every fixture host-port binding so single- and multi-Broker topologies can run together locally.
- Document the concurrency and isolation strategy in English and Simplified Chinese.

## Validation
- dotnet format EventHorizon.RocketMQ.sln --no-restore
- dotnet build EventHorizon.RocketMQ.sln --no-restore
- dotnet test tests/EventHorizon.RocketMQ.Grpc.Tests/EventHorizon.RocketMQ.Grpc.Tests.csproj --no-build --no-restore
- dotnet test tests/EventHorizon.RocketMQ.Remoting.Tests/EventHorizon.RocketMQ.Remoting.Tests.csproj --no-build --no-restore
- dotnet test tests/EventHorizon.RocketMQ.Compatibility.Tests/EventHorizon.RocketMQ.Compatibility.Tests.csproj --no-build --no-restore
- dotnet test tests/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj --no-build --no-restore (9 passed)
- dotnet test tests/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj --no-build --no-restore (18 passed)