### PR TITLE
docs: clarify gRPC telemetry control sessions

### DIFF
--- a/src/EventHorizon.RocketMQ.Grpc/Protocol/Telemetry/GrpcSessionManager.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Protocol/Telemetry/GrpcSessionManager.cs
@@ -21,6 +21,9 @@ using Proto = Apache.Rocketmq.V2;
 
 namespace EventHorizon.RocketMQ.Grpc.Protocol.Telemetry;
 
+/// <summary>
+/// Coordinates the endpoint-scoped RocketMQ Telemetry RPC control sessions for one client role.
+/// </summary>
 internal sealed class GrpcSessionManager : IAsyncDisposable
 {
     private static readonly TimeSpan InitialReconnectDelay = TimeSpan.FromSeconds(1);

--- a/src/EventHorizon.RocketMQ.Grpc/Protocol/Telemetry/GrpcTelemetrySession.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Protocol/Telemetry/GrpcTelemetrySession.cs
@@ -19,6 +19,12 @@ using Proto = Apache.Rocketmq.V2;
 
 namespace EventHorizon.RocketMQ.Grpc.Protocol.Telemetry;
 
+/// <summary>
+/// Maintains one RocketMQ Telemetry RPC control stream for a gRPC endpoint.
+/// </summary>
+/// <remarks>
+/// This protocol session synchronizes client settings and transports server commands; it is not OpenTelemetry instrumentation.
+/// </remarks>
 internal sealed class GrpcTelemetrySession : IGrpcTelemetrySession
 {
     private static readonly Task _never = new TaskCompletionSource(


### PR DESCRIPTION
## Summary
- Clarify that `GrpcTelemetrySession` is RocketMQ Telemetry RPC control traffic, not OpenTelemetry instrumentation.
- Document the endpoint-scoped responsibility of `GrpcSessionManager`.

## Validation
- `dotnet format EventHorizon.RocketMQ.slnx --no-restore --verbosity minimal`
- Telemetry session and manager unit tests on `net8.0` and `net10.0`