### PR TITLE
fix: preserve remoting responses during connection close

### DIFF
--- a/src/EventHorizon.RocketMQ.Remoting/Protocol/RemotingClient.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Protocol/RemotingClient.cs
@@ -130,6 +130,12 @@ internal class RemotingClient : IRemotingClient
                 {
                     await HandleConnectionFailureAsync(endPoint, connection, exception, pending)
                         .ConfigureAwait(false);
+                    // A matching response can arrive before the concurrent receive failure cancels this flush.
+                    if (pending.Completion.Task.IsCompletedSuccessfully)
+                    {
+                        return await pending.Completion.Task.ConfigureAwait(false);
+                    }
+
                     throw;
                 }
 

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/RemotingClientTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/RemotingClientTests.cs
@@ -441,6 +441,44 @@ public sealed class RemotingClientTests
     }
 
     [Fact]
+    public async Task InvokeAsync_ReturnsResponseReceivedBeforePeerClosesDuringSend()
+    {
+        const int BodyLength = 8 * 1024 * 1024;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var server = new LoopbackServer(cancellationToken);
+        var request = CreateRequest("response-before-close");
+        request.Body = GC.AllocateUninitializedArray<byte>(BodyLength);
+        var serverTask = ServeAsync();
+        await using var client = CreateClient();
+
+        var response = await client.InvokeAsync(
+            server.EndPoint,
+            request,
+            OperationTimeout,
+            cancellationToken);
+
+        Assert.Equal(request.Opaque, response.Opaque);
+        Assert.Equal("response-before-close", Encoding.UTF8.GetString(response.Body!));
+        await serverTask;
+
+        async Task ServeAsync()
+        {
+            using var socket = await server.AcceptAsync();
+            socket.ReceiveBufferSize = 1024;
+            var stream = socket.GetStream();
+            var prefix = new byte[1];
+            var received = await stream.ReadAsync(prefix, server.CancellationToken);
+            Assert.Equal(1, received);
+
+            var connection = new CommandConnection(stream);
+            await connection.WriteAsync(
+                CreateResponse(request, "response-before-close"),
+                server.CancellationToken);
+            await Task.Delay(TimeSpan.FromMilliseconds(100), server.CancellationToken);
+        }
+    }
+
+    [Fact]
     public async Task RemoteDisconnect_FailsPendingRequestAndNextRequestReconnects()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/RemotingConnectionTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/RemotingConnectionTests.cs
@@ -96,6 +96,32 @@ public sealed class RemotingConnectionTests
         await connection.DisposeAsync();
     }
 
+    [Fact]
+    public async Task CallerCancellationDuringWrite_FaultsConnectionAndRejectsSubsequentFrames()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var callerCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var stream = new CancellationAwareWriteStream();
+        var connection = new RemotingConnection(stream, new RemoteCommandSerializer());
+        var send = connection.SendAsync(
+            new RemotingCommand
+            {
+                Code = RequestCode.GetRouteInfoByTopic,
+                Body = new byte[4096]
+            },
+            callerCts.Token).AsTask();
+
+        await stream.WriteStarted.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+        callerCts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => send);
+        Assert.False(connection.IsUsable);
+        await Assert.ThrowsAsync<IOException>(() => connection.SendAsync(
+            new RemotingCommand { Code = RequestCode.GetRouteInfoByTopic },
+            CancellationToken.None).AsTask());
+        await connection.DisposeAsync();
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -208,6 +234,50 @@ public sealed class RemotingConnectionTests
             output.GetSpan(sizeof(int));
             output.Advance(sizeof(int));
             throw new InvalidOperationException("simulated buffer writer failure");
+        }
+    }
+
+    private sealed class CancellationAwareWriteStream : Stream
+    {
+        private readonly TaskCompletionSource _writeStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task WriteStarted => _writeStarted.Task;
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            _writeStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve a successfully matched Remoting response when a concurrent peer close aborts the request flush
- continue faulting and disposing the connection so partial writes can never share a stream with later frames
- add deterministic loopback and caller-cancellation regression coverage

## Validation
- dotnet format EventHorizon.RocketMQ.slnx --no-restore --verify-no-changes
- dotnet restore EventHorizon.RocketMQ.slnx
- dotnet build EventHorizon.RocketMQ.slnx --configuration Release --no-restore
- Remoting UT: 327 passed on net8.0 and net10.0
- Remoting IT: 19 passed
- new net10.0 close-during-send regression: 12 consecutive passes; it fails against the previous implementation