### PR TITLE
fix: harden producer and consumer edge cases

### DIFF
--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Lite/GrpcLitePushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Lite/GrpcLitePushConsumer.cs
@@ -74,9 +74,9 @@ internal sealed class GrpcLitePushConsumer : IGrpcLitePushConsumer
                 return;
             }
 
-            Volatile.Write(ref _started, 0);
             await _subscriptions.StopAsync(cancellationToken).ConfigureAwait(false);
             await _dispatcher.StopAsync(cancellationToken).ConfigureAwait(false);
+            Volatile.Write(ref _started, 0);
         }
         finally
         {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
@@ -198,6 +198,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         var receivingCts = _receivingCts!;
         var processingCts = _processingCts!;
         var fifoRetryCts = _fifoRetryCts!;
+        var workersDetached = false;
         receivingCts.Cancel();
         fifoRetryCts.Cancel();
         try
@@ -229,14 +230,8 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 processingCts.Cancel();
-                try
-                {
-                    await Task.WhenAll(_workers).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (processingCts.IsCancellationRequested)
-                {
-                }
-
+                ObserveWorkers(workers, processingCts, fifoRetryCts);
+                workersDetached = true;
                 throw;
             }
             catch (OperationCanceledException) when (processingCts.IsCancellationRequested)
@@ -245,16 +240,23 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         }
         finally
         {
-            processingCts.Cancel();
+            if (!workersDetached)
+            {
+                processingCts.Cancel();
+            }
+
             _messages.Writer.TryComplete();
             try
             {
-                try
+                if (!workersDetached)
                 {
-                    await Task.WhenAll(_workers).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (processingCts.IsCancellationRequested)
-                {
+                    try
+                    {
+                        await Task.WhenAll(_workers).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (processingCts.IsCancellationRequested)
+                    {
+                    }
                 }
             }
             finally
@@ -266,8 +268,13 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 finally
                 {
                     receivingCts.Dispose();
-                    processingCts.Dispose();
-                    fifoRetryCts.Dispose();
+                    // Detached handlers can still register with these tokens while they unwind.
+                    if (!workersDetached)
+                    {
+                        processingCts.Dispose();
+                        fifoRetryCts.Dispose();
+                    }
+
                     _receivingCts = null;
                     _processingCts = null;
                     _fifoRetryCts = null;
@@ -535,7 +542,8 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
 
     private async Task ProcessMessagesAsync(CancellationToken cancellationToken)
     {
-        await foreach (var message in _messages.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        var messages = _messages;
+        await foreach (var message in messages.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
         {
             try
             {
@@ -763,14 +771,21 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 message.ReceiveActivityContext);
             try
             {
-                var execution = fifo
-                    ? new HandlerExecution(
-                        await _messageHandler(message, cancellationToken).ConfigureAwait(false),
-                        false)
-                    : await InvokeConcurrentMessageHandlerAsync(
+                HandlerExecution execution;
+                if (fifo)
+                {
+                    var handlerResult = await _messageHandler(message, cancellationToken).ConfigureAwait(false);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    execution = new HandlerExecution(handlerResult, false);
+                }
+                else
+                {
+                    execution = await InvokeConcurrentMessageHandlerAsync(
                         message,
                         renewalCts,
                         cancellationToken).ConfigureAwait(false);
+                }
+
                 result = execution.Result;
                 telemetry.Complete(
                     result == ConsumeResult.Success,
@@ -837,7 +852,9 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             timeoutCancellation.Cancel();
             if (handlerTask.IsCompleted)
             {
-                return new HandlerExecution(await handlerTask.ConfigureAwait(false), false);
+                var handlerResult = await handlerTask.ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                return new HandlerExecution(handlerResult, false);
             }
 
             if (cancellationToken.IsCancellationRequested)
@@ -895,6 +912,35 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         finally
         {
             handlerCancellation.Dispose();
+        }
+    }
+
+    private void ObserveWorkers(
+        Task workers,
+        CancellationTokenSource processingCts,
+        CancellationTokenSource fifoRetryCts) =>
+        _ = ObserveWorkersAsync(workers, processingCts, fifoRetryCts);
+
+    private async Task ObserveWorkersAsync(
+        Task workers,
+        CancellationTokenSource processingCts,
+        CancellationTokenSource fifoRetryCts)
+    {
+        try
+        {
+            await workers.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception exception)
+        {
+            _logger.LogDebug(exception, "A message worker completed with an exception after consumer shutdown was canceled");
+        }
+        finally
+        {
+            processingCts.Dispose();
+            fifoRetryCts.Dispose();
         }
     }
 

--- a/src/EventHorizon.RocketMQ.Grpc/Producer/GrpcProducer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Producer/GrpcProducer.cs
@@ -46,6 +46,7 @@ internal sealed class GrpcProducer : IGrpcProducer
     private readonly HashSet<string> _declaredTopics;
     private readonly HashSet<string> _topics;
     private readonly object _topicsGate = new();
+    private readonly SemaphoreSlim _topicSettingsGate = new(1, 1);
     private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
     private int _started;
     private int _disposed;
@@ -316,7 +317,7 @@ internal sealed class GrpcProducer : IGrpcProducer
 
                     if (isNewTopic)
                     {
-                        await sessions.SyncSettingsAsync(settings, cancellationToken).ConfigureAwait(false);
+                        await SyncTopicSettingsAsync(sessions, cancellationToken).ConfigureAwait(false);
                         isNewTopic = false;
                     }
 
@@ -437,7 +438,7 @@ internal sealed class GrpcProducer : IGrpcProducer
         await sessions.EnsureAsync(new[] { endpoint }, settings, cancellationToken).ConfigureAwait(false);
         if (isNewTopic)
         {
-            await sessions.SyncSettingsAsync(settings, cancellationToken).ConfigureAwait(false);
+            await SyncTopicSettingsAsync(sessions, cancellationToken).ConfigureAwait(false);
         }
 
         var response = await _client.RecallMessageAsync(endpoint, new Proto.RecallMessageRequest
@@ -646,6 +647,19 @@ internal sealed class GrpcProducer : IGrpcProducer
             Topics = { topics.Select(Resource) }
         };
         return settings;
+    }
+
+    private async Task SyncTopicSettingsAsync(GrpcSessionManager sessions, CancellationToken cancellationToken)
+    {
+        await _topicSettingsGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await sessions.SyncSettingsAsync(BuildSettings(), cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _topicSettingsGate.Release();
+        }
     }
 
     private Proto.Settings BaseSettings(Proto.ClientType clientType) => new()

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
@@ -134,7 +134,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             catch
             {
                 _run = null;
-                await ShutdownRunAsync(run).ConfigureAwait(false);
+                await ShutdownRunAsync(run, CancellationToken.None).ConfigureAwait(false);
                 throw;
             }
         }
@@ -156,7 +156,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             }
 
             _run = null;
-            await ShutdownRunAsync(run).ConfigureAwait(false);
+            await ShutdownRunAsync(run, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -992,6 +992,11 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
 
                 var outcomes = await Task.WhenAll(pending.Select(static delivery => delivery.Completion.Task))
                     .WaitAsync(cancellationToken).ConfigureAwait(false);
+                if (run.ShouldAbandonHandlerResults)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
                 if (_options.ConsumerMode == ConsumerMode.Broadcasting)
                 {
                     for (var index = 0; index < outcomes.Length; index++)
@@ -1153,6 +1158,11 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                         receiver,
                         message,
                         cancellationToken).ConfigureAwait(false);
+                    if (run.ShouldAbandonHandlerResults)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     if (outcome == OrderlyDeliveryOutcome.LeaseLost)
                     {
                         completed = false;
@@ -1240,8 +1250,14 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             await run.OrderlyConcurrency.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                result = (await InvokeMessageHandlerAsync(new[] { message }, cancellationToken).ConfigureAwait(false))
-                    .Result;
+                var batchResult = await InvokeMessageHandlerAsync(run, new[] { message }, cancellationToken)
+                    .ConfigureAwait(false);
+                if (run.ShouldAbandonHandlerResults)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                result = batchResult.Result;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1501,8 +1517,13 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                         }
 
                         var result = UsesConcurrentTimeoutRecovery(batch)
-                            ? await InvokeConcurrentDeliveryBatchAsync(batch, linked.Token).ConfigureAwait(false)
-                            : await HandleDeliveryBatchAsync(batch, linked.Token).ConfigureAwait(false);
+                            ? await InvokeConcurrentDeliveryBatchAsync(run, batch, linked.Token).ConfigureAwait(false)
+                            : await HandleDeliveryBatchAsync(run, batch, linked.Token).ConfigureAwait(false);
+                        if (run.ShouldAbandonHandlerResults)
+                        {
+                            linked.Token.ThrowIfCancellationRequested();
+                        }
+
                         for (var index = 0; index < batch.Deliveries.Count; index++)
                         {
                             batch.Deliveries[index].Completion.TrySetResult(result.GetOutcome(index));
@@ -1548,21 +1569,24 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
     }
 
     private async ValueTask<BatchDeliveryResult> HandleDeliveryBatchAsync(
+        RunState run,
         DeliveryBatch batch,
         CancellationToken cancellationToken)
     {
         if (batch.Deliveries.Count == 1)
         {
-            var outcome = await HandleMessageAsync(batch.Deliveries[0], cancellationToken).ConfigureAwait(false);
+            var outcome = await HandleMessageAsync(run, batch.Deliveries[0], cancellationToken).ConfigureAwait(false);
             return BatchDeliveryResult.All(outcome.Result, 1, outcome.DelayLevelWhenNextConsume);
         }
 
         return await InvokeMessageHandlerAsync(
+            run,
             batch.Deliveries.Select(static delivery => delivery.Message).ToArray(),
             cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask<MessageConsumeResult> HandleMessageAsync(
+        RunState run,
         Delivery delivery,
         CancellationToken cancellationToken)
     {
@@ -1573,6 +1597,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             try
             {
                 var batchResult = await InvokeMessageHandlerAsync(
+                    run,
                     new[] { delivery.Message },
                     cancellationToken).ConfigureAwait(false);
                 outcome = delivery.FifoOrder is null
@@ -1609,6 +1634,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
     }
 
     private ValueTask<BatchDeliveryResult> InvokeMessageHandlerAsync(
+        RunState run,
         IReadOnlyList<RemotingMessageView> messages,
         CancellationToken cancellationToken)
     {
@@ -1617,6 +1643,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
             messages,
             context,
             cancellationToken,
+            run,
             StartMessageHandlerTelemetry(messages));
     }
 
@@ -1630,11 +1657,17 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         IReadOnlyList<RemotingMessageView> messages,
         RemotingPushConsumeContext context,
         CancellationToken cancellationToken,
+        RunState run,
         MessageHandlerTelemetry telemetry)
     {
         try
         {
             var result = await _messageHandler(messages, context, cancellationToken).ConfigureAwait(false);
+            if (run.ShouldAbandonHandlerResults)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
             var batchResult = BatchDeliveryResult.Create(
                 result,
                 context.AckIndex,
@@ -1660,6 +1693,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         batch.Deliveries.All(static delivery => delivery.FifoOrder is null);
 
     private async ValueTask<BatchDeliveryResult> InvokeConcurrentDeliveryBatchAsync(
+        RunState run,
         DeliveryBatch batch,
         CancellationToken cancellationToken)
     {
@@ -1675,6 +1709,7 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                 messages,
                 context,
                 activeHandlerCancellation.Token,
+                run,
                 telemetry);
             if (handler.IsCompletedSuccessfully)
             {
@@ -1750,21 +1785,36 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         }
     }
 
-    private async Task ShutdownRunAsync(RunState run)
+    private async Task ShutdownRunAsync(RunState run, CancellationToken cancellationToken)
     {
+        using var abandonHandlerResultsRegistration = cancellationToken.Register(run.AbandonHandlerResults);
+        Task? detachedTasks = null;
+        QueueReceiver[] receivers = [];
         run.Stopping.Cancel();
         SignalRebalance(run);
         run.Deliveries.Writer.TryComplete();
         await AwaitTaskAsync(run.Coordinator).ConfigureAwait(false);
 
-        var receivers = run.Receivers.Values.ToArray();
+        receivers = run.Receivers.Values.ToArray();
         foreach (var receiver in receivers)
         {
             receiver.Stopping.Cancel();
         }
 
-        await AwaitReceiversAsync(receivers).ConfigureAwait(false);
-        await AwaitTasksAsync(run.Workers).ConfigureAwait(false);
+        var activeTasks = receivers
+            .Select(static receiver => receiver.Task)
+            .Concat(run.Workers)
+            .ToArray();
+        try
+        {
+            await AwaitTasksAsync(activeTasks, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            run.AbandonHandlerResults();
+            detachedTasks = Task.WhenAll(activeTasks);
+        }
+
         if (UsesBrokerQueueLocks && receivers.Length > 0)
         {
             await UnlockQueuesAsync(
@@ -1785,12 +1835,19 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         {
             await _consumerEngine.StopAsync(CancellationToken.None).ConfigureAwait(false);
 
-            foreach (var receiver in receivers)
+            if (detachedTasks is null)
             {
-                receiver.Dispose();
+                DisposeRunResources(run, receivers);
             }
+            else
+            {
+                ObserveDetachedWorkers(run, receivers, detachedTasks);
+            }
+        }
 
-            run.Dispose();
+        if (detachedTasks is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
         }
     }
 
@@ -1893,23 +1950,66 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
     private static async Task AwaitReceiversAsync(IEnumerable<QueueReceiver> receivers) =>
         await AwaitTasksAsync(receivers.Select(static receiver => receiver.Task)).ConfigureAwait(false);
 
-    private static async Task AwaitTasksAsync(IEnumerable<Task> tasks)
+    private static async Task AwaitTasksAsync(
+        IEnumerable<Task> tasks,
+        CancellationToken cancellationToken = default)
     {
         foreach (var task in tasks)
         {
-            await AwaitTaskAsync(task).ConfigureAwait(false);
+            await AwaitTaskAsync(task, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    private static async Task AwaitTaskAsync(Task task)
+    private static async Task AwaitTaskAsync(Task task, CancellationToken cancellationToken = default)
     {
         try
         {
-            await task.ConfigureAwait(false);
+            if (cancellationToken.CanBeCanceled)
+            {
+                await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await task.ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private void ObserveDetachedWorkers(RunState run, QueueReceiver[] receivers, Task workers) =>
+        _ = ObserveDetachedWorkersAsync(run, receivers, workers);
+
+    private async Task ObserveDetachedWorkersAsync(RunState run, QueueReceiver[] receivers, Task workers)
+    {
+        try
+        {
+            await workers.ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
         }
+        catch (Exception exception)
+        {
+            _logger.LogDebug(
+                exception,
+                "A legacy message processing task completed with an exception after consumer shutdown was canceled");
+        }
+        finally
+        {
+            DisposeRunResources(run, receivers);
+        }
+    }
+
+    private static void DisposeRunResources(RunState run, IEnumerable<QueueReceiver> receivers)
+    {
+        foreach (var receiver in receivers)
+        {
+            receiver.Dispose();
+        }
+
+        run.Dispose();
     }
 
     private static int GetDelayLevel(TimeSpan delay)
@@ -1976,9 +2076,14 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
 
         private object FifoGate { get; } = new();
         private Dictionary<string, Task> FifoTails { get; } = new(StringComparer.Ordinal);
+        private int _abandonHandlerResults;
         private long _subscriptionVersion;
 
         public void BumpSubscriptionVersion() => Interlocked.Increment(ref _subscriptionVersion);
+
+        public bool ShouldAbandonHandlerResults => Volatile.Read(ref _abandonHandlerResults) != 0;
+
+        public void AbandonHandlerResults() => Interlocked.Exchange(ref _abandonHandlerResults, 1);
 
         public async ValueTask ReserveDeliverySlotsAsync(int count, CancellationToken cancellationToken)
         {

--- a/src/EventHorizon.RocketMQ.Remoting/Producer/RemotingProducer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Producer/RemotingProducer.cs
@@ -636,6 +636,18 @@ internal sealed class RemotingProducer : IRemotingProducer
             {
                 throw;
             }
+            catch (RemotingCommandException exception) when (
+                IsRetryableResponse(exception.ResponseCode) &&
+                attempt + 1 < attempts)
+            {
+                lastException = exception;
+                _logger.LogWarning(
+                    exception,
+                    "Failed to send message to broker {BrokerName}; retrying attempt {Attempt} of {Attempts}",
+                    lastBroker,
+                    attempt + 2,
+                    attempts);
+            }
             catch (RemotingCommandException)
             {
                 throw;

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Lite/GrpcLitePushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Lite/GrpcLitePushConsumerTests.cs
@@ -468,6 +468,63 @@ public sealed class GrpcLitePushConsumerTests
     }
 
     [Fact]
+    public async Task LitePushConsumer_RetriesStopAfterSubscriptionManagerCancellation()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var endpoint = new Uri("http://127.0.0.1:8081");
+        var subscriptionSynchronizationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSubscriptionSynchronization = new TaskCompletionSource<Proto.SyncLiteSubscriptionResponse>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var synchronizationCalls = 0;
+        var client = new Mock<IRocketMQGrpcClient>(MockBehavior.Strict);
+        client
+            .Setup(value => value.SyncLiteSubscriptionAsync(
+                endpoint,
+                It.IsAny<Proto.SyncLiteSubscriptionRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref synchronizationCalls) == 2)
+                {
+                    subscriptionSynchronizationStarted.TrySetResult();
+                    return releaseSubscriptionSynchronization.Task;
+                }
+
+                return Task.FromResult(new Proto.SyncLiteSubscriptionResponse { Status = OkStatus() });
+            });
+        var manager = CreateManager(client.Object, CreateRouteService(endpoint));
+        var dispatcher = new Mock<IGrpcPushConsumer>(MockBehavior.Strict);
+        dispatcher.Setup(value => value.StartAsync(cancellationToken)).Returns(ValueTask.CompletedTask);
+        dispatcher.Setup(value => value.StopAsync(CancellationToken.None)).Returns(ValueTask.CompletedTask);
+        dispatcher.Setup(value => value.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        var consumer = new GrpcLitePushConsumer(dispatcher.Object, manager);
+
+        try
+        {
+            await consumer.StartAsync(cancellationToken);
+            var subscribe = consumer.SubscribeLiteAsync("alpha", cancellationToken: cancellationToken);
+            await subscriptionSynchronizationStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+            using var stopCancellation = new CancellationTokenSource();
+            var canceledStop = consumer.StopAsync(stopCancellation.Token).AsTask();
+            Assert.False(canceledStop.IsCompleted);
+            stopCancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledStop);
+
+            releaseSubscriptionSynchronization.TrySetResult(new Proto.SyncLiteSubscriptionResponse { Status = OkStatus() });
+            await subscribe.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            await consumer.StopAsync(CancellationToken.None);
+
+            dispatcher.Verify(value => value.StopAsync(CancellationToken.None), Times.Once);
+        }
+        finally
+        {
+            releaseSubscriptionSynchronization.TrySetResult(new Proto.SyncLiteSubscriptionResponse { Status = OkStatus() });
+            await consumer.DisposeAsync();
+        }
+    }
+
+    [Fact]
     public async Task LitePushConsumer_StopsTheDispatcherWhenSubscriptionStartupFails()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
@@ -673,6 +673,75 @@ public sealed class GrpcPushConsumerTests
     }
 
     [Fact]
+    public async Task StopAsync_CancelsNonCooperativeFifoHandlerAndIgnoresLateSuccess()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var queue = Queue();
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var receiveCalls = 0;
+        var client = new FakeGrpcClient
+        {
+            QueryAssignmentHandler = (_, _) => Task.FromResult(AssignmentResponse(queue)),
+            ReceiveHandler = async (_, _, receiverCancellationToken) =>
+            {
+                if (Interlocked.Increment(ref receiveCalls) == 1)
+                {
+                    return
+                    [
+                        new Proto.ReceiveMessageResponse { Message = ProtoMessage("first", "account-7") },
+                        ReceiveStatus(Proto.Code.Ok)
+                    ];
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, receiverCancellationToken);
+                return [];
+            }
+        };
+        var consumer = CreateConsumer(
+            client,
+            async (_, handlerCancellationToken) =>
+            {
+                handlerStarted.TrySetResult();
+                await releaseHandler.Task.ConfigureAwait(false);
+                using var registration = handlerCancellationToken.Register(static () => { });
+                return ConsumeResult.Success;
+            },
+            options => options.MaxConcurrency = 1,
+            CreateRouteService(queue));
+        Task? worker = null;
+
+        try
+        {
+            await consumer.StartAsync(cancellationToken);
+            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            var workersField = typeof(GrpcPushConsumer).GetField("_workers", BindingFlags.Instance | BindingFlags.NonPublic);
+            worker = Assert.Single(Assert.IsType<Task[]>(workersField?.GetValue(consumer)));
+
+            using var stopCancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => consumer.StopAsync(stopCancellation.Token).AsTask()
+                    .WaitAsync(TimeSpan.FromSeconds(3), cancellationToken));
+
+            await consumer.StartAsync(cancellationToken);
+            releaseHandler.TrySetResult();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => worker.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken));
+
+            Assert.Empty(client.AckRequests);
+            Assert.Empty(client.ChangeInvisibleRequests);
+            Assert.Empty(client.DeadLetterRequests);
+
+            await consumer.StopAsync(cancellationToken);
+        }
+        finally
+        {
+            releaseHandler.TrySetResult();
+            await consumer.DisposeAsync();
+        }
+    }
+
+    [Fact]
     public async Task ConcurrentMessageTimeout_CancelsHandlerRequestsRetryAndIgnoresLateSuccess()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Producer/GrpcProducerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Producer/GrpcProducerTests.cs
@@ -154,6 +154,80 @@ public sealed class GrpcProducerTests
     }
 
     [Fact]
+    public async Task SendAsync_ConcurrentNewTopicsKeepEveryTopicInTelemetrySettings()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var firstSettingsRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstSettingsRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var settingsUpdates = new ConcurrentQueue<Proto.Settings>();
+        var serverSettingsReads = 0;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var session = new Mock<IGrpcTelemetrySession>(MockBehavior.Strict);
+        session
+            .SetupGet(value => value.ServerSettings)
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref serverSettingsReads) == 1)
+                {
+                    firstSettingsRead.TrySetResult();
+                    releaseFirstSettingsRead.Task.GetAwaiter().GetResult();
+                }
+
+                return null;
+            });
+        session.SetupGet(value => value.Completion).Returns(completion.Task);
+        session
+            .Setup(value => value.WriteSettingsAsync(
+                It.IsAny<Proto.Settings>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Proto.Settings, CancellationToken>((settings, _) => settingsUpdates.Enqueue(settings.Clone()))
+            .Returns(Task.CompletedTask);
+        session
+            .Setup(value => value.WriteCommandAsync(
+                It.IsAny<Proto.TelemetryCommand>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        session
+            .Setup(value => value.DisposeAsync())
+            .Callback(() => completion.TrySetResult())
+            .Returns(ValueTask.CompletedTask);
+        var client = new FakeGrpcClient
+        {
+            OpenTelemetryHandler = _ => Task.FromResult(session.Object)
+        };
+        var options = new GrpcProducerOptions
+        {
+            RetryTimesWhenSendFailed = 0,
+            TransactionChecker = static (_, _) => ValueTask.FromResult(TransactionResolution.Unknown)
+        };
+        await using var producer = CreateProducer(client, options);
+        await producer.StartAsync(cancellationToken);
+
+        var firstSend = Task.Run(async () => await producer.SendAsync(
+            new Message("alpha", [1]), cancellationToken).ConfigureAwait(false));
+        await firstSettingsRead.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+        try
+        {
+            await producer.SendAsync(new Message("beta", [2]), cancellationToken);
+        }
+        finally
+        {
+            releaseFirstSettingsRead.TrySetResult();
+        }
+
+        await firstSend.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+        var updates = settingsUpdates.ToArray();
+        Assert.Equal(2, updates.Length);
+        Assert.All(
+            updates,
+            settings => Assert.Equal(
+                ["alpha", "beta"],
+                settings.Publishing.Topics.Select(static topic => topic.Name).OrderBy(static topic => topic)));
+    }
+
+    [Fact]
     public async Task SendAsync_RetryExcludesEveryQueueOnFailedBroker()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Protocol/RocketMQGrpcClientTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Protocol/RocketMQGrpcClientTests.cs
@@ -1,0 +1,178 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Net.Sockets;
+using EventHorizon.RocketMQ.Grpc.Protocol;
+using Grpc.Core;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Proto = Apache.Rocketmq.V2;
+
+namespace EventHorizon.RocketMQ.Grpc.Tests.Protocol;
+
+public sealed class RocketMQGrpcClientTests
+{
+    [Fact]
+    public async Task QueryRouteAsync_TriesEveryAccessPointAfterTransientFailure()
+    {
+        var firstListener = StartListener();
+        var secondListener = StartListener();
+        var firstConnections = 0;
+        var secondConnections = 0;
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var firstRejector = RejectConnectionsAsync(
+            firstListener,
+            () => Interlocked.Increment(ref firstConnections),
+            cancellationTokenSource.Token);
+        var secondRejector = RejectConnectionsAsync(
+            secondListener,
+            () => Interlocked.Increment(ref secondConnections),
+            cancellationTokenSource.Token);
+        await using var client = CreateClient(firstListener, secondListener);
+
+        try
+        {
+            var exception = await Assert.ThrowsAsync<RpcException>(() => client.QueryRouteAsync(
+                new Proto.QueryRouteRequest(),
+                TestContext.Current.CancellationToken));
+
+            Assert.True(exception.StatusCode is StatusCode.Unavailable or StatusCode.Internal);
+            Assert.True(Volatile.Read(ref firstConnections) > 0);
+            Assert.True(Volatile.Read(ref secondConnections) > 0);
+        }
+        finally
+        {
+            cancellationTokenSource.Cancel();
+            firstListener.Stop();
+            secondListener.Stop();
+            await Task.WhenAll(firstRejector, secondRejector);
+        }
+    }
+
+    [Fact]
+    public async Task EndpointOperations_PropagateTransportFailure()
+    {
+        var listener = StartListener();
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var rejector = RejectConnectionsAsync(listener, static () => { }, cancellationTokenSource.Token);
+        await using var client = CreateClient(listener);
+        var endpoint = new Uri($"http://127.0.0.1:{((IPEndPoint)listener.LocalEndpoint).Port}");
+
+        try
+        {
+            await AssertTransportFailureAsync(() => client.SendMessageAsync(
+                endpoint,
+                new Proto.SendMessageRequest(),
+                TimeSpan.FromSeconds(1),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.QueryAssignmentAsync(
+                endpoint,
+                new Proto.QueryAssignmentRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.ReceiveMessageAsync(
+                endpoint,
+                new Proto.ReceiveMessageRequest(),
+                TimeSpan.FromSeconds(1),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.AckMessageAsync(
+                endpoint,
+                new Proto.AckMessageRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.ChangeInvisibleDurationAsync(
+                endpoint,
+                new Proto.ChangeInvisibleDurationRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.ForwardToDeadLetterQueueAsync(
+                endpoint,
+                new Proto.ForwardMessageToDeadLetterQueueRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.EndTransactionAsync(
+                endpoint,
+                new Proto.EndTransactionRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.HeartbeatAsync(
+                endpoint,
+                new Proto.HeartbeatRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.NotifyTerminationAsync(
+                endpoint,
+                new Proto.NotifyClientTerminationRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.RecallMessageAsync(
+                endpoint,
+                new Proto.RecallMessageRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.SyncLiteSubscriptionAsync(
+                endpoint,
+                new Proto.SyncLiteSubscriptionRequest(),
+                TestContext.Current.CancellationToken));
+            await AssertTransportFailureAsync(() => client.OpenTelemetryAsync(
+                endpoint,
+                new Proto.Settings(),
+                null,
+                TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            cancellationTokenSource.Cancel();
+            listener.Stop();
+            await rejector;
+        }
+    }
+
+    private static RocketMQGrpcClient CreateClient(params TcpListener[] listeners)
+    {
+        var options = Options.Create(new GrpcClientOptions
+        {
+            Endpoint = string.Join(';', listeners.Select(static listener =>
+                $"127.0.0.1:{((IPEndPoint)listener.LocalEndpoint).Port}")),
+            RequestTimeout = TimeSpan.FromSeconds(1)
+        });
+        return new RocketMQGrpcClient(options, new GrpcMetadataFactory(options, "test"));
+    }
+
+    private static TcpListener StartListener()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return listener;
+    }
+
+    private static async Task AssertTransportFailureAsync<T>(Func<Task<T>> operation)
+    {
+        var exception = await Assert.ThrowsAsync<RpcException>(async () => await operation());
+
+        Assert.True(exception.StatusCode is StatusCode.Unavailable or StatusCode.Internal);
+    }
+
+    private static async Task RejectConnectionsAsync(
+        TcpListener listener,
+        Action connectionAccepted,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (true)
+            {
+                using var connection = await listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                connectionAccepted();
+            }
+        }
+        catch (Exception) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+}

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Protocol/Telemetry/GrpcSessionManagerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Protocol/Telemetry/GrpcSessionManagerTests.cs
@@ -198,6 +198,53 @@ public sealed class GrpcSessionManagerTests
     }
 
     [Fact]
+    public async Task ReconnectCommandReceivedDuringSessionOpening_IsHonoredAfterRegistration()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var endpoint = new Uri("http://127.0.0.1:8081");
+        var first = CreateSession();
+        var replacement = CreateSession();
+        var replacementOpened = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var openCalls = 0;
+        var client = CreateClient();
+        client
+            .Setup(value => value.OpenTelemetryAsync(
+                endpoint,
+                It.IsAny<Proto.Settings>(),
+                It.IsAny<Func<Proto.TelemetryCommand, CancellationToken, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Uri, Proto.Settings, Func<Proto.TelemetryCommand, CancellationToken, Task>?, CancellationToken>(
+                async (_, _, handler, token) =>
+                {
+                    if (Interlocked.Increment(ref openCalls) == 1)
+                    {
+                        var commandHandler = Assert.IsType<Func<Proto.TelemetryCommand, CancellationToken, Task>>(handler);
+                        await commandHandler(new Proto.TelemetryCommand
+                        {
+                            ReconnectEndpointsCommand = new Proto.ReconnectEndpointsCommand { Nonce = "reconnect-queued" }
+                        }, token);
+                        return first.Session.Object;
+                    }
+
+                    replacementOpened.TrySetResult();
+                    return replacement.Session.Object;
+                });
+        client
+            .Setup(value => value.NotifyTerminationAsync(
+                endpoint,
+                It.IsAny<Proto.NotifyClientTerminationRequest>(),
+                CancellationToken.None))
+            .ReturnsAsync(OkTerminationResponse());
+        await using var manager = CreateManager(client.Object, "orders", null);
+
+        await manager.EnsureAsync([endpoint], new Proto.Settings(), cancellationToken);
+        await replacementOpened.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+        Assert.Equal(2, Volatile.Read(ref openCalls));
+        first.Session.Verify(value => value.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
     public async Task SessionFailure_ReplacesTheTelemetrySession()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -232,6 +279,48 @@ public sealed class GrpcSessionManagerTests
         await replacementOpened.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
 
         first.Session.Verify(value => value.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task FailedSessionReplacement_IsCancelledWhenTheManagerIsDisposed()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var endpoint = new Uri("http://127.0.0.1:8081");
+        var first = CreateSession();
+        var replacementAttempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var openCalls = 0;
+        var client = CreateClient();
+        client
+            .Setup(value => value.OpenTelemetryAsync(
+                endpoint,
+                It.IsAny<Proto.Settings>(),
+                It.IsAny<Func<Proto.TelemetryCommand, CancellationToken, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Uri, Proto.Settings, Func<Proto.TelemetryCommand, CancellationToken, Task>?, CancellationToken>(
+                (_, _, _, _) =>
+                {
+                    if (Interlocked.Increment(ref openCalls) == 1)
+                    {
+                        return Task.FromResult<IGrpcTelemetrySession>(first.Session.Object);
+                    }
+
+                    replacementAttempted.TrySetResult();
+                    return Task.FromException<IGrpcTelemetrySession>(new IOException("telemetry unavailable"));
+                });
+        client
+            .Setup(value => value.NotifyTerminationAsync(
+                endpoint,
+                It.IsAny<Proto.NotifyClientTerminationRequest>(),
+                CancellationToken.None))
+            .ReturnsAsync(OkTerminationResponse());
+        await using var manager = CreateManager(client.Object, "orders", null);
+
+        await manager.EnsureAsync([endpoint], new Proto.Settings(), cancellationToken);
+        first.Completion.TrySetResult();
+        await replacementAttempted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await manager.DisposeAsync();
+
+        Assert.Equal(2, Volatile.Read(ref openCalls));
     }
 
     [Fact]
@@ -277,6 +366,108 @@ public sealed class GrpcSessionManagerTests
         Assert.Equal(Proto.ClientType.Producer, heartbeat.ClientType);
         Assert.Equal("orders", heartbeat.Group.Name);
         Assert.Equal("tenant-a", heartbeat.Group.ResourceNamespace);
+    }
+
+    [Fact]
+    public async Task Start_ContinuesAfterAHeartbeatFailure()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var endpoint = new Uri("http://127.0.0.1:8081");
+        var telemetry = CreateSession();
+        var heartbeatSucceeded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var heartbeatAttempts = 0;
+        var client = CreateClient();
+        client
+            .Setup(value => value.OpenTelemetryAsync(
+                endpoint,
+                It.IsAny<Proto.Settings>(),
+                It.IsAny<Func<Proto.TelemetryCommand, CancellationToken, Task>>(),
+                cancellationToken))
+            .ReturnsAsync(telemetry.Session.Object);
+        client
+            .Setup(value => value.HeartbeatAsync(
+                endpoint,
+                It.IsAny<Proto.HeartbeatRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Uri, Proto.HeartbeatRequest, CancellationToken>((_, _, _) =>
+            {
+                if (Interlocked.Increment(ref heartbeatAttempts) == 1)
+                {
+                    return Task.FromException<Proto.HeartbeatResponse>(new IOException("heartbeat unavailable"));
+                }
+
+                heartbeatSucceeded.TrySetResult();
+                return Task.FromResult(new Proto.HeartbeatResponse { Status = OkStatus() });
+            });
+        client
+            .Setup(value => value.NotifyTerminationAsync(
+                endpoint,
+                It.IsAny<Proto.NotifyClientTerminationRequest>(),
+                CancellationToken.None))
+            .ReturnsAsync(OkTerminationResponse());
+        await using var manager = CreateManager(
+            client.Object,
+            "orders",
+            null,
+            heartbeatInterval: TimeSpan.FromMilliseconds(10));
+
+        manager.Start();
+        await manager.EnsureAsync([endpoint], new Proto.Settings(), cancellationToken);
+        await heartbeatSucceeded.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+        Assert.True(Volatile.Read(ref heartbeatAttempts) >= 2);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsAnInFlightHeartbeat()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var endpoint = new Uri("http://127.0.0.1:8081");
+        var telemetry = CreateSession();
+        var heartbeatStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = CreateClient();
+        client
+            .Setup(value => value.OpenTelemetryAsync(
+                endpoint,
+                It.IsAny<Proto.Settings>(),
+                It.IsAny<Func<Proto.TelemetryCommand, CancellationToken, Task>>(),
+                cancellationToken))
+            .ReturnsAsync(telemetry.Session.Object);
+        client
+            .Setup(value => value.HeartbeatAsync(
+                endpoint,
+                It.IsAny<Proto.HeartbeatRequest>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Uri, Proto.HeartbeatRequest, CancellationToken>((_, _, token) =>
+            {
+                heartbeatStarted.TrySetResult();
+                return WaitForHeartbeatCancellationAsync(token);
+            });
+        client
+            .Setup(value => value.NotifyTerminationAsync(
+                endpoint,
+                It.IsAny<Proto.NotifyClientTerminationRequest>(),
+                CancellationToken.None))
+            .ReturnsAsync(OkTerminationResponse());
+        await using var manager = CreateManager(
+            client.Object,
+            "orders",
+            null,
+            heartbeatInterval: TimeSpan.FromMilliseconds(10));
+
+        manager.Start();
+        await manager.EnsureAsync([endpoint], new Proto.Settings(), cancellationToken);
+        await heartbeatStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await manager.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task GetServerSettings_ReturnsNullWhenTheEndpointHasNoSession()
+    {
+        var client = CreateClient();
+        await using var manager = CreateManager(client.Object, "orders", null);
+
+        Assert.Null(manager.GetServerSettings(new Uri("http://127.0.0.1:8081")));
     }
 
     private static Mock<IRocketMQGrpcClient> CreateClient() => new(MockBehavior.Strict);
@@ -346,6 +537,13 @@ public sealed class GrpcSessionManagerTests
     {
         replacementOpened.TrySetResult();
         return session;
+    }
+
+    private static async Task<Proto.HeartbeatResponse> WaitForHeartbeatCancellationAsync(
+        CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        return new Proto.HeartbeatResponse { Status = OkStatus() };
     }
 
     private static Proto.Status OkStatus() => new() { Code = Proto.Code.Ok };

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Protocol/Telemetry/GrpcTelemetrySessionTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Protocol/Telemetry/GrpcTelemetrySessionTests.cs
@@ -26,6 +26,16 @@ namespace EventHorizon.RocketMQ.Grpc.Tests.Protocol.Telemetry;
 public sealed class GrpcTelemetrySessionTests
 {
     [Fact]
+    public async Task Completion_IsIncompleteBeforeTheSessionStarts()
+    {
+        var responses = new ChannelStreamReader<Proto.TelemetryCommand>();
+        var requests = CreateRequestWriter(new ConcurrentQueue<Proto.TelemetryCommand>());
+        await using var session = new GrpcTelemetrySession(CreateCall(requests.Object, responses), null);
+
+        Assert.False(session.Completion.IsCompleted);
+    }
+
+    [Fact]
     public async Task SessionOutlivesInitializationTokenAndHonorsReconnectCommand()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -70,6 +80,116 @@ public sealed class GrpcTelemetrySessionTests
         }, cancellationToken);
         await session.Completion.WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
         await session.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
+    }
+
+    [Fact]
+    public async Task StartAsync_FailsWhenTheTelemetryStreamClosesBeforeSettings()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var responses = new ChannelStreamReader<Proto.TelemetryCommand>();
+        responses.Complete();
+        var requests = CreateRequestWriter(new ConcurrentQueue<Proto.TelemetryCommand>());
+        await using var session = new GrpcTelemetrySession(CreateCall(requests.Object, responses), null);
+
+        var exception = await Assert.ThrowsAsync<RpcException>(() => session.StartAsync(
+            new Proto.Settings(),
+            TimeSpan.FromSeconds(1),
+            cancellationToken));
+
+        Assert.Equal(StatusCode.Unavailable, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IgnoresUnavailableReaderFailure()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var responses = new SequenceStreamReader<Proto.TelemetryCommand>(
+            new Proto.TelemetryCommand { Settings = new Proto.Settings() },
+            new RpcException(new Status(StatusCode.Unavailable, "telemetry closed")));
+        var requests = CreateRequestWriter(new ConcurrentQueue<Proto.TelemetryCommand>());
+        await using var session = new GrpcTelemetrySession(CreateCall(requests.Object, responses), null);
+
+        await session.StartAsync(new Proto.Settings(), TimeSpan.FromSeconds(1), cancellationToken);
+        var exception = await Assert.ThrowsAsync<RpcException>(() => session.Completion);
+        await session.DisposeAsync();
+
+        Assert.Equal(StatusCode.Unavailable, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IgnoresCancelledReaderFailure()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var responses = new SequenceStreamReader<Proto.TelemetryCommand>(
+            new Proto.TelemetryCommand { Settings = new Proto.Settings() },
+            new OperationCanceledException("telemetry cancelled"));
+        var requests = CreateRequestWriter(new ConcurrentQueue<Proto.TelemetryCommand>());
+        await using var session = new GrpcTelemetrySession(CreateCall(requests.Object, responses), null);
+
+        await session.StartAsync(new Proto.Settings(), TimeSpan.FromSeconds(1), cancellationToken);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => session.Completion);
+        await session.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task CommandHandlerFailure_DoesNotStopTheTelemetryDispatcher()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var responses = new ChannelStreamReader<Proto.TelemetryCommand>();
+        var requests = CreateRequestWriter(new ConcurrentQueue<Proto.TelemetryCommand>());
+        var secondCommandHandled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handledCommands = 0;
+        await using var session = new GrpcTelemetrySession(
+            CreateCall(requests.Object, responses),
+            (_, _) =>
+            {
+                if (Interlocked.Increment(ref handledCommands) == 1)
+                {
+                    throw new InvalidOperationException("handler failed");
+                }
+
+                secondCommandHandled.TrySetResult();
+                return Task.CompletedTask;
+            });
+        await responses.WriteAsync(new Proto.TelemetryCommand { Settings = new Proto.Settings() }, cancellationToken);
+        await session.StartAsync(new Proto.Settings(), TimeSpan.FromSeconds(1), cancellationToken);
+
+        await responses.WriteAsync(new Proto.TelemetryCommand
+        {
+            NotifyUnsubscribeLiteCommand = new Proto.NotifyUnsubscribeLiteCommand { LiteTopic = "orders" }
+        }, cancellationToken);
+        await responses.WriteAsync(new Proto.TelemetryCommand
+        {
+            NotifyUnsubscribeLiteCommand = new Proto.NotifyUnsubscribeLiteCommand { LiteTopic = "payments" }
+        }, cancellationToken);
+        await secondCommandHandled.Task.WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
+
+        Assert.Equal(2, Volatile.Read(ref handledCommands));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CancelsAnActiveTelemetryCommandHandler()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var responses = new ChannelStreamReader<Proto.TelemetryCommand>();
+        var requests = CreateRequestWriter(new ConcurrentQueue<Proto.TelemetryCommand>());
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var session = new GrpcTelemetrySession(
+            CreateCall(requests.Object, responses),
+            async (_, token) =>
+            {
+                handlerStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            });
+        await responses.WriteAsync(new Proto.TelemetryCommand { Settings = new Proto.Settings() }, cancellationToken);
+        await session.StartAsync(new Proto.Settings(), TimeSpan.FromSeconds(1), cancellationToken);
+        await responses.WriteAsync(new Proto.TelemetryCommand
+        {
+            NotifyUnsubscribeLiteCommand = new Proto.NotifyUnsubscribeLiteCommand { LiteTopic = "orders" }
+        }, cancellationToken);
+        await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(2), cancellationToken);
+
+        await session.DisposeAsync();
     }
 
     [Fact]
@@ -125,6 +245,16 @@ public sealed class GrpcTelemetrySessionTests
         Assert.Equal("verify-2", writtenRequests.Last().VerifyMessageResult.Nonce);
     }
 
+    private static AsyncDuplexStreamingCall<Proto.TelemetryCommand, Proto.TelemetryCommand> CreateCall(
+        IClientStreamWriter<Proto.TelemetryCommand> requests,
+        IAsyncStreamReader<Proto.TelemetryCommand> responses) => new(
+        requests,
+        responses,
+        Task.FromResult(new Metadata()),
+        static () => Status.DefaultSuccess,
+        static () => new Metadata(),
+        static () => { });
+
     private static Mock<IClientStreamWriter<T>> CreateRequestWriter<T>(ConcurrentQueue<T> messages)
     {
         var writer = new Mock<IClientStreamWriter<T>>(MockBehavior.Strict);
@@ -151,6 +281,8 @@ public sealed class GrpcTelemetrySessionTests
         public ValueTask WriteAsync(T item, CancellationToken cancellationToken) =>
             _channel.Writer.WriteAsync(item, cancellationToken);
 
+        public void Complete(Exception? exception = null) => _channel.Writer.TryComplete(exception);
+
         public async Task<bool> MoveNext(CancellationToken cancellationToken)
         {
             try
@@ -162,6 +294,31 @@ public sealed class GrpcTelemetrySessionTests
             {
                 return false;
             }
+        }
+    }
+
+    private sealed class SequenceStreamReader<T>(params object[] responses) : IAsyncStreamReader<T>
+    {
+        private readonly Queue<object> _responses = new(responses);
+
+        public T Current { get; private set; } = default!;
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_responses.Count == 0)
+            {
+                return Task.FromResult(false);
+            }
+
+            var response = _responses.Dequeue();
+            if (response is Exception exception)
+            {
+                return Task.FromException<bool>(exception);
+            }
+
+            Current = (T)response;
+            return Task.FromResult(true);
         }
     }
 

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
@@ -2012,6 +2012,640 @@ public sealed class RemotingPushConsumerTests
         Assert.DoesNotContain(remoting.Requests, static request => request.Code == RequestCode.ConsumerSendMsgBack);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task StopAsync_CancelsWhenFifoOrOrderlyHandlerIgnoresCancellation(bool consumeOrderly)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var handlerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerCancellationRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseHandler = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerFinished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processCompleted = new TaskCompletionSource<(Exception? Exception, bool? Success, string? Outcome)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processDisposed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var processOperation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        processOperation
+            .Setup(value => value.Complete(It.IsAny<Exception>()))
+            .Callback<Exception>(exception => { processCompleted.TrySetResult((exception, null, null)); });
+        processOperation
+            .Setup(value => value.Complete(It.IsAny<bool>(), It.IsAny<string?>()))
+            .Callback<bool, string?>((success, outcome) => { processCompleted.TrySetResult((null, success, outcome)); });
+        processOperation.Setup(value => value.Dispose()).Callback(() => { processDisposed.TrySetResult(); });
+        var telemetry = new ProcessTelemetry(processOperation.Object);
+        var delivered = 0;
+        var body = CreateMessageRecord(
+            "orders",
+            "stuck",
+            consumeOrderly ? null : "account-7",
+            0,
+            1_000);
+        var remoting = new FakeRemotingClient($"127.0.0.1@stop-cancellation-{consumeOrderly}")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            ConsumeOrderly = consumeOrderly,
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = async (_, _, token) =>
+            {
+                handlerStarted.TrySetResult();
+                using var registration = token.Register(() => handlerCancellationRequested.TrySetResult());
+                await releaseHandler.Task;
+                handlerFinished.TrySetResult();
+                return ConsumeResult.Success;
+            }
+        };
+        options.Subscribe("orders");
+        var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            $"stop-cancellation-{consumeOrderly}",
+            telemetry);
+
+        try
+        {
+            await consumer.StartAsync(cancellationToken);
+            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+            using var stopCancellation = new CancellationTokenSource();
+            var stop = consumer.StopAsync(stopCancellation.Token).AsTask();
+            await handlerCancellationRequested.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            stopCancellation.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                stop.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken));
+
+            releaseHandler.TrySetResult();
+            await handlerFinished.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            var completion = await processCompleted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+            await processDisposed.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+            Assert.IsType<OperationCanceledException>(completion.Exception);
+            Assert.DoesNotContain(remoting.Requests, static request => request.Code == RequestCode.ConsumerSendMsgBack);
+            Assert.DoesNotContain(
+                remoting.UpdatedOffsets,
+                static update => update.Topic == "orders" && update.Offset == 1);
+        }
+        finally
+        {
+            releaseHandler.TrySetResult();
+            await consumer.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public void Constructor_DisposesFirstRequestHandlerRegistrationWhenSecondRegistrationFails()
+    {
+        var disposed = false;
+        var registration = new Mock<IDisposable>(MockBehavior.Strict);
+        registration.Setup(value => value.Dispose()).Callback(() => { disposed = true; });
+        var remoting = new Mock<IRemotingClient>(MockBehavior.Strict);
+        remoting
+            .SetupSequence(value => value.RegisterRequestHandler(
+                It.IsAny<int>(),
+                It.IsAny<RemotingRequestHandler>()))
+            .Returns(registration.Object)
+            .Throws(new InvalidOperationException("The reset-offset registration failed."));
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new RemotingPushConsumer(
+            Options.Create(options),
+            Options.Create(new RemotingClientOptions()),
+            new Mock<IRemotingConsumerEngine>(MockBehavior.Strict).Object,
+            new Mock<ITopicRouteService>(MockBehavior.Strict).Object,
+            remoting.Object,
+            TimeProvider.System,
+            NullLogger<RemotingPushConsumer>.Instance));
+
+        Assert.Equal("The reset-offset registration failed.", exception.Message);
+        Assert.True(disposed);
+        registration.Verify(value => value.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UnsubscribeAsync_ClearsPendingResetBoundaryBeforeResubscribing()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var remoting = new FakeRemotingClient("127.0.0.1@clear-reset-boundary");
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 8,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "clear-reset-boundary");
+        var body = Encoding.UTF8.GetBytes(
+            """
+            {"offsetTable":[[{"topic":"orders","brokerName":"broker-a","queueId":0},9]]}
+            """);
+
+        var reset = await remoting.InvokeBrokerRequestAsync(
+            RequestCode.ResetConsumerOffset,
+            new Dictionary<string, object>
+            {
+                ["group"] = "legacy-group",
+                ["topic"] = "orders"
+            },
+            body,
+            cancellationToken);
+        Assert.True(reset.IsHandled);
+        Assert.True(reset.SuppressResponse);
+
+        await consumer.UnsubscribeAsync("orders", cancellationToken);
+        await consumer.SubscribeAsync("orders", cancellationToken: cancellationToken);
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForTopicPullsAsync("orders", 1, cancellationToken);
+
+        Assert.Equal(
+            0,
+            remoting.PullOffsets.First(static pull => pull.Topic == "orders").Offset);
+    }
+
+    [Fact]
+    public async Task StartAsync_UsesReadableQueueWithSlaveAddressWhenRouteContainsInvalidEntries()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var route = new TopicRouteData
+        {
+            QueueDatas =
+            [
+                new QueueData
+                {
+                    BrokerName = "write-only",
+                    ReadQueueNums = 1,
+                    WriteQueueNums = 1,
+                    Perm = 2
+                },
+                new QueueData
+                {
+                    BrokerName = "missing-broker",
+                    ReadQueueNums = 1,
+                    WriteQueueNums = 1,
+                    Perm = 6
+                },
+                new QueueData
+                {
+                    BrokerName = "no-address",
+                    ReadQueueNums = 1,
+                    WriteQueueNums = 1,
+                    Perm = 6
+                },
+                new QueueData
+                {
+                    BrokerName = "slave-only",
+                    ReadQueueNums = 1,
+                    WriteQueueNums = 1,
+                    Perm = 6
+                }
+            ],
+            BrokerDatas =
+            [
+                new BrokerData { BrokerName = "no-address" },
+                new BrokerData
+                {
+                    BrokerName = "slave-only",
+                    BrokerAddrs = new ConcurrentDictionary<long, string>(
+                        [new KeyValuePair<long, string>(1, "127.0.0.1:10912")])
+                }
+            ]
+        };
+        var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
+        routes
+            .Setup(value => value.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, bool, CancellationToken>((topic, _, _) =>
+                Task.FromResult(topic == "orders" ? route : new TopicRouteData()));
+        var remoting = new FakeRemotingClient("127.0.0.1@route-with-invalid-entries");
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 8,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            routes.Object,
+            remoting,
+            "route-with-invalid-entries");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForTopicPullsAsync("orders", 1, cancellationToken);
+
+        var membershipRequest = Assert.Single(
+            remoting.Requests,
+            static request => request.Code == RequestCode.GetConsumerListByGroup);
+        Assert.Equal("slave-only", membershipRequest.ExtFields["bname"]);
+        Assert.Equal(
+            1,
+            remoting.PullOffsets.Count(static pull => pull.Topic == "orders"));
+    }
+
+    [Fact]
+    public async Task StopAsync_CompletesWhenBrokerRejectsUnregister()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var remoting = new FakeRemotingClient("127.0.0.1@unregister-rejected")
+        {
+            UnregisterHandler = static (_, _) => Task.FromResult(new RemotingCommand
+            {
+                Code = ResponseCodes.ResError,
+                Remark = "The broker rejected the unregister request."
+            })
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            MaxConcurrency = 1,
+            MaxCachedMessages = 8,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "unregister-rejected");
+
+        await consumer.StartAsync(cancellationToken);
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.Equal(1, remoting.UnregisterCalls);
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_MapsRetryDelayBeyondBrokerScheduleToLastDelayLevel()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "slow-retry", null, 0, 1_000);
+        var remoting = new FakeRemotingClient("127.0.0.1@maximum-delay-level")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            RetryDelay = TimeSpan.FromHours(3),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Retry)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "maximum-delay-level");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 1, cancellationToken);
+        await consumer.StopAsync(cancellationToken);
+
+        var sendBack = Assert.Single(
+            remoting.Requests,
+            static request => request.Code == RequestCode.ConsumerSendMsgBack);
+        Assert.Equal(18, Convert.ToInt32(sendBack.ExtFields["delayLevel"]));
+    }
+
+    [Fact]
+    public async Task Coordination_RecoversHealthyTopicAfterRouteMembershipAndHeartbeatFailures()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var membershipRequests = 0;
+        var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
+        routes
+            .Setup(value => value.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, bool, CancellationToken>((topic, _, _) => topic == "invoices"
+                ? Task.FromResult(Route(1))
+                : Task.FromException<TopicRouteData>(
+                    new IOException($"The route for {topic} is temporarily unavailable.")));
+        var remoting = new FakeRemotingClient("127.0.0.1@coordination-recovery")
+        {
+            HeartbeatHandler = static (_, _) => Task.FromResult(new RemotingCommand
+            {
+                Code = ResponseCodes.ResError,
+                Remark = "The heartbeat was rejected."
+            }),
+            ConsumerIdsHandler = (_, _) => Interlocked.Increment(ref membershipRequests) == 1
+                ? Task.FromResult(new RemotingCommand
+                {
+                    Code = ResponseCodes.ResError,
+                    Remark = "The consumer-list request failed."
+                })
+                : Task.FromResult(new RemotingCommand
+                {
+                    Code = ResponseCodes.ResSuccess,
+                    Body = JsonSerializer.SerializeToUtf8Bytes(new
+                    {
+                        consumerIdList = new[] { "127.0.0.1@coordination-recovery" }
+                    })
+                })
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 8,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+        options.Subscribe("invoices");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            routes.Object,
+            remoting,
+            "coordination-recovery");
+
+        await consumer.StartAsync(cancellationToken);
+        Assert.DoesNotContain(remoting.PullOffsets, static pull => pull.Topic == "invoices");
+
+        await remoting.NotifyConsumerIdsChangedAsync("legacy-group", cancellationToken);
+        await remoting.WaitForTopicPullsAsync("invoices", 1, cancellationToken);
+
+        Assert.Equal(2, membershipRequests);
+        Assert.Contains(remoting.Requests, static request => request.Code == RequestCode.HeartBeat);
+    }
+
+    [Fact]
+    public async Task PushConsumer_RetriesOffsetInitializationAfterTransientBrokerFailure()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var offsetQueries = 0;
+        var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
+        routes
+            .Setup(value => value.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, bool, CancellationToken>((topic, _, _) =>
+                Task.FromResult(topic == "orders" ? Route(1) : new TopicRouteData()));
+        var remoting = new FakeRemotingClient("127.0.0.1@offset-initialization-retry")
+        {
+            ConsumerOffsetHandler = (_, _) => Interlocked.Increment(ref offsetQueries) == 1
+                ? Task.FromException<RemotingCommand>(
+                    new IOException("The broker did not respond to the initial offset query."))
+                : Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResQueryNotFound })
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 8,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            routes.Object,
+            remoting,
+            "offset-initialization-retry");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForTopicPullsAsync("orders", 1, cancellationToken);
+
+        Assert.Equal(2, offsetQueries);
+        Assert.Equal(
+            0,
+            remoting.PullOffsets.First(static pull => pull.Topic == "orders").Offset);
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_RecoversFromOffsetIllegalAndHandlerFailureWhenRetryTopicIsMissing()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var orderPulls = 0;
+        var body = CreateMessageRecord("orders", "recoverable", null, 4, 1_004);
+        var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
+        routes
+            .Setup(value => value.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, bool, CancellationToken>((topic, _, _) =>
+                Task.FromResult(topic == "orders" ? Route(1) : new TopicRouteData()));
+        var remoting = new FakeRemotingClient("127.0.0.1@offset-illegal-recovery")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders")
+                {
+                    return Interlocked.Increment(ref orderPulls) switch
+                    {
+                        1 => PullOffsetIllegal(4),
+                        2 => PullSuccess(body, 5),
+                        _ => await WaitForCanceledPullAsync(token)
+                    };
+                }
+
+                return await WaitForCanceledPullAsync(token);
+            },
+            MaxOffsetHandler = (request, _) => Task.FromResult(
+                Assert.IsType<string>(request.ExtFields["topic"]) == "%RETRY%legacy-group"
+                    ? new RemotingCommand { Code = ResponseCodes.ResTopicNotExist }
+                    : new RemotingCommand
+                    {
+                        Code = ResponseCodes.ResSuccess,
+                        ExtFields = new Dictionary<string, object> { ["offset"] = "17" }
+                    })
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => throw new InvalidOperationException("The application handler failed.")
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            routes.Object,
+            remoting,
+            "offset-illegal-recovery");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 1, cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update =>
+                   update.Topic == "orders" && update.Offset == 5) ||
+               !remoting.UpdatedOffsets.Any(static update =>
+                   update.Topic == "%RETRY%legacy-group" && update.Offset == 0))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        Assert.Equal(
+            [0L, 4L],
+            remoting.PullOffsets
+                .Where(static pull => pull.Topic == "orders")
+                .Take(2)
+                .Select(static pull => pull.Offset));
+    }
+
+    [Fact]
+    public async Task ConcurrentPushConsumer_RedeliversWhenSendBackFails()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var deliveries = 0;
+        var sendBackAttempts = 0;
+        var body = CreateMessageRecord("orders", "send-back-retry", null, 0, 1_000);
+        var remoting = new FakeRemotingClient("127.0.0.1@send-back-retry")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Increment(ref deliveries) <= 2)
+                {
+                    return PullSuccess(body, 1);
+                }
+
+                return await WaitForCanceledPullAsync(token);
+            },
+            SendBackHandler = (_, _) => Interlocked.Increment(ref sendBackAttempts) == 1
+                ? Task.FromException<RemotingCommand>(
+                    new IOException("The broker did not accept the retry acknowledgement."))
+                : Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResSuccess })
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            RetryDelay = TimeSpan.FromMilliseconds(10),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Retry)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "send-back-retry");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 2, cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update =>
+                   update.Topic == "orders" && update.Offset == 1))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        Assert.Equal(2, sendBackAttempts);
+        Assert.Equal(
+            [0L, 0L],
+            remoting.PullOffsets
+                .Where(static pull => pull.Topic == "orders")
+                .Take(2)
+                .Select(static pull => pull.Offset));
+    }
+
+    [Fact]
+    public async Task OrderlyConsumer_DeadLettersMessageAndCommitsPastIt()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var delivered = 0;
+        var body = CreateMessageRecord("orders", "dead-letter", null, 0, 1_000);
+        var remoting = new FakeRemotingClient("127.0.0.1@orderly-dead-letter")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(body, 1);
+                }
+
+                return await WaitForCanceledPullAsync(token);
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            ConsumeOrderly = true,
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.DeadLetter)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "orderly-dead-letter");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 1, cancellationToken);
+        while (!remoting.UpdatedOffsets.Any(static update =>
+                   update.Topic == "orders" && update.Offset == 1))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
+
+        var sendBack = Assert.Single(
+            remoting.Requests,
+            static request => request.Code == RequestCode.ConsumerSendMsgBack);
+        Assert.Equal(-1, Convert.ToInt32(sendBack.ExtFields["delayLevel"]));
+    }
+
     [Fact]
     public async Task OrderlyConsumer_UsesBrokerQueueLockBeforePulling()
     {
@@ -2487,6 +3121,23 @@ public sealed class RemotingPushConsumerTests
         }
     };
 
+    private static RemotingCommand PullOffsetIllegal(long nextOffset) => new()
+    {
+        Code = ResponseCodes.ResPullOffsetMoved,
+        ExtFields = new Dictionary<string, object>
+        {
+            ["nextBeginOffset"] = nextOffset.ToString(),
+            ["minOffset"] = "0",
+            ["maxOffset"] = nextOffset.ToString()
+        }
+    };
+
+    private static async Task<RemotingCommand> WaitForCanceledPullAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+    }
+
     private static byte[] CreateMessageRecord(
         string topic,
         string messageId,
@@ -2763,8 +3414,14 @@ public sealed class RemotingPushConsumerTests
         public ConcurrentQueue<(string Topic, long Offset)> UpdatedOffsets { get; } = new();
         public ConcurrentQueue<RemotingCommand> Requests { get; } = new();
         public ConcurrentQueue<RemotingCommand> OnewayRequests { get; } = new();
+        public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? HeartbeatHandler { get; init; }
+        public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? ConsumerIdsHandler { get; init; }
+        public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? ConsumerOffsetHandler { get; init; }
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? LockHandler { get; set; }
+        public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? MaxOffsetHandler { get; init; }
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? PullHandler { get; init; }
+        public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? SendBackHandler { get; init; }
+        public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? UnregisterHandler { get; init; }
         public bool TrackCommittedOffsets { get; init; }
         public int CanceledPulls;
         public int UnregisterCalls;
@@ -2839,17 +3496,26 @@ public sealed class RemotingPushConsumerTests
             {
                 case RequestCode.HeartBeat:
                     HeartbeatBodies.Enqueue(request.Body!);
-                    return Success();
+                    return HeartbeatHandler is null
+                        ? Success()
+                        : await HeartbeatHandler(request, cancellationToken);
                 case RequestCode.GetConsumerListByGroup:
-                    return Success(JsonSerializer.SerializeToUtf8Bytes(new
-                    {
-                        consumerIdList = Volatile.Read(ref _consumerIds)
-                    }));
+                    return ConsumerIdsHandler is null
+                        ? Success(JsonSerializer.SerializeToUtf8Bytes(new
+                        {
+                            consumerIdList = Volatile.Read(ref _consumerIds)
+                        }))
+                        : await ConsumerIdsHandler(request, cancellationToken);
                 case RequestCode.LockBatchMq:
                     return LockHandler is null
                         ? LockSuccess(request)
                         : await LockHandler(request, cancellationToken);
                 case RequestCode.QueryConsumerOffset:
+                    if (ConsumerOffsetHandler is not null)
+                    {
+                        return await ConsumerOffsetHandler(request, cancellationToken);
+                    }
+
                     if (TrackCommittedOffsets &&
                         _committedOffsets.TryGetValue((
                             Assert.IsType<string>(request.ExtFields["topic"]),
@@ -2862,7 +3528,9 @@ public sealed class RemotingPushConsumerTests
                 case RequestCode.GetMinOffset:
                     return Success(offset: 0);
                 case RequestCode.GetMaxOffset:
-                    return Success(offset: 17);
+                    return MaxOffsetHandler is null
+                        ? Success(offset: 17)
+                        : await MaxOffsetHandler(request, cancellationToken);
                 case RequestCode.SearchOffsetByTimestamp:
                     return Success(offset: 9);
                 case RequestCode.UpdateConsumerOffset:
@@ -2906,9 +3574,15 @@ public sealed class RemotingPushConsumerTests
                         _pullCanceled.TrySetResult();
                         throw;
                     }
+                case RequestCode.ConsumerSendMsgBack:
+                    return SendBackHandler is null
+                        ? Success()
+                        : await SendBackHandler(request, cancellationToken);
                 case RequestCode.UnregisterClient:
                     Interlocked.Increment(ref UnregisterCalls);
-                    return Success();
+                    return UnregisterHandler is null
+                        ? Success()
+                        : await UnregisterHandler(request, cancellationToken);
                 default:
                     return Success();
             }

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Producer/RemotingProducerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Producer/RemotingProducerTests.cs
@@ -18,6 +18,7 @@ using System.Net;
 using System.Text;
 using EventHorizon.RocketMQ.Remoting.Exceptions;
 using EventHorizon.RocketMQ.Remoting.Producer;
+using EventHorizon.RocketMQ.Remoting.Producer.Transactions;
 using EventHorizon.RocketMQ.Remoting.Protocol;
 using EventHorizon.RocketMQ.Remoting.Protocol.Route;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -29,6 +30,76 @@ namespace EventHorizon.RocketMQ.Remoting.Tests.Producer;
 
 public sealed class RemotingProducerTests
 {
+    [Fact]
+    public async Task StartAsync_RequiresPositiveHeartbeatInterval()
+    {
+        var remoting = new Mock<IRemotingClient>(MockBehavior.Strict);
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(
+            remoting.Object,
+            routes.Mock.Object,
+            configureClient: options => options.HeartbeatBrokerInterval = TimeSpan.Zero);
+
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await producer.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("HeartbeatBrokerInterval", exception.ParamName);
+        remoting.Verify(value => value.RegisterRequestHandler(
+            It.IsAny<int>(),
+            It.IsAny<RemotingRequestHandler>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_IsIdempotent()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+        await producer.StopAsync(TestContext.Current.CancellationToken);
+
+        remoting.Verify(value => value.RegisterRequestHandler(
+            RequestCode.PushReplyMessageToClient,
+            It.IsAny<RemotingRequestHandler>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task StartAsync_DisposesReplyRegistrationWhenTransactionRegistrationFails()
+    {
+        var replyRegistration = new Mock<IDisposable>(MockBehavior.Strict);
+        replyRegistration.Setup(value => value.Dispose());
+        var remoting = new Mock<IRemotingClient>(MockBehavior.Strict);
+        remoting
+            .Setup(value => value.RegisterRequestHandler(
+                RequestCode.PushReplyMessageToClient,
+                It.IsAny<RemotingRequestHandler>()))
+            .Returns(replyRegistration.Object);
+        remoting
+            .Setup(value => value.RegisterRequestHandler(
+                RequestCode.CheckTransactionState,
+                It.IsAny<RemotingRequestHandler>()))
+            .Throws(new InvalidOperationException("transaction handler registration failed"));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(
+            remoting.Object,
+            routes.Mock.Object,
+            options =>
+            {
+                options.LocalTransactionExecutor = static (_, _, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Commit);
+                options.TransactionChecker = static (_, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Commit);
+            });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await producer.StartAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("transaction handler registration failed", exception.Message);
+        replyRegistration.Verify(value => value.Dispose(), Times.Once);
+    }
+
     [Fact]
     public async Task SendAsync_MapsResponseAndEncodesRequest()
     {
@@ -333,10 +404,15 @@ public sealed class RemotingProducerTests
         await producer.SendAsync(
             new Message("orders", [3]) { LiteTopic = "lite-orders" },
             TestContext.Current.CancellationToken);
+        var keyedMessage = new Message("orders", [4]);
+        keyedMessage.Keys.Add("first");
+        keyedMessage.Keys.Add("second");
+        await producer.SendAsync(keyedMessage, TestContext.Current.CancellationToken);
 
         Assert.Equal("1893456000123", Properties(captured[0])["TIMER_DELIVER_MS"]);
         Assert.Equal("3", Properties(captured[1])["_SYS_MSG_PRIORITY_"]);
         Assert.Equal("lite-orders", Properties(captured[2])["__LITE_TOPIC"]);
+        Assert.Equal("first second", Properties(captured[3])["KEYS"]);
     }
 
     [Fact]
@@ -403,6 +479,21 @@ public sealed class RemotingProducerTests
         Assert.Equal("broker-a", queues[0].BrokerName);
         Assert.Equal(0, queues[0].QueueId);
         Assert.Contains(queues, queue => queue.BrokerName == "broker-b" && queue.QueueId == 7);
+    }
+
+    [Fact]
+    public async Task GetPublishMessageQueuesAsync_RejectsRouteWithoutWritableQueues()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(new TopicRouteData());
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<RocketMQClientException>(() => producer.GetPublishMessageQueuesAsync(
+            "orders",
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal("No writable message queue is available for topic 'orders'.", exception.Message);
     }
 
     [Fact]
@@ -532,6 +623,93 @@ public sealed class RemotingProducerTests
     }
 
     [Fact]
+    public async Task SendOnewayAsync_RetriesTransientFailureWithRefreshedRoute()
+    {
+        var attempts = 0;
+        var remoting = new Mock<IRemotingClient>(MockBehavior.Strict);
+        remoting
+            .Setup(value => value.RegisterRequestHandler(
+                It.IsAny<int>(),
+                It.IsAny<RemotingRequestHandler>()))
+            .Returns(new NoopRegistration());
+        remoting
+            .Setup(value => value.InvokeOnewayAsync(
+                It.IsAny<EndPoint>(),
+                It.IsAny<RemotingCommand>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(() => Interlocked.Increment(ref attempts) == 1
+                ? Task.FromException(new IOException("first broker unavailable"))
+                : Task.CompletedTask);
+        var routes = CreateRouteServiceMock(
+            Route("broker-a", "localhost:10911"),
+            Route("broker-b", "localhost:20911"));
+        var producer = CreateProducer(
+            remoting.Object,
+            routes.Mock.Object,
+            options => options.RetryTimesWhenSendFailed = 1);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        await producer.SendOnewayAsync(
+            new Message("orders", "payload"u8.ToArray()),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, attempts);
+        Assert.Equal([false, true], routes.ForceRefreshCalls);
+    }
+
+    [Fact]
+    public async Task SendOnewayAsync_ReportsFailureAfterLastAttempt()
+    {
+        var remoting = new Mock<IRemotingClient>(MockBehavior.Strict);
+        remoting
+            .Setup(value => value.RegisterRequestHandler(
+                It.IsAny<int>(),
+                It.IsAny<RemotingRequestHandler>()))
+            .Returns(new NoopRegistration());
+        remoting
+            .Setup(value => value.InvokeOnewayAsync(
+                It.IsAny<EndPoint>(),
+                It.IsAny<RemotingCommand>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("broker unavailable"));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(
+            remoting.Object,
+            routes.Mock.Object,
+            options => options.RetryTimesWhenSendFailed = 0);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<RocketMQClientException>(() => producer.SendOnewayAsync(
+            new Message("orders", "payload"u8.ToArray()),
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal("Failed to send one-way message for topic 'orders' after 1 attempts.", exception.Message);
+        Assert.IsType<IOException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task SendAsync_WrapsFinalTransportFailure()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) =>
+            Task.FromException<RemotingCommand>(new IOException("broker unavailable")));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(
+            remoting.Object,
+            routes.Mock.Object,
+            options => options.RetryTimesWhenSendFailed = 0);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<RocketMQClientException>(() => producer.SendAsync(
+            new Message("orders", "payload"u8.ToArray()),
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal("Failed to send message for topic 'orders' after 1 attempts.", exception.Message);
+        Assert.IsType<IOException>(exception.InnerException);
+    }
+
+    [Fact]
     public async Task SendAsync_BatchEncodesMiniRecordsAndReturnsEachMessageId()
     {
         RemotingCommand? captured = null;
@@ -565,6 +743,72 @@ public sealed class RemotingProducerTests
     }
 
     [Fact]
+    public async Task SendAsync_BatchUsesExplicitWritableQueue()
+    {
+        RemotingCommand? captured = null;
+        var remoting = CreateRemotingClientMock((_, request, _, _) =>
+        {
+            captured = request;
+            return Task.FromResult(SuccessResponse());
+        });
+        var routes = CreateRouteServiceMock(Route(
+            ("broker-a", "localhost:10911"),
+            ("broker-b", "localhost:20911")));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+        await producer.SendAsync(
+            [new Message("orders", "first"u8.ToArray()), new Message("orders", "second"u8.ToArray())],
+            new RemotingMessageQueue("orders", "broker-b", 3),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Equal("broker-b", captured.ExtFields["bname"]);
+        Assert.Equal(3, captured.ExtFields["queueId"]);
+    }
+
+    [Fact]
+    public async Task SendAsync_BatchUsesSelectorAgainstCurrentWritableQueues()
+    {
+        RemotingCommand? captured = null;
+        IReadOnlyList<RemotingMessageQueue>? availableQueues = null;
+        var selectorArgument = new object();
+        var messages = new[]
+        {
+            new Message("orders", "first"u8.ToArray()),
+            new Message("orders", "second"u8.ToArray())
+        };
+        var remoting = CreateRemotingClientMock((_, request, _, _) =>
+        {
+            captured = request;
+            return Task.FromResult(SuccessResponse());
+        });
+        var routes = CreateRouteServiceMock(Route(
+            ("broker-a", "localhost:10911"),
+            ("broker-b", "localhost:20911")));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+        await producer.SendAsync(
+            messages,
+            (queues, routingMessage, argument) =>
+            {
+                availableQueues = queues;
+                Assert.Same(messages[0], routingMessage);
+                Assert.Same(selectorArgument, argument);
+                return queues.Single(queue => queue.BrokerName == "broker-b" && queue.QueueId == 5);
+            },
+            selectorArgument,
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(availableQueues);
+        Assert.Equal(16, availableQueues.Count);
+        Assert.NotNull(captured);
+        Assert.Equal("broker-b", captured.ExtFields["bname"]);
+        Assert.Equal(5, captured.ExtFields["queueId"]);
+    }
+
+    [Fact]
     public async Task SendAsync_BatchRejectsMixedTopicsAndDelayedMessagesBeforeRemoting()
     {
         var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
@@ -581,6 +825,91 @@ public sealed class RemotingProducerTests
 
         Assert.Contains("same topic", mixedTopics.Message);
         Assert.Contains("Delayed", delayed.Message);
+        remoting.Verify(value => value.InvokeAsync(
+            It.IsAny<EndPoint>(),
+            It.IsAny<RemotingCommand>(),
+            It.IsAny<TimeSpan>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendAsync_BatchRejectsEmptyAndOversizedPayloadsBeforeRemoting()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(
+            remoting.Object,
+            routes.Mock.Object,
+            options => options.MaxMessageSize = 1);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var empty = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            Array.Empty<Message>(),
+            TestContext.Current.CancellationToken));
+        var oversized = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            [new Message("orders", [1])],
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("cannot be empty", empty.Message);
+        Assert.Contains("maximum", oversized.Message);
+        remoting.Verify(value => value.InvokeAsync(
+            It.IsAny<EndPoint>(),
+            It.IsAny<RemotingCommand>(),
+            It.IsAny<TimeSpan>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendAsync_BatchRejectsRetryAndTransactionalMessagesBeforeRemoting()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        var transactional = new Message("orders", [1]);
+        transactional.Properties["TRAN_MSG"] = "true";
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var retryTopic = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            [new Message("%RETRY%tests", [1])],
+            TestContext.Current.CancellationToken));
+        var transaction = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            [transactional],
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("Retry-topic", retryTopic.Message);
+        Assert.Contains("Transactional", transaction.Message);
+        remoting.Verify(value => value.InvokeAsync(
+            It.IsAny<EndPoint>(),
+            It.IsAny<RemotingCommand>(),
+            It.IsAny<TimeSpan>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendAsync_RejectsInvalidMessageFieldsBeforeRemoting()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var emptyBody = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            new Message("orders", []),
+            TestContext.Current.CancellationToken));
+        var emptyGroup = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            new Message("orders", [1]) { MessageGroup = " " },
+            TestContext.Current.CancellationToken));
+        var negativePriority = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            new Message("orders", [1]) { Priority = -1 },
+            TestContext.Current.CancellationToken));
+        var emptyLiteTopic = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            new Message("orders", [1]) { LiteTopic = " " },
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("body cannot be empty", emptyBody.Message);
+        Assert.Contains("Message group cannot be empty", emptyGroup.Message);
+        Assert.Contains("priority must be greater", negativePriority.Message);
+        Assert.Contains("Lite topic cannot be empty", emptyLiteTopic.Message);
         remoting.Verify(value => value.InvokeAsync(
             It.IsAny<EndPoint>(),
             It.IsAny<RemotingCommand>(),
@@ -650,6 +979,154 @@ public sealed class RemotingProducerTests
             It.IsAny<RemotingCommand>(),
             It.IsAny<TimeSpan>(),
             It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecallAsync_RejectsBrokerFailureAndResponseWithoutMessageId()
+    {
+        var response = new RemotingCommand
+        {
+            Code = ResponseCodes.ResSystemBusy,
+            Remark = "broker is busy"
+        };
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(response));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        var recallHandle = CreateRecallHandle("orders", "broker-a", "1893456000000", "message-id");
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var rejected = await Assert.ThrowsAsync<RemotingCommandException>(() => producer.RecallAsync(
+            "orders",
+            recallHandle,
+            TestContext.Current.CancellationToken));
+
+        response = new RemotingCommand { Code = ResponseCodes.ResSuccess };
+        var malformed = await Assert.ThrowsAsync<InvalidDataException>(() => producer.RecallAsync(
+            "orders",
+            recallHandle,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal(ResponseCodes.ResSystemBusy, rejected.ResponseCode);
+        Assert.Equal("broker is busy", rejected.Message);
+        Assert.Equal("Broker response did not contain a valid recalled-message ID.", malformed.Message);
+    }
+
+    [Fact]
+    public async Task RecallAsync_RejectsRetryTopicBeforeParsingHandle()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => producer.RecallAsync(
+            "%RETRY%tests",
+            "not-a-recall-handle",
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("Retry and dead-letter topics", exception.Message);
+        remoting.Verify(value => value.InvokeAsync(
+            It.IsAny<EndPoint>(),
+            It.IsAny<RemotingCommand>(),
+            It.IsAny<TimeSpan>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RecallAsync_UsesAnAvailableBrokerWhenHandleBrokerIsNoLongerRouted()
+    {
+        EndPoint? capturedEndpoint = null;
+        var remoting = CreateRemotingClientMock((endpoint, _, _, _) =>
+        {
+            capturedEndpoint = endpoint;
+            return Task.FromResult(new RemotingCommand
+            {
+                Code = ResponseCodes.ResSuccess,
+                ExtFields = new Dictionary<string, object> { ["msgId"] = "recalled-message-id" }
+            });
+        });
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var messageId = await producer.RecallAsync(
+            "orders",
+            CreateRecallHandle("orders", "broker-removed", "1893456000000", "message-id"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("recalled-message-id", messageId);
+        var endpoint = Assert.IsType<DnsEndPoint>(capturedEndpoint);
+        Assert.Equal("localhost", endpoint.Host);
+        Assert.Equal(10911, endpoint.Port);
+    }
+
+    [Fact]
+    public async Task RecallAsync_RejectsRouteWithoutAnyBrokerEndpoint()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(new TopicRouteData());
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<RocketMQClientException>(() => producer.RecallAsync(
+            "orders",
+            CreateRecallHandle("orders", "broker-a", "1893456000000", "message-id"),
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal("No broker endpoint is available to recall a message for broker 'broker-a'.", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_RejectsQueueWithAnotherTopicBeforeResolvingRoute()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendAsync(
+            new Message("orders", [1]),
+            new RemotingMessageQueue("payments", "broker-a", 0),
+            TestContext.Current.CancellationToken));
+
+        Assert.Contains("does not match queue topic", exception.Message);
+        remoting.Verify(value => value.InvokeAsync(
+            It.IsAny<EndPoint>(),
+            It.IsAny<RemotingCommand>(),
+            It.IsAny<TimeSpan>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RequestAsync_RequiresPositiveTimeoutBeforeStartingTheProducer()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => producer.RequestAsync(
+            new Message("orders", [1]),
+            TimeSpan.Zero,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal("timeout", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task SendTransactionAsync_RequiresBothTransactionCallbacks()
+    {
+        var remoting = CreateRemotingClientMock((_, _, _, _) => Task.FromResult(SuccessResponse()));
+        var routes = CreateRouteServiceMock(Route("broker-a", "localhost:10911"));
+        var producer = CreateProducer(remoting.Object, routes.Mock.Object);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => producer.SendTransactionAsync(
+            new Message("orders", "payload"u8.ToArray()),
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            "Both a local transaction executor and a transaction checker must be configured before sending transactional messages.",
+            exception.Message);
     }
 
     private static RemotingProducer CreateProducer(

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Producer/RemotingRequestReplyTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Producer/RemotingRequestReplyTests.cs
@@ -79,6 +79,123 @@ public sealed class RemotingRequestReplyTests
     }
 
     [Fact]
+    public async Task RequestAsync_RetriesRetryableHeartbeatBeforeSending()
+    {
+        var remoting = new RequestReplyRemotingClient();
+        remoting.HeartbeatResponses.Enqueue(new RemotingCommand
+        {
+            Code = ResponseCodes.ResSystemBusy,
+            Remark = "broker is busy"
+        });
+        var producer = CreateProducer(remoting, retryTimesWhenSendFailed: 1);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            var replyTask = producer.RequestAsync(
+                new Message("orders", "request"u8.ToArray()),
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            var sentRequest = await remoting.WaitForSendMessageAsync(TestContext.Current.CancellationToken);
+            var invocations = remoting.Invocations.ToArray();
+
+            Assert.Collection(
+                invocations,
+                invocation => Assert.Equal(RequestCode.HeartBeat, invocation.Request.Code),
+                invocation => Assert.Equal(RequestCode.HeartBeat, invocation.Request.Code),
+                invocation => Assert.Equal(RequestCode.SendMessage, invocation.Request.Code));
+
+            var properties = MessagePropertyCodec.Deserialize(
+                Assert.IsType<string>(sentRequest.ExtFields["properties"]));
+            var correlationId = Assert.IsType<string>(properties["CORRELATION_ID"]);
+            await remoting.DispatchInboundAsync(CreateReplyCallback(correlationId, "reply"u8.ToArray()));
+
+            var reply = await replyTask;
+            Assert.Equal("reply"u8.ToArray(), reply.Body);
+        }
+        finally
+        {
+            await producer.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task RequestAsync_UsesExplicitWritableQueue()
+    {
+        var remoting = new RequestReplyRemotingClient();
+        var producer = CreateProducer(remoting);
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            var replyTask = producer.RequestAsync(
+                new Message("orders", "request"u8.ToArray()),
+                new RemotingMessageQueue("orders", "broker-a", 0),
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            var sentRequest = await remoting.WaitForSendMessageAsync(TestContext.Current.CancellationToken);
+
+            Assert.Equal("broker-a", sentRequest.ExtFields["bname"]);
+            Assert.Equal(0, sentRequest.ExtFields["queueId"]);
+            var properties = MessagePropertyCodec.Deserialize(
+                Assert.IsType<string>(sentRequest.ExtFields["properties"]));
+            await remoting.DispatchInboundAsync(CreateReplyCallback(
+                Assert.IsType<string>(properties["CORRELATION_ID"]),
+                "reply"u8.ToArray()));
+
+            var reply = await replyTask;
+            Assert.Equal("reply"u8.ToArray(), reply.Body);
+        }
+        finally
+        {
+            await producer.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task RequestAsync_UsesSelectorAgainstCurrentWritableQueues()
+    {
+        var remoting = new RequestReplyRemotingClient();
+        var producer = CreateProducer(remoting);
+        var message = new Message("orders", "request"u8.ToArray());
+        var selectorArgument = new object();
+        IReadOnlyList<RemotingMessageQueue>? availableQueues = null;
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            var replyTask = producer.RequestAsync(
+                message,
+                (queues, selectedMessage, argument) =>
+                {
+                    availableQueues = queues;
+                    Assert.Same(message, selectedMessage);
+                    Assert.Same(selectorArgument, argument);
+                    return Assert.Single(queues);
+                },
+                selectorArgument,
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            var sentRequest = await remoting.WaitForSendMessageAsync(TestContext.Current.CancellationToken);
+
+            Assert.NotNull(availableQueues);
+            Assert.Equal("orders", Assert.Single(availableQueues).Topic);
+            var properties = MessagePropertyCodec.Deserialize(
+                Assert.IsType<string>(sentRequest.ExtFields["properties"]));
+            await remoting.DispatchInboundAsync(CreateReplyCallback(
+                Assert.IsType<string>(properties["CORRELATION_ID"]),
+                "reply"u8.ToArray()));
+
+            var reply = await replyTask;
+            Assert.Equal("reply"u8.ToArray(), reply.Body);
+        }
+        finally
+        {
+            await producer.StopAsync(TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
     public async Task ReplyCallback_AcknowledgesUnknownCorrelation()
     {
         var remoting = new RequestReplyRemotingClient();
@@ -287,7 +404,9 @@ public sealed class RemotingRequestReplyTests
         }
     }
 
-    private static RemotingProducer CreateProducer(RequestReplyRemotingClient remoting)
+    private static RemotingProducer CreateProducer(
+        RequestReplyRemotingClient remoting,
+        int retryTimesWhenSendFailed = 0)
     {
         var routeService = new Mock<ITopicRouteService>(MockBehavior.Strict);
         routeService
@@ -300,7 +419,7 @@ public sealed class RemotingRequestReplyTests
             Options.Create(new RemotingProducerOptions
             {
                 GroupName = "request-reply-tests",
-                RetryTimesWhenSendFailed = 0
+                RetryTimesWhenSendFailed = retryTimesWhenSendFailed
             }),
             Options.Create(new RemotingClientOptions
             {
@@ -370,6 +489,8 @@ public sealed class RemotingRequestReplyTests
 
         public ConcurrentQueue<Invocation> Invocations { get; } = new();
 
+        public ConcurrentQueue<RemotingCommand> HeartbeatResponses { get; } = new();
+
         public int RequestHandlerCount => _requestHandlers.Count;
 
         public Task<RemotingCommand> InvokeAsync(
@@ -379,6 +500,11 @@ public sealed class RemotingRequestReplyTests
             CancellationToken cancellationToken = default)
         {
             Invocations.Enqueue(new Invocation(endPoint, request));
+            if (request.Code == RequestCode.HeartBeat && HeartbeatResponses.TryDequeue(out var heartbeatResponse))
+            {
+                return Task.FromResult(heartbeatResponse);
+            }
+
             if (request.Code is RequestCode.SendMessage or RequestCode.SendReplyMessage)
             {
                 _sendMessage.TrySetResult(request);

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Producer/Transactions/RemotingTransactionTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Producer/Transactions/RemotingTransactionTests.cs
@@ -98,6 +98,55 @@ public sealed class RemotingTransactionTests
     }
 
     [Fact]
+    public async Task SendTransactionAsync_ReturnsLocalOutcomeWhenEndTransactionFails()
+    {
+        var remoting = new FakeRemotingClient
+        {
+            OnewayHandler = static (_, _) => Task.FromException(new IOException("broker unavailable"))
+        };
+        var producer = CreateProducer(
+            remoting,
+            options =>
+            {
+                options.LocalTransactionExecutor = static (_, _, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Commit);
+                options.TransactionChecker = static (_, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Unknown);
+            });
+
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+        var result = await producer.SendTransactionAsync(
+            new Message("orders", "transactional"u8.ToArray()),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(RemotingTransactionResolution.Commit, result.LocalTransactionResolution);
+        Assert.Single(remoting.OnewayInvocations);
+    }
+
+    [Fact]
+    public async Task SendTransactionAsync_RejectsSpecializedMessagesBeforeSendingHalfMessage()
+    {
+        var remoting = new FakeRemotingClient();
+        var producer = CreateProducer(
+            remoting,
+            options =>
+            {
+                options.LocalTransactionExecutor = static (_, _, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Commit);
+                options.TransactionChecker = static (_, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Unknown);
+            });
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => producer.SendTransactionAsync(
+            new Message("orders", "transactional"u8.ToArray()) { Priority = 0 },
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("Transactional messages cannot use", exception.Message);
+        Assert.Empty(remoting.Invocations);
+    }
+
+    [Fact]
     public async Task TransactionCheck_QueuesCheckerAndEndsTransactionAtCallingBroker()
     {
         var remoting = new FakeRemotingClient();
@@ -151,6 +200,72 @@ public sealed class RemotingTransactionTests
         Assert.True(Assert.IsType<bool>(endTransaction.Request.ExtFields["fromTransactionCheck"]));
         Assert.Equal(1234L, endTransaction.Request.ExtFields["commitLogOffset"]);
         Assert.Equal(42L, endTransaction.Request.ExtFields["tranStateTableOffset"]);
+    }
+
+    [Fact]
+    public async Task TransactionCheck_IgnoresMalformedOrUnrelatedRequests()
+    {
+        var remoting = new FakeRemotingClient();
+        var producer = CreateProducer(
+            remoting,
+            options =>
+            {
+                options.LocalTransactionExecutor = static (_, _, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Commit);
+                options.TransactionChecker = static (_, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Commit);
+            });
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+        var endpoint = new IPEndPoint(IPAddress.Loopback, 10911);
+
+        var malformedHeader = await remoting.DispatchInboundAsync(endpoint, new RemotingCommand
+        {
+            Code = RequestCode.CheckTransactionState,
+            ExtFields = new Dictionary<string, object>()
+        });
+        var missingMessageId = await remoting.DispatchInboundAsync(endpoint, CreateTransactionCheckRequest(messageId: null));
+        var malformedBody = await remoting.DispatchInboundAsync(
+            endpoint,
+            CreateTransactionCheckRequest(body: []));
+        var unrelatedGroup = await remoting.DispatchInboundAsync(
+            endpoint,
+            CreateTransactionCheckRequest(producerGroup: "other-producer"));
+
+        Assert.False(malformedHeader.IsHandled);
+        Assert.True(missingMessageId.IsHandled);
+        Assert.True(missingMessageId.SuppressResponse);
+        Assert.True(malformedBody.IsHandled);
+        Assert.True(malformedBody.SuppressResponse);
+        Assert.False(unrelatedGroup.IsHandled);
+        Assert.Empty(remoting.OnewayInvocations);
+    }
+
+    [Fact]
+    public async Task TransactionCheck_CheckerFailureReportsUnknown()
+    {
+        var remoting = new FakeRemotingClient();
+        var producer = CreateProducer(
+            remoting,
+            options =>
+            {
+                options.LocalTransactionExecutor = static (_, _, _) =>
+                    ValueTask.FromResult(RemotingTransactionResolution.Commit);
+                options.TransactionChecker = static (_, _) =>
+                    ValueTask.FromException<RemotingTransactionResolution>(
+                        new InvalidOperationException("transaction store unavailable"));
+            });
+        await producer.StartAsync(TestContext.Current.CancellationToken);
+
+        var handlerResult = await remoting.DispatchInboundAsync(
+            new IPEndPoint(IPAddress.Loopback, 10911),
+            CreateTransactionCheckRequest());
+        await WaitForAsync(() => remoting.OnewayInvocations.Count == 1, TestContext.Current.CancellationToken);
+
+        Assert.True(handlerResult.IsHandled);
+        Assert.True(handlerResult.SuppressResponse);
+        var endTransaction = Assert.Single(remoting.OnewayInvocations);
+        Assert.Equal(MessageSysFlag.TransactionNotType, endTransaction.Request.ExtFields["commitOrRollback"]);
+        Assert.Contains("transaction checker failed", endTransaction.Request.Remark, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -213,6 +328,33 @@ public sealed class RemotingTransactionTests
             }
         ]
     };
+
+    private static RemotingCommand CreateTransactionCheckRequest(
+        string producerGroup = "tests",
+        string? messageId = "message-id",
+        byte[]? body = null)
+    {
+        var fields = new Dictionary<string, object>
+        {
+            ["topic"] = "orders",
+            ["tranStateTableOffset"] = "42",
+            ["commitLogOffset"] = "1234",
+            ["transactionId"] = "transaction-id",
+            ["offsetMsgId"] = CreateOffsetMessageId(1234),
+            ["bname"] = "broker-a"
+        };
+        if (messageId is not null)
+        {
+            fields["msgId"] = messageId;
+        }
+
+        return new RemotingCommand
+        {
+            Code = RequestCode.CheckTransactionState,
+            ExtFields = fields,
+            Body = body ?? (messageId is null ? [] : CreateTransactionCheckMessage("orders", messageId, producerGroup))
+        };
+    }
 
     private static RemotingCommand SendSuccessResponse() => new()
     {
@@ -304,6 +446,8 @@ public sealed class RemotingTransactionTests
 
         public List<(EndPoint EndPoint, RemotingCommand Request)> OnewayInvocations { get; } = [];
 
+        public Func<EndPoint, RemotingCommand, Task>? OnewayHandler { get; init; }
+
         public int RequestHandlerCount => _requestHandlers.Count;
 
         public Task<RemotingCommand> InvokeAsync(
@@ -323,7 +467,7 @@ public sealed class RemotingTransactionTests
             CancellationToken cancellationToken = default)
         {
             OnewayInvocations.Add((endPoint, request));
-            return Task.CompletedTask;
+            return OnewayHandler?.Invoke(endPoint, request) ?? Task.CompletedTask;
         }
 
         public IDisposable RegisterRequestHandler(int requestCode, RemotingRequestHandler handler)

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/RemotingClientTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/RemotingClientTests.cs
@@ -687,6 +687,216 @@ public sealed class RemotingClientTests
     }
 
     [Fact]
+    public async Task UnsupportedTransactionStateCheck_IsIgnoredWithoutWritingResponse()
+    {
+        const int BrokerOpaque = 7006;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var server = new LoopbackServer(cancellationToken);
+        var serverTask = ServeAsync();
+        await using var client = CreateClient();
+
+        var response = await client.InvokeAsync(
+            server.EndPoint,
+            CreateRequest("open-connection"),
+            OperationTimeout,
+            cancellationToken);
+
+        Assert.Equal("normal-response", Encoding.UTF8.GetString(response.Body!));
+        await serverTask;
+
+        async Task ServeAsync()
+        {
+            using var socket = await server.AcceptAsync();
+            var connection = new CommandConnection(socket.GetStream());
+            var request = await connection.ReadAsync(server.CancellationToken);
+            await connection.WriteAsync(
+                CreateBrokerRequest(RequestCode.CheckTransactionState, BrokerOpaque),
+                server.CancellationToken);
+
+            using var noResponseCts = CancellationTokenSource.CreateLinkedTokenSource(server.CancellationToken);
+            noResponseCts.CancelAfter(TimeSpan.FromMilliseconds(250));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                connection.ReadAsync(noResponseCts.Token));
+
+            await connection.WriteAsync(CreateResponse(request, "normal-response"), server.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task UnsupportedOnewayBrokerRequest_IsIgnoredWithoutWritingResponse()
+    {
+        const int UnknownRequestCode = 1206;
+        const int BrokerOpaque = 7007;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var server = new LoopbackServer(cancellationToken);
+        var serverTask = ServeAsync();
+        await using var client = CreateClient();
+
+        var response = await client.InvokeAsync(
+            server.EndPoint,
+            CreateRequest("open-connection"),
+            OperationTimeout,
+            cancellationToken);
+
+        Assert.Equal("normal-response", Encoding.UTF8.GetString(response.Body!));
+        await serverTask;
+
+        async Task ServeAsync()
+        {
+            using var socket = await server.AcceptAsync();
+            var connection = new CommandConnection(socket.GetStream());
+            var request = await connection.ReadAsync(server.CancellationToken);
+            await connection.WriteAsync(
+                CreateBrokerRequest(UnknownRequestCode, BrokerOpaque, oneway: true),
+                server.CancellationToken);
+
+            using var noResponseCts = CancellationTokenSource.CreateLinkedTokenSource(server.CancellationToken);
+            noResponseCts.CancelAfter(TimeSpan.FromMilliseconds(250));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                connection.ReadAsync(noResponseCts.Token));
+
+            await connection.WriteAsync(CreateResponse(request, "normal-response"), server.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task DisposedBrokerRequestHandler_ReturnsNotSupportedResponse()
+    {
+        const int BrokerRequestCode = 1207;
+        const int BrokerOpaque = 7008;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var server = new LoopbackServer(cancellationToken);
+        var serverTask = ServeAsync();
+        await using var client = CreateClient();
+        var registration = client.RegisterRequestHandler(
+            BrokerRequestCode,
+            static _ => ValueTask.FromResult(RemotingRequestResult.NoResponse));
+        registration.Dispose();
+
+        var response = await client.InvokeAsync(
+            server.EndPoint,
+            CreateRequest("open-connection"),
+            OperationTimeout,
+            cancellationToken);
+
+        Assert.Equal("normal-response", Encoding.UTF8.GetString(response.Body!));
+        await serverTask;
+
+        async Task ServeAsync()
+        {
+            using var socket = await server.AcceptAsync();
+            var connection = new CommandConnection(socket.GetStream());
+            var request = await connection.ReadAsync(server.CancellationToken);
+            await connection.WriteAsync(
+                CreateBrokerRequest(BrokerRequestCode, BrokerOpaque),
+                server.CancellationToken);
+
+            var unsupportedResponse = await connection.ReadAsync(server.CancellationToken);
+            Assert.Equal(ResponseCodes.ResRequestCodeNotSupported, unsupportedResponse.Code);
+            Assert.Equal(BrokerOpaque, unsupportedResponse.Opaque);
+            await connection.WriteAsync(CreateResponse(request, "normal-response"), server.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task MultipleBrokerRequestHandlers_UseFirstHandledResponse()
+    {
+        const int BrokerRequestCode = 1208;
+        const int BrokerOpaque = 7009;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var server = new LoopbackServer(cancellationToken);
+        var serverTask = ServeAsync();
+        await using var client = CreateClient();
+        using var firstRegistration = client.RegisterRequestHandler(
+            BrokerRequestCode,
+            static _ => ValueTask.FromResult(RemotingRequestResult.NotHandled));
+        using var secondRegistration = client.RegisterRequestHandler(
+            BrokerRequestCode,
+            static _ => ValueTask.FromResult(RemotingRequestResult.Respond(new RemotingCommand
+            {
+                Code = ResponseCodes.ResSuccess,
+                Body = Encoding.UTF8.GetBytes("first-handler-response")
+            })));
+        using var thirdRegistration = client.RegisterRequestHandler(
+            BrokerRequestCode,
+            static _ => ValueTask.FromResult(RemotingRequestResult.Respond(new RemotingCommand
+            {
+                Code = ResponseCodes.ResError,
+                Body = Encoding.UTF8.GetBytes("second-handler-response")
+            })));
+
+        var response = await client.InvokeAsync(
+            server.EndPoint,
+            CreateRequest("open-connection"),
+            OperationTimeout,
+            cancellationToken);
+
+        Assert.Equal("normal-response", Encoding.UTF8.GetString(response.Body!));
+        await serverTask;
+
+        async Task ServeAsync()
+        {
+            using var socket = await server.AcceptAsync();
+            var connection = new CommandConnection(socket.GetStream());
+            var request = await connection.ReadAsync(server.CancellationToken);
+            await connection.WriteAsync(
+                CreateBrokerRequest(BrokerRequestCode, BrokerOpaque),
+                server.CancellationToken);
+
+            var handlerResponse = await connection.ReadAsync(server.CancellationToken);
+            Assert.Equal(ResponseCodes.ResSuccess, handlerResponse.Code);
+            Assert.Equal(BrokerOpaque, handlerResponse.Opaque);
+            Assert.Equal("first-handler-response", Encoding.UTF8.GetString(handlerResponse.Body!));
+            await connection.WriteAsync(CreateResponse(request, "normal-response"), server.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task TransactionStateHandlerWithoutResponse_SuppressesResponse()
+    {
+        const int BrokerOpaque = 7010;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var server = new LoopbackServer(cancellationToken);
+        var handlerInvoked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var serverTask = ServeAsync();
+        await using var client = CreateClient();
+        using var registration = client.RegisterRequestHandler(
+            RequestCode.CheckTransactionState,
+            _ =>
+            {
+                handlerInvoked.TrySetResult();
+                return ValueTask.FromResult(RemotingRequestResult.NoResponse);
+            });
+
+        var response = await client.InvokeAsync(
+            server.EndPoint,
+            CreateRequest("open-connection"),
+            OperationTimeout,
+            cancellationToken);
+
+        Assert.Equal("normal-response", Encoding.UTF8.GetString(response.Body!));
+        await serverTask;
+
+        async Task ServeAsync()
+        {
+            using var socket = await server.AcceptAsync();
+            var connection = new CommandConnection(socket.GetStream());
+            var request = await connection.ReadAsync(server.CancellationToken);
+            await connection.WriteAsync(
+                CreateBrokerRequest(RequestCode.CheckTransactionState, BrokerOpaque),
+                server.CancellationToken);
+            await handlerInvoked.Task.WaitAsync(OperationTimeout, server.CancellationToken);
+
+            using var noResponseCts = CancellationTokenSource.CreateLinkedTokenSource(server.CancellationToken);
+            noResponseCts.CancelAfter(TimeSpan.FromMilliseconds(250));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                connection.ReadAsync(noResponseCts.Token));
+
+            await connection.WriteAsync(CreateResponse(request, "normal-response"), server.CancellationToken);
+        }
+    }
+
+    [Fact]
     public async Task SyncHandlerWithoutResponse_ReturnsErrorInsteadOfTimingOut()
     {
         const int BrokerRequestCode = 1205;
@@ -769,6 +979,63 @@ public sealed class RemotingClientTests
                 CreateBrokerRequest(BrokerRequestCode, opaque: 7003, oneway: true),
                 server.CancellationToken);
             await handlerEntered.Task.WaitAsync(OperationTimeout, server.CancellationToken);
+            await connection.WriteAsync(CreateResponse(request, "normal-response"), server.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task FullInboundRequestQueue_ReturnsSystemBusyResponse()
+    {
+        const int BrokerRequestCode = 1209;
+        const int InitialBrokerOpaque = 8000;
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var server = new LoopbackServer(cancellationToken);
+        var workersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handlerCount = 0;
+        var serverTask = ServeAsync();
+        await using var client = CreateClient();
+        using var registration = client.RegisterRequestHandler(BrokerRequestCode, async context =>
+        {
+            if (Interlocked.Increment(ref handlerCount) == 2)
+            {
+                workersStarted.TrySetResult();
+            }
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, context.CancellationToken);
+            return RemotingRequestResult.NoResponse;
+        });
+
+        var response = await client.InvokeAsync(
+            server.EndPoint,
+            CreateRequest("open-connection"),
+            OperationTimeout,
+            cancellationToken);
+
+        Assert.Equal("normal-response", Encoding.UTF8.GetString(response.Body!));
+        await serverTask;
+
+        async Task ServeAsync()
+        {
+            using var socket = await server.AcceptAsync();
+            var connection = new CommandConnection(socket.GetStream());
+            var request = await connection.ReadAsync(server.CancellationToken);
+            await connection.WriteManyAsync(
+                [
+                    CreateBrokerRequest(BrokerRequestCode, InitialBrokerOpaque),
+                    CreateBrokerRequest(BrokerRequestCode, InitialBrokerOpaque + 1)
+                ],
+                server.CancellationToken);
+            await workersStarted.Task.WaitAsync(OperationTimeout, server.CancellationToken);
+
+            await connection.WriteManyAsync(
+                Enumerable.Range(2, 129)
+                    .Select(index => CreateBrokerRequest(BrokerRequestCode, InitialBrokerOpaque + index)),
+                server.CancellationToken);
+
+            var busyResponse = await connection.ReadAsync(server.CancellationToken);
+            Assert.Equal(ResponseCodes.ResSystemBusy, busyResponse.Code);
+            Assert.Equal(InitialBrokerOpaque + 130, busyResponse.Opaque);
+            Assert.True(busyResponse.IsResponseType());
             await connection.WriteAsync(CreateResponse(request, "normal-response"), server.CancellationToken);
         }
     }


### PR DESCRIPTION
## Summary
- make gRPC and Remoting consumer shutdown cancellation-safe when handlers do not cooperate
- prevent late handler results from being acknowledged after cancellation
- preserve concurrent gRPC producer topic telemetry settings and retry retryable Remoting reply-heartbeat failures
- add regression coverage for producer, consumer, telemetry-session, transport, and remoting request handling edge cases

## Validation
- dotnet format EventHorizon.RocketMQ.slnx --no-restore
- gRPC, Remoting, and compatibility unit tests on net8.0 and net10.0
- gRPC integration tests (9 passed)
- Remoting integration tests (19 passed)