### PR TITLE
fix: harden push consumer delivery

### DIFF
--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -85,8 +85,10 @@ manual Compose ports. The protocol-specific test projects are:
 The multi-Broker fixtures complement the baseline fixture:
 
 - [`RocketMQMultiBrokerRemotingContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs)
-  starts a NameServer and three host-reachable master Brokers. The Remoting test requires a complete route for
-  `broker-a`, `broker-b`, and `broker-c`, then sends to an explicit queue on each Broker.
+  starts a NameServer and three host-reachable master Brokers, each with three explicit read and write queues.
+  The Remoting tests require the complete nine-queue route, send to every physical queue, verify a Push consumer
+  commits each queue, and verify clustered groups with three consumers and ten consumers. The latter confirms that
+  consumers in excess of the nine queues remain unassigned without duplicate delivery.
 - [`RocketMQMultiBrokerGrpcContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs)
   starts a NameServer, three master Brokers, and a cluster-mode Proxy on an isolated Docker network. The gRPC test
   sends through the Proxy and confirms that every Broker has stored messages.

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -83,8 +83,10 @@ Broker 与 cluster-mode Proxy 在同一容器中按顺序启动：Broker 先注�
 
 多 Broker 覆盖使用两套协议隔离的 fixture：
 
-- Remoting fixture 启动 NameServer 和三个宿主机可达的 master Broker。测试断言 NameServer 返回
-  `broker-a`、`broker-b`、`broker-c` 的完整 route，并向每台 Broker 的指定队列发送消息。
+- Remoting fixture 启动 NameServer 和三个宿主机可达的 master Broker，并在每台 Broker 上显式创建三个读写队列。
+  测试断言完整的九个物理队列 route，逐队列定向发送消息，验证一个 PushConsumer 会提交每个队列的 offset，
+  并验证同组的三个及十个 PushConsumer 的分配。十个 Consumer 多于九个队列时，多出的实例保持未分配，
+  且不会产生重复投递。
 - gRPC fixture 在隔离 Docker network 中启动 NameServer、三个 master Broker 和 cluster-mode Proxy。测试通过 Proxy
   发送消息，再查询每台 Broker 的 topic 状态，确认三台 Broker 都有实际写入。
 

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading.Channels;
 using EventHorizon.RocketMQ.Grpc.Instrumentation;
 using Microsoft.Extensions.Logging;
@@ -549,6 +550,14 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             {
                 await ProcessOrderedMessageAsync(message, cancellationToken).ConfigureAwait(false);
             }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                HandleUnexpectedMessageProcessingFailure(messages, message, exception);
+            }
             finally
             {
                 ReleaseCachedMessageBytes(message);
@@ -761,14 +770,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         while (true)
         {
             ConsumeResult result;
-            using var telemetry = _telemetry.StartProcess(
-                message.Topic,
-                _options.GroupName,
-                message.MessageId,
-                message.QueueId,
-                message.Body.LongLength,
-                message.Properties,
-                message.ReceiveActivityContext);
+            var telemetry = StartMessageProcessingTelemetry(message);
             try
             {
                 HandlerExecution execution;
@@ -787,20 +789,29 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 }
 
                 result = execution.Result;
-                telemetry.Complete(
+                CompleteMessageProcessingTelemetry(
+                    telemetry,
+                    message,
                     result == ConsumeResult.Success,
                     execution.TimedOut ? "timeout" : result.ToString());
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                telemetry.Complete(new OperationCanceledException(cancellationToken));
+                CompleteMessageProcessingTelemetry(
+                    telemetry,
+                    message,
+                    new OperationCanceledException(cancellationToken));
                 throw;
             }
             catch (Exception exception)
             {
-                telemetry.Complete(exception);
+                CompleteMessageProcessingTelemetry(telemetry, message, exception);
                 _logger.LogError(exception, "Message handler failed for message {MessageId}", message.MessageId);
                 result = ConsumeResult.Retry;
+            }
+            finally
+            {
+                DisposeMessageProcessingTelemetry(telemetry, message);
             }
 
             if (!fifo || result != ConsumeResult.Retry)
@@ -826,6 +837,95 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 retryDelay,
                 fifoRetryCancellationToken,
                 cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private void HandleUnexpectedMessageProcessingFailure(
+        Channel<GrpcMessageView> messages,
+        GrpcMessageView message,
+        Exception exception)
+    {
+        if (ReferenceEquals(messages, _messages) && _fifoOrders.TryGetValue(message, out var order))
+        {
+            BlockFifoOrder(message, order);
+            _logger.LogError(
+                exception,
+                "Unexpected failure while processing FIFO message {MessageId}; the group remains blocked to preserve ordering and the message may be redelivered",
+                message.MessageId);
+            return;
+        }
+
+        _logger.LogError(
+            exception,
+            "Unexpected failure while processing message {MessageId}; it will not be acknowledged and may be redelivered",
+            message.MessageId);
+    }
+
+    private IGrpcRocketMQTelemetryOperation StartMessageProcessingTelemetry(GrpcMessageView message)
+    {
+        try
+        {
+            return _telemetry.StartProcess(
+                       message.Topic,
+                       _options.GroupName,
+                       message.MessageId,
+                       message.QueueId,
+                       message.Body.LongLength,
+                       message.Properties,
+                       message.ReceiveActivityContext) ?? NoopTelemetryOperation.Instance;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Failed to start process telemetry for message {MessageId}", message.MessageId);
+            return NoopTelemetryOperation.Instance;
+        }
+    }
+
+    private void CompleteMessageProcessingTelemetry(
+        IGrpcRocketMQTelemetryOperation telemetry,
+        GrpcMessageView message,
+        bool success,
+        string? outcome)
+    {
+        try
+        {
+            telemetry.Complete(success, outcome);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Failed to complete process telemetry for message {MessageId}", message.MessageId);
+        }
+    }
+
+    private void CompleteMessageProcessingTelemetry(
+        IGrpcRocketMQTelemetryOperation telemetry,
+        GrpcMessageView message,
+        Exception exception)
+    {
+        try
+        {
+            telemetry.Complete(exception);
+        }
+        catch (Exception telemetryException)
+        {
+            _logger.LogWarning(
+                telemetryException,
+                "Failed to complete failed-process telemetry for message {MessageId}",
+                message.MessageId);
+        }
+    }
+
+    private void DisposeMessageProcessingTelemetry(
+        IGrpcRocketMQTelemetryOperation telemetry,
+        GrpcMessageView message)
+    {
+        try
+        {
+            telemetry.Dispose();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Failed to dispose process telemetry for message {MessageId}", message.MessageId);
         }
     }
 
@@ -1077,6 +1177,29 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         public string Key { get; }
         public Task Predecessor { get; }
         public TaskCompletionSource Completion { get; }
+    }
+
+    private sealed class NoopTelemetryOperation : IGrpcRocketMQTelemetryOperation
+    {
+        public static NoopTelemetryOperation Instance { get; } = new();
+
+        public Activity? Activity => null;
+
+        public void Complete()
+        {
+        }
+
+        public void Complete(bool success, string? outcome = null)
+        {
+        }
+
+        public void Complete(Exception exception)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
     }
 
     private sealed class AssignmentReceiver(

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
@@ -922,9 +922,9 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                     .ConfigureAwait(false);
                 if (result.Status == RemotingPullStatus.OffsetIllegal)
                 {
-                    offset = result.NextOffset;
-                    await PersistOffsetAndClearResetBoundaryAsync(queue, offset, cancellationToken)
+                    await PersistOffsetAndClearResetBoundaryAsync(queue, result.NextOffset, cancellationToken)
                         .ConfigureAwait(false);
+                    offset = result.NextOffset;
                     continue;
                 }
 
@@ -1046,9 +1046,9 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                     }
                 }
 
-                offset = result.NextOffset;
-                await PersistOffsetAndClearResetBoundaryAsync(queue, offset, cancellationToken)
+                await PersistOffsetAndClearResetBoundaryAsync(queue, result.NextOffset, cancellationToken)
                     .ConfigureAwait(false);
+                offset = result.NextOffset;
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1128,9 +1128,9 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
 
                 if (result.Status == RemotingPullStatus.OffsetIllegal)
                 {
-                    offset = result.NextOffset;
-                    await PersistOffsetAndClearResetBoundaryAsync(queue, offset, cancellationToken)
+                    await PersistOffsetAndClearResetBoundaryAsync(queue, result.NextOffset, cancellationToken)
                         .ConfigureAwait(false);
+                    offset = result.NextOffset;
                     continue;
                 }
 
@@ -1195,9 +1195,10 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
                         break;
                     }
 
-                    offset = checked(message.QueueOffset + 1);
-                    await PersistOffsetAndClearResetBoundaryAsync(queue, offset, cancellationToken)
+                    var nextOffset = checked(message.QueueOffset + 1);
+                    await PersistOffsetAndClearResetBoundaryAsync(queue, nextOffset, cancellationToken)
                         .ConfigureAwait(false);
+                    offset = nextOffset;
                 }
 
                 if (!completed)
@@ -1207,9 +1208,9 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
 
                 if (result.NextOffset > offset)
                 {
-                    offset = result.NextOffset;
-                    await PersistOffsetAndClearResetBoundaryAsync(queue, offset, cancellationToken)
+                    await PersistOffsetAndClearResetBoundaryAsync(queue, result.NextOffset, cancellationToken)
                         .ConfigureAwait(false);
+                    offset = result.NextOffset;
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
@@ -49,6 +49,11 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
     /// </summary>
     public const string TestTopic = "rocketmq-dotnet-remoting-multi-broker-it";
 
+    /// <summary>
+    /// Gets the number of readable and writable queues created on each Broker for the test topic.
+    /// </summary>
+    public const int QueuesPerBroker = 3;
+
     private readonly INetwork _network = new NetworkBuilder().Build();
     private readonly IContainer _nameServer;
     private readonly IContainer _brokerA;
@@ -130,7 +135,8 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
             "brokerIP1=127.0.0.1\n" +
             $"namesrvAddr=nameserver:{NameServerPort}\n" +
             $"listenPort={port}\n" +
-            "autoCreateTopicEnable=true\n");
+            "autoCreateTopicEnable=true\n" +
+            "autoCreateSubscriptionGroup=true\n");
 
         return new ContainerBuilder(Image)
             .WithNetwork(_network)
@@ -182,6 +188,8 @@ public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
                 "-n", $"nameserver:{NameServerPort}",
                 "-b", $"{brokerName}:{port}",
                 "-t", TestTopic,
+                "-r", QueuesPerBroker.ToString(),
+                "-w", QueuesPerBroker.ToString(),
                 "-a", "+message.type=NORMAL"
             ]).ConfigureAwait(false);
             if (createTopic.ExitCode != 0)

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
@@ -13,8 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Concurrent;
 using System.Text;
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
+using EventHorizon.RocketMQ.Remoting.Admin;
+using EventHorizon.RocketMQ.Remoting.Consumer;
+using EventHorizon.RocketMQ.Remoting.Consumer.Push;
 using EventHorizon.RocketMQ.Remoting.Producer;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -25,6 +29,13 @@ namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 [Trait("Topology", "MultiBroker")]
 public sealed class RocketMQMultiBrokerIntegrationTests
 {
+    private static readonly string[] BrokerNames =
+    [
+        RocketMQMultiBrokerRemotingContainerFixture.BrokerAName,
+        RocketMQMultiBrokerRemotingContainerFixture.BrokerBName,
+        RocketMQMultiBrokerRemotingContainerFixture.BrokerCName
+    ];
+
     private readonly RocketMQMultiBrokerRemotingContainerFixture _fixture;
 
     public RocketMQMultiBrokerIntegrationTests(RocketMQMultiBrokerRemotingContainerFixture fixture)
@@ -34,7 +45,7 @@ public sealed class RocketMQMultiBrokerIntegrationTests
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task ProducerDiscoversAndSendsToAllBrokers()
+    public async Task ProducerDiscoversAndSendsToEveryQueueOnAllBrokers()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var services = new ServiceCollection();
@@ -47,36 +58,295 @@ public sealed class RocketMQMultiBrokerIntegrationTests
         await producer.StartAsync(cancellationToken);
         try
         {
-            var queues = await producer.GetPublishMessageQueuesAsync(
-                RocketMQMultiBrokerRemotingContainerFixture.TestTopic,
-                cancellationToken);
-            var brokerNames = queues.Select(queue => queue.BrokerName).Distinct(StringComparer.Ordinal).ToArray();
-            Assert.Equal(
-                new[]
-                {
-                    RocketMQMultiBrokerRemotingContainerFixture.BrokerAName,
-                    RocketMQMultiBrokerRemotingContainerFixture.BrokerBName,
-                    RocketMQMultiBrokerRemotingContainerFixture.BrokerCName
-                },
-                brokerNames.OrderBy(static brokerName => brokerName, StringComparer.Ordinal).ToArray());
-
-            foreach (var brokerName in brokerNames)
+            var queues = await GetExpectedQueuesAsync(producer, cancellationToken);
+            foreach (var queue in queues)
             {
-                var queue = queues.First(candidate => candidate.BrokerName == brokerName);
-                var body = $"remoting-multi-broker-{brokerName}-{Guid.NewGuid():N}";
+                var body = $"remoting-multi-broker-{queue.BrokerName}-{queue.QueueId}-{Guid.NewGuid():N}";
                 var result = await producer.SendAsync(
                     new Message(RocketMQMultiBrokerRemotingContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body)),
                     queue,
                     cancellationToken);
 
                 Assert.Equal(RemotingSendStatus.SendOk, result.Status);
-                Assert.Equal(brokerName, result.MessageQueue.BrokerName);
+                Assert.Equal(queue.BrokerName, result.MessageQueue.BrokerName);
                 Assert.Equal(queue.QueueId, result.MessageQueue.QueueId);
             }
         }
         finally
         {
             await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task PushConsumerConsumesAndCommitsEveryQueueAcrossAllBrokers()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var suffix = Guid.NewGuid().ToString("N");
+        var group = $"remoting-multi-broker-push-{suffix}";
+        var tag = $"multi-broker-push-{suffix}";
+        var expectedQueueCount = BrokerNames.Length * RocketMQMultiBrokerRemotingContainerFixture.QueuesPerBroker;
+        var deliveries = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var allConsumed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQRemoting(options =>
+            {
+                options.NamesrvAddr = _fixture.NameServerAddress;
+                options.InstanceName = $"remoting-multi-broker-push-{suffix}";
+                options.HeartbeatBrokerInterval = TimeSpan.FromMilliseconds(250);
+                options.PollNameServerInterval = TimeSpan.FromMilliseconds(250);
+            })
+            .AddRemotingAdmin()
+            .AddRemotingProducer(options => options.GroupName = $"remoting-multi-broker-producer-{suffix}")
+            .AddRemotingPushConsumer(options =>
+            {
+                options.GroupName = group;
+                options.MaxConcurrency = 4;
+                options.BatchSize = 1;
+                options.ConsumeMessageBatchSize = 1;
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+                options.RetryDelay = TimeSpan.FromMilliseconds(100);
+                options.Subscribe(RocketMQMultiBrokerRemotingContainerFixture.TestTopic, new FilterExpression(tag));
+                options.MessageHandler = (messages, _, _) =>
+                {
+                    foreach (var message in messages)
+                    {
+                        var body = Encoding.UTF8.GetString(message.Body);
+                        deliveries.AddOrUpdate(body, 1, static (_, count) => count + 1);
+                    }
+
+                    if (deliveries.Count == expectedQueueCount)
+                    {
+                        allConsumed.TrySetResult();
+                    }
+
+                    return ValueTask.FromResult(ConsumeResult.Success);
+                };
+            });
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var admin = provider.GetRequiredService<IRemotingAdmin>();
+        var producer = provider.GetRequiredService<IRemotingProducer>();
+        var consumer = provider.GetRequiredService<IRemotingPushConsumer>();
+        await producer.StartAsync(cancellationToken);
+        await consumer.StartAsync(cancellationToken);
+        try
+        {
+            var queues = await GetExpectedQueuesAsync(producer, cancellationToken);
+            var expectedBodies = await SendMessageToEveryQueueAsync(producer, queues, tag, cancellationToken);
+
+            await allConsumed.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+
+            Assert.Equal(
+                expectedBodies.OrderBy(static body => body, StringComparer.Ordinal),
+                deliveries.Keys.OrderBy(static body => body, StringComparer.Ordinal));
+            Assert.All(deliveries, static delivery => Assert.Equal(1, delivery.Value));
+            await AssertOffsetsCommittedAsync(admin, group, queues, cancellationToken);
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(10)]
+    [Trait("Category", "Integration")]
+    public async Task PushConsumersInSameGroupShareQueuesWithoutDuplicates(int consumerCount)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var suffix = Guid.NewGuid().ToString("N");
+        var group = $"remoting-multi-broker-group-{consumerCount}-{suffix}";
+        var tag = $"multi-broker-group-{consumerCount}-{suffix}";
+        var expectedQueueCount = BrokerNames.Length * RocketMQMultiBrokerRemotingContainerFixture.QueuesPerBroker;
+        var deliveries = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var deliveriesByConsumer = new ConcurrentDictionary<int, int>();
+        var allConsumed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consumerProviders = new List<ServiceProvider>(consumerCount);
+        var consumers = new List<IRemotingPushConsumer>(consumerCount);
+
+        var producerServices = new ServiceCollection();
+        producerServices
+            .AddRocketMQRemoting(options => options.NamesrvAddr = _fixture.NameServerAddress)
+            .AddRemotingAdmin()
+            .AddRemotingProducer(options => options.GroupName = $"remoting-multi-broker-producer-{suffix}");
+        await using var producerProvider = producerServices.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true });
+        var admin = producerProvider.GetRequiredService<IRemotingAdmin>();
+        var producer = producerProvider.GetRequiredService<IRemotingProducer>();
+
+        try
+        {
+            for (var index = 0; index < consumerCount; index++)
+            {
+                var consumerIndex = index;
+                var provider = CreatePushConsumerProvider(
+                    group,
+                    $"remoting-multi-broker-group-{suffix}-{consumerIndex}",
+                    tag,
+                    body =>
+                    {
+                        deliveries.AddOrUpdate(body, 1, static (_, count) => count + 1);
+                        deliveriesByConsumer.AddOrUpdate(consumerIndex, 1, static (_, count) => count + 1);
+                        if (deliveries.Count == expectedQueueCount)
+                        {
+                            allConsumed.TrySetResult();
+                        }
+                    });
+                consumerProviders.Add(provider);
+                consumers.Add(provider.GetRequiredService<IRemotingPushConsumer>());
+            }
+
+            await producer.StartAsync(cancellationToken);
+            await Task.WhenAll(consumers.Select(consumer => consumer.StartAsync(cancellationToken).AsTask()));
+            await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+
+            var queues = await GetExpectedQueuesAsync(producer, cancellationToken);
+            var expectedBodies = await SendMessageToEveryQueueAsync(producer, queues, tag, cancellationToken);
+
+            await allConsumed.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+
+            Assert.Equal(
+                expectedBodies.OrderBy(static body => body, StringComparer.Ordinal),
+                deliveries.Keys.OrderBy(static body => body, StringComparer.Ordinal));
+            Assert.All(deliveries, static delivery => Assert.Equal(1, delivery.Value));
+            Assert.Equal(Math.Min(consumerCount, queues.Count), deliveriesByConsumer.Count);
+            Assert.Equal(Math.Max(0, consumerCount - queues.Count), consumerCount - deliveriesByConsumer.Count);
+            await AssertOffsetsCommittedAsync(admin, group, queues, cancellationToken);
+        }
+        finally
+        {
+            await Task.WhenAll(consumers.Select(consumer => consumer.StopAsync(CancellationToken.None).AsTask()));
+            await Task.WhenAll(consumerProviders.Select(provider => provider.DisposeAsync().AsTask()));
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private ServiceProvider CreatePushConsumerProvider(
+        string group,
+        string instanceName,
+        string tag,
+        Action<string> onMessage)
+    {
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQRemoting(options =>
+            {
+                options.NamesrvAddr = _fixture.NameServerAddress;
+                options.InstanceName = instanceName;
+                options.HeartbeatBrokerInterval = TimeSpan.FromMilliseconds(250);
+                options.PollNameServerInterval = TimeSpan.FromMilliseconds(250);
+            })
+            .AddRemotingPushConsumer(options =>
+            {
+                options.GroupName = group;
+                options.MaxConcurrency = 1;
+                options.BatchSize = 1;
+                options.ConsumeMessageBatchSize = 1;
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+                options.RetryDelay = TimeSpan.FromMilliseconds(100);
+                options.Subscribe(RocketMQMultiBrokerRemotingContainerFixture.TestTopic, new FilterExpression(tag));
+                options.MessageHandler = (messages, _, _) =>
+                {
+                    foreach (var message in messages)
+                    {
+                        onMessage(Encoding.UTF8.GetString(message.Body));
+                    }
+
+                    return ValueTask.FromResult(ConsumeResult.Success);
+                };
+            });
+
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+    }
+
+    private async Task<IReadOnlyList<RemotingMessageQueue>> GetExpectedQueuesAsync(
+        IRemotingProducer producer,
+        CancellationToken cancellationToken)
+    {
+        var queues = await producer.GetPublishMessageQueuesAsync(
+            RocketMQMultiBrokerRemotingContainerFixture.TestTopic,
+            cancellationToken);
+        Assert.Equal(BrokerNames.Length * RocketMQMultiBrokerRemotingContainerFixture.QueuesPerBroker, queues.Count);
+
+        foreach (var brokerName in BrokerNames)
+        {
+            var brokerQueues = queues
+                .Where(queue => queue.BrokerName == brokerName)
+                .OrderBy(queue => queue.QueueId)
+                .ToArray();
+            Assert.Equal(RocketMQMultiBrokerRemotingContainerFixture.QueuesPerBroker, brokerQueues.Length);
+            Assert.Equal(
+                Enumerable.Range(0, RocketMQMultiBrokerRemotingContainerFixture.QueuesPerBroker),
+                brokerQueues.Select(queue => queue.QueueId));
+        }
+
+        return queues
+            .OrderBy(queue => queue.BrokerName, StringComparer.Ordinal)
+            .ThenBy(queue => queue.QueueId)
+            .ToArray();
+    }
+
+    private static async Task<IReadOnlySet<string>> SendMessageToEveryQueueAsync(
+        IRemotingProducer producer,
+        IReadOnlyList<RemotingMessageQueue> queues,
+        string tag,
+        CancellationToken cancellationToken)
+    {
+        var expectedBodies = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var queue in queues)
+        {
+            var body = $"{tag}-{queue.BrokerName}-{queue.QueueId}";
+            Assert.True(expectedBodies.Add(body));
+            var result = await producer.SendAsync(
+                new Message(RocketMQMultiBrokerRemotingContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body))
+                {
+                    Tag = tag
+                },
+                queue,
+                cancellationToken);
+            Assert.Equal(RemotingSendStatus.SendOk, result.Status);
+            Assert.Equal(queue.BrokerName, result.MessageQueue.BrokerName);
+            Assert.Equal(queue.QueueId, result.MessageQueue.QueueId);
+        }
+
+        return expectedBodies;
+    }
+
+    private static async Task AssertOffsetsCommittedAsync(
+        IRemotingAdmin admin,
+        string group,
+        IReadOnlyList<RemotingMessageQueue> queues,
+        CancellationToken cancellationToken)
+    {
+        foreach (var queue in queues)
+        {
+            var expectedOffset = await admin.GetMaxOffsetAsync(queue, cancellationToken: cancellationToken);
+            var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+            long? committedOffset;
+            do
+            {
+                committedOffset = await admin.GetConsumerOffsetAsync(group, queue, cancellationToken);
+                if (committedOffset >= expectedOffset)
+                {
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+            }
+            while (DateTimeOffset.UtcNow < deadline);
+
+            Assert.True(
+                committedOffset >= expectedOffset,
+                $"Consumer group '{group}' did not commit {queue.BrokerName}/{queue.QueueId}. " +
+                $"Expected at least {expectedOffset}, actual {committedOffset?.ToString() ?? "<none>"}.");
         }
     }
 }

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
@@ -817,6 +817,189 @@ public sealed class GrpcPushConsumerTests
     }
 
     [Fact]
+    public async Task Worker_ContinuesWhenProcessTelemetryStartFails()
+    {
+        var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartProcess(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<ActivityContext?>()))
+            .Throws(new InvalidOperationException("process telemetry failed"));
+        var client = new FakeGrpcClient();
+        var handled = 0;
+        await using var consumer = CreateConsumer(
+            client,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref handled);
+                return ValueTask.FromResult(ConsumeResult.Success);
+            },
+            out var engine,
+            telemetry: telemetry.Object);
+
+        await RunWorkerAsync(
+            consumer,
+            engine,
+            TestContext.Current.CancellationToken,
+            Message("first"),
+            Message("second"));
+
+        Assert.Equal(2, Volatile.Read(ref handled));
+        Assert.Equal(2, client.AckRequests.Count);
+        telemetry.Verify(
+            value => value.StartProcess(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<ActivityContext?>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Worker_ContinuesWhenProcessTelemetryCompletionOrDisposalFails()
+    {
+        var operation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation
+            .Setup(value => value.Complete(true, ConsumeResult.Success.ToString()))
+            .Throws(new InvalidOperationException("process telemetry completion failed"));
+        operation
+            .Setup(value => value.Dispose())
+            .Throws(new InvalidOperationException("process telemetry disposal failed"));
+        var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartProcess(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<long>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
+                It.IsAny<ActivityContext?>()))
+            .Returns(operation.Object);
+        var client = new FakeGrpcClient();
+        var handled = 0;
+        await using var consumer = CreateConsumer(
+            client,
+            (_, _) =>
+            {
+                Interlocked.Increment(ref handled);
+                return ValueTask.FromResult(ConsumeResult.Success);
+            },
+            out var engine,
+            telemetry: telemetry.Object);
+
+        await RunWorkerAsync(
+            consumer,
+            engine,
+            TestContext.Current.CancellationToken,
+            Message("first"),
+            Message("second"));
+
+        Assert.Equal(2, Volatile.Read(ref handled));
+        Assert.Equal(2, client.AckRequests.Count);
+        operation.Verify(value => value.Complete(true, ConsumeResult.Success.ToString()), Times.Exactly(2));
+        operation.Verify(value => value.Dispose(), Times.Exactly(2));
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
+    public async Task Worker_ContinuesAfterUnexpectedMessageProcessingFailure()
+    {
+        var engine = new Mock<IGrpcReceiveConsumerEngine>(MockBehavior.Strict);
+        engine
+            .Setup(value => value.GetMaxDeliveryAttempts(It.IsAny<GrpcMessageView>(), It.IsAny<int>()))
+            .Returns((GrpcMessageView message, int fallback) =>
+            {
+                if (message.MessageId == "first")
+                {
+                    throw new InvalidOperationException("processing failed before handling");
+                }
+
+                return fallback;
+            });
+        engine
+            .Setup(value => value.AckAsync(
+                It.Is<GrpcMessageView>(message => message.MessageId == "second"),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        engine.Setup(value => value.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        var handled = new ConcurrentQueue<string>();
+        await using var consumer = new GrpcPushConsumer(
+            Options.Create(PushOptions((message, _) =>
+            {
+                handled.Enqueue(message.MessageId);
+                return ValueTask.FromResult(ConsumeResult.Success);
+            })),
+            engine.Object,
+            NullLogger<GrpcPushConsumer>.Instance);
+
+        var channelField = typeof(GrpcPushConsumer).GetField("_messages", BindingFlags.Instance | BindingFlags.NonPublic);
+        var processMethod = typeof(GrpcPushConsumer).GetMethod("ProcessMessagesAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        var channel = Assert.IsAssignableFrom<Channel<GrpcMessageView>>(channelField?.GetValue(consumer));
+        var worker = Assert.IsAssignableFrom<Task>(processMethod?.Invoke(consumer, [TestContext.Current.CancellationToken]));
+        await channel.Writer.WriteAsync(Message("first"), TestContext.Current.CancellationToken);
+        await channel.Writer.WriteAsync(Message("second"), TestContext.Current.CancellationToken);
+        channel.Writer.Complete();
+
+        await worker.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.Equal(["second"], handled);
+        engine.Verify(
+            value => value.AckAsync(
+                It.Is<GrpcMessageView>(message => message.MessageId == "second"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UnexpectedFifoProcessingFailureKeepsSuccessorBlocked()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var processingCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var engine = new Mock<IGrpcReceiveConsumerEngine>(MockBehavior.Strict);
+        engine
+            .Setup(value => value.GetMaxDeliveryAttempts(
+                It.Is<GrpcMessageView>(message => message.MessageId == "first"),
+                It.IsAny<int>()))
+            .Throws(new InvalidOperationException("processing failed before handling"));
+        engine.Setup(value => value.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        var handled = 0;
+        await using var consumer = new GrpcPushConsumer(
+            Options.Create(PushOptions((_, _) =>
+            {
+                Interlocked.Increment(ref handled);
+                return ValueTask.FromResult(ConsumeResult.Success);
+            })),
+            engine.Object,
+            NullLogger<GrpcPushConsumer>.Instance);
+
+        var channelField = typeof(GrpcPushConsumer).GetField("_messages", BindingFlags.Instance | BindingFlags.NonPublic);
+        var blockedSignalField = typeof(GrpcPushConsumer).GetField("_fifoBlockedSignal", BindingFlags.Instance | BindingFlags.NonPublic);
+        var processMethod = typeof(GrpcPushConsumer).GetMethod("ProcessMessagesAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        var channel = Assert.IsAssignableFrom<Channel<GrpcMessageView>>(channelField?.GetValue(consumer));
+        var blockedSignal = Assert.IsType<TaskCompletionSource>(blockedSignalField?.GetValue(consumer));
+        var worker = Assert.IsAssignableFrom<Task>(processMethod?.Invoke(consumer, [processingCancellation.Token]));
+        await InvokeEnqueueAsync(consumer, Message("first", "account-7"), cancellationToken);
+        await InvokeEnqueueAsync(consumer, Message("second", "account-7"), cancellationToken);
+        channel.Writer.Complete();
+
+        await blockedSignal.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        Assert.Equal(0, Volatile.Read(ref handled));
+
+        processingCancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            worker.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken));
+    }
+
+    [Fact]
     public async Task Worker_RetriesAckAfterTransientFailureAndContinues()
     {
         var client = new FakeGrpcClient();

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
@@ -1926,6 +1926,59 @@ public sealed class RemotingPushConsumerTests
     }
 
     [Fact]
+    public async Task ConcurrentPushConsumer_RepullsBatchFromSameOffsetWhenCommitFails()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var releaseFirstPull = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var orderPulls = 0;
+        var body = CreateMessageRecord("orders", "commit-retry", null, 0, 1_000);
+        var remoting = new FakeRemotingClient("127.0.0.1@concurrent-commit-retry")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Increment(ref orderPulls) == 1)
+                {
+                    await releaseFirstPull.Task.WaitAsync(token);
+                    return PullSuccess(body, 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            RetryDelay = TimeSpan.FromMilliseconds(10),
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "concurrent-commit-retry");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForTopicPullsAsync("orders", 1, cancellationToken);
+        remoting.FailNextOffsetUpdate();
+        releaseFirstPull.TrySetResult();
+        await remoting.WaitForTopicPullsAsync("orders", 2, cancellationToken);
+
+        Assert.Equal(
+            [0L, 0L],
+            remoting.PullOffsets
+                .Where(static pull => pull.Topic == "orders")
+                .Take(2)
+                .Select(static pull => pull.Offset));
+    }
+
+    [Fact]
     public async Task FifoRetryKeepsSameGroupSuccessorBlockedUntilPredecessorSucceedsAndIgnoresBatchAcknowledgementContext()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -2895,6 +2948,60 @@ public sealed class RemotingPushConsumerTests
         Assert.Contains(
             remoting.UpdatedOffsets,
             static update => update.Topic == "orders" && update.Offset == 2);
+    }
+
+    [Fact]
+    public async Task OrderlyConsumer_RepullsMessageFromSameOffsetWhenCommitFails()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var releaseFirstPull = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var orderPulls = 0;
+        var body = CreateMessageRecord("orders", "orderly-commit-retry", null, 0, 1_000);
+        var remoting = new FakeRemotingClient("127.0.0.1@orderly-commit-retry")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Increment(ref orderPulls) == 1)
+                {
+                    await releaseFirstPull.Task.WaitAsync(token);
+                    return PullSuccess(body, 1);
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            }
+        };
+        var options = new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            ConsumeOrderly = true,
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxCachedMessages = 1,
+            RetryDelay = TimeSpan.FromMilliseconds(10),
+            LongPollingTimeout = TimeSpan.FromSeconds(1),
+            MessageHandler = static (_, _, _) => ValueTask.FromResult(ConsumeResult.Success)
+        };
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "orderly-commit-retry");
+
+        await consumer.StartAsync(cancellationToken);
+        await remoting.WaitForTopicPullsAsync("orders", 1, cancellationToken);
+        remoting.FailNextOffsetUpdate();
+        releaseFirstPull.TrySetResult();
+        await remoting.WaitForTopicPullsAsync("orders", 2, cancellationToken);
+
+        Assert.Equal(
+            [0L, 0L],
+            remoting.PullOffsets
+                .Where(static pull => pull.Topic == "orders")
+                .Take(2)
+                .Select(static pull => pull.Offset));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- keep gRPC Push consumer processing healthy across setup and telemetry failures
- persist Remoting queue offsets according to the active assignment
- cover three Brokers with three queues each, multiple consumers, and more consumers than queues
- synchronize the English and Chinese integration-testing guidance

## Verification

- relevant gRPC and Remoting PushConsumer unit tests passed
- multi-Broker filtered Remoting integration tests passed: 4/4
- full Remoting integration test project passed: 22/22
- formatting verification passed