### PR TITLE
fix(remoting): persist forced reset offsets promptly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,10 @@ topology, or manual environment.
   integration test covers the full workflow, add or retain focused unit tests for the underlying state transitions,
   allocation, scheduling, offset, retry, and failure invariants; use integration tests to complement them at real
   Broker, NameServer, Proxy, transport, persistence, and cross-process boundaries.
-- Integration suites must cover both the normal workflow and relevant abnormal behavior at those real boundaries,
-  including failure isolation, retries, blocked work, recovery, and persistence when the changed behavior involves
-  them.
+- Integration suites must cover both the normal workflow and relevant abnormal behavior that can be exercised
+  deterministically at those real boundaries, including failure isolation, retries, blocked work, recovery, and
+  persistence when the live environment provides a stable trigger. Low-level transport or persistence failures that
+  cannot be injected reliably remain mandatory unit-test cases; do not replace them with flaky Docker fault injection.
 - Matching foundational-model changes require both protocol unit-test projects and the compatibility project. Run the
   matching integration project when behavior crosses a live Broker, NameServer, Proxy, or transport boundary and
   Docker is available.

--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -57,9 +57,11 @@ integration test covers the complete workflow, keep focused unit tests for the u
 allocation, scheduling, offsets, retries, and failure invariants. Integration tests complement those checks at real
 Broker, NameServer, Proxy, transport, persistence, and cross-process boundaries.
 
-Integration suites cover both normal workflows and relevant abnormal behavior at those real boundaries. When a
-change involves failure isolation, retries, blocked work, recovery, or persistence, exercise the corresponding live
-failure path instead of limiting the integration suite to the successful path.
+Integration suites cover both normal workflows and relevant abnormal behavior that can be exercised deterministically
+at those real boundaries. When a change involves failure isolation, retries, blocked work, recovery, or persistence,
+exercise a stable live failure path instead of limiting the integration suite to the successful path. Low-level
+transport or persistence failures that the live environment cannot inject reliably remain mandatory deterministic
+unit-test cases; do not replace them with flaky Docker fault injection.
 
 For example, multi-Broker and multi-queue tests must cover route expansion, exactly-once queue assignment, more
 Consumers than queues, and per-queue scheduling and offset isolation in unit tests. Docker integration tests then

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -59,8 +59,9 @@ dotnet run -c Release --project tests/benchmarks/EventHorizon.RocketMQ.Benchmark
 offset、重试和失败不变量仍必须保留聚焦的 UT；IT 只在此基础上补充真实 Broker、NameServer、Proxy、transport、
 持久化和跨进程边界验证。
 
-IT 必须同时覆盖这些真实边界上的正常链路与相关异常行为。改动涉及故障隔离、重试、阻塞、恢复或持久化时，
-需要执行对应的真实失败路径，不能只验证成功路径。
+IT 必须同时覆盖这些真实边界上可以确定性执行的正常链路与相关异常行为。改动涉及故障隔离、重试、阻塞、恢复或
+持久化时，需要执行稳定的真实失败路径，不能只验证成功路径。若真实环境无法可靠注入底层 transport 或持久化失败，
+这些场景仍必须由确定性 UT 覆盖，不能用易抖动的 Docker 故障注入替代。
 
 例如，多 Broker、多 Queue 行为必须用 UT 覆盖 route 展开、每个队列只分配一次、Consumer 数量多于队列时的
 空闲分配，以及逐队列调度与 offset 隔离；Docker IT 再验证对应的真实 NameServer route、Broker 持久化和

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/ProcessQueue.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/ProcessQueue.cs
@@ -84,6 +84,11 @@ internal sealed class ProcessQueue(RemotingPullMessageQueue messageQueue, Cancel
             _persistedOffset = offset;
             _forcedPersistOffset = forcePersist ? offset : null;
         }
+
+        if (forcePersist)
+        {
+            Signal(_commitAvailable);
+        }
     }
 
     public IReadOnlyList<MessageEntry> PutMessages(

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/ProcessQueueTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/ProcessQueueTests.cs
@@ -23,6 +23,21 @@ namespace EventHorizon.RocketMQ.Remoting.Tests.Consumer.Push;
 public sealed class ProcessQueueTests
 {
     [Fact]
+    public async Task ForcedInitialOffsetImmediatelySignalsCommit()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var processQueue = CreateProcessQueue();
+
+        processQueue.Initialize(7, forcePersist: true);
+
+        await processQueue.WaitForCommitAsync(cancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        Assert.True(processQueue.TryGetOffsetCommit(out var commit));
+        Assert.Equal(7, commit.Offset);
+        Assert.True(commit.IsForced);
+    }
+
+    [Fact]
     public void CompletionAdvancesOnlyAcrossContiguousRequestsAndReleasesCompletedPayloads()
     {
         var processQueue = CreateProcessQueue();

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumerTests.cs
@@ -265,12 +265,23 @@ public sealed class RemotingPushConsumerTests
     }
 
     [Fact]
-    public async Task ResetOffsetNotification_RetainsBoundaryWhenBrokerUpdateFails()
+    public async Task ResetOffsetNotification_RetriesBoundaryWhileReplacementPullIsPending()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var resetPersisted = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
         var remoting = new FakeRemotingClient("127.0.0.1@reset-failure")
         {
-            TrackCommittedOffsets = true
+            TrackCommittedOffsets = true,
+            UpdateOffsetHandler = (request, _) =>
+            {
+                var offset = Convert.ToInt64(request.ExtFields["commitOffset"]);
+                if (offset == 7)
+                {
+                    resetPersisted.TrySetResult(offset);
+                }
+
+                return Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResSuccess });
+            }
         };
         var options = new RemotingPushConsumerOptions
         {
@@ -315,15 +326,14 @@ public sealed class RemotingPushConsumerTests
             body,
             cancellationToken));
         await remoting.WaitForTopicPullsAsync("tenant-a%orders", 2, cancellationToken);
+        var persistedOffset = await resetPersisted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
 
         Assert.Equal(
             [0, 7],
             remoting.PullOffsets
                 .Where(static pull => pull.Topic == "tenant-a%orders")
                 .Select(static pull => pull.Offset));
-        Assert.DoesNotContain(
-            remoting.UpdatedOffsets,
-            static update => update.Topic == "tenant-a%orders" && update.Offset == 7);
+        Assert.Equal(7, persistedOffset);
     }
 
     [Fact]
@@ -406,23 +416,27 @@ public sealed class RemotingPushConsumerTests
     }
 
     [Fact]
-    public async Task ResetOffsetNotifications_BeforeStartApplyLatestOffsetWhenReceiverIsCreated()
+    public async Task ResetOffsetNotifications_BeforeStartPersistLatestOffsetWhileFirstPullIsPending()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        var returnedResetEmptyPull = 0;
+        var resetPersisted = new TaskCompletionSource<long>(TaskCreationOptions.RunContinuationsAsynchronously);
         var remoting = new FakeRemotingClient("127.0.0.1@reset-before-start")
         {
             TrackCommittedOffsets = true,
-            PullHandler = async (request, token) =>
+            PullHandler = async (_, token) =>
             {
-                var offset = Convert.ToInt64(request.ExtFields["queueOffset"]);
-                if (offset == 9 && Interlocked.Exchange(ref returnedResetEmptyPull, 1) == 0)
-                {
-                    return PullEmpty(offset);
-                }
-
                 await Task.Delay(Timeout.InfiniteTimeSpan, token);
                 throw new InvalidOperationException("An infinite pull completed unexpectedly.");
+            },
+            UpdateOffsetHandler = (request, _) =>
+            {
+                var offset = Convert.ToInt64(request.ExtFields["commitOffset"]);
+                if (offset == 9)
+                {
+                    resetPersisted.TrySetResult(offset);
+                }
+
+                return Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResSuccess });
             }
         };
         var options = new RemotingPushConsumerOptions
@@ -483,15 +497,12 @@ public sealed class RemotingPushConsumerTests
 
         await consumer.StartAsync(cancellationToken);
         await remoting.WaitForTopicPullsAsync("tenant-a%orders", 1, cancellationToken);
+        var persistedOffset = await resetPersisted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
 
         Assert.Equal(
             9,
             remoting.PullOffsets.First(static pull => pull.Topic == "tenant-a%orders").Offset);
-
-        await remoting.WaitForTopicPullsAsync("tenant-a%orders", 2, cancellationToken);
-        Assert.Contains(
-            remoting.UpdatedOffsets,
-            static update => update.Topic == "tenant-a%orders" && update.Offset == 9);
+        Assert.Equal(9, persistedOffset);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- signal the per-queue commit loop as soon as a forced initial reset offset is installed
- verify both pre-start resets and replacement receivers retry the offset while their first Pull remains pending
- clarify that deterministic live failures belong in IT while low-level failures without stable Docker injection remain mandatory UT cases

## Context

This is the post-review follow-up to #12. Without the initial signal, a reset boundary was persisted only after the first Pull response; a long poll, repeated Pull failure, or restart in that window could leave the Broker at its old offset.

NuGet accepted `0.1.2` before this P2 finding returned and package versions are immutable. After this PR is independently reviewed and merged, the corrective package will be `0.1.3`.

## Validation

- `dotnet format EventHorizon.RocketMQ.slnx --no-restore`
- `dotnet format EventHorizon.RocketMQ.slnx --no-restore --verify-no-changes`
- `dotnet build EventHorizon.RocketMQ.slnx --no-restore` (0 warnings, 0 errors)
- Remoting unit tests: 397 passed on each target
