### PR TITLE
test: clarify remoting push test helper

### DIFF
--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RemotingTestPushMessageHandler.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RemotingTestPushMessageHandler.cs
@@ -21,7 +21,7 @@ namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
 internal static class RemotingTestPushMessageHandlerExtensions
 {
-    internal static RemotingRocketMQBuilder AddTestRemotingPushConsumer<TMarker>(
+    internal static RemotingRocketMQBuilder AddRemotingPushConsumerWithTestHandler<TMarker>(
         this RemotingRocketMQBuilder builder,
         Action<RemotingPushConsumerOptions> configure,
         Func<

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
@@ -315,7 +315,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.NamesrvAddr = _fixture.NameServerAddress;
             })
             .AddRemotingProducer(options => options.GroupName = "legacy-push-producer-it")
-            .AddTestRemotingPushConsumer<RocketMQContainerTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQContainerTests>(options =>
             {
                 options.GroupName = "legacy-push-consumer-it";
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -402,7 +402,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         });
         rocketMQ.AddRemotingProducer(options =>
             options.GroupName = orders.CreateProducerGroupName("multiple-remoting-push-producer"));
-        rocketMQ.AddTestRemotingPushConsumer<OrdersPushConsumerMarker>(options =>
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<OrdersPushConsumerMarker>(options =>
         {
             options.GroupName = orders.CreateConsumerGroupName("orders-remoting-push-consumer");
             options.LongPollingTimeout = TimeSpan.FromSeconds(1);
@@ -425,7 +425,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
 
                 return ValueTask.FromResult(ConsumeResult.Success);
             });
-        rocketMQ.AddTestRemotingPushConsumer<OrdersObserverPushConsumerMarker>(options =>
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<OrdersObserverPushConsumerMarker>(options =>
         {
             options.GroupName = orders.CreateConsumerGroupName("orders-observer-remoting-push-consumer");
             options.LongPollingTimeout = TimeSpan.FromSeconds(1);
@@ -448,7 +448,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
 
                 return ValueTask.FromResult(ConsumeResult.Success);
             });
-        rocketMQ.AddTestRemotingPushConsumer<PaymentsPushConsumerMarker>(options =>
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<PaymentsPushConsumerMarker>(options =>
         {
             options.GroupName = payments.CreateConsumerGroupName("payments-remoting-push-consumer");
             options.LongPollingTimeout = TimeSpan.FromSeconds(1);
@@ -581,14 +581,14 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         });
         rocketMQ.AddRemotingProducer(options =>
             options.GroupName = scope.CreateProducerGroupName("remoting-shared-push-producer"));
-        rocketMQ.AddTestRemotingPushConsumer<FirstSharedGroupPushConsumerMarker>(options =>
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<FirstSharedGroupPushConsumerMarker>(options =>
         {
             options.GroupName = group;
             options.MaxConcurrency = 4;
             options.LongPollingTimeout = TimeSpan.FromSeconds(1);
             options.Subscribe(scope.Topic, new FilterExpression(tag));
         }, CreateHandler(() => Interlocked.Increment(ref firstConsumerCalls)));
-        rocketMQ.AddTestRemotingPushConsumer<SecondSharedGroupPushConsumerMarker>(options =>
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<SecondSharedGroupPushConsumerMarker>(options =>
         {
             options.GroupName = group;
             options.MaxConcurrency = 4;
@@ -672,7 +672,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.NamesrvAddr = _fixture.NameServerAddress;
             })
             .AddRemotingProducer(options => options.GroupName = $"legacy-push-batch-producer-{suffix}")
-            .AddTestRemotingPushConsumer<RocketMQContainerTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQContainerTests>(options =>
             {
                 options.GroupName = group;
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -756,7 +756,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.NamesrvAddr = _fixture.NameServerAddress;
             })
             .AddRemotingProducer(options => options.GroupName = $"legacy-push-partial-ack-producer-{suffix}")
-            .AddTestRemotingPushConsumer<RocketMQContainerTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQContainerTests>(options =>
             {
                 options.GroupName = group;
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -876,7 +876,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.PollNameServerInterval = TimeSpan.FromMilliseconds(250);
             })
             .AddRemotingProducer(options => options.GroupName = $"legacy-orderly-producer-{suffix}")
-            .AddTestRemotingPushConsumer<RocketMQContainerTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQContainerTests>(options =>
             {
                 options.GroupName = group;
                 options.ConsumeOrderly = true;
@@ -1023,7 +1023,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                     options.HeartbeatBrokerInterval = TimeSpan.FromMilliseconds(250);
                     options.PollNameServerInterval = TimeSpan.FromMilliseconds(250);
                 })
-                .AddTestRemotingPushConsumer<RocketMQContainerTests>(options =>
+                .AddRemotingPushConsumerWithTestHandler<RocketMQContainerTests>(options =>
                 {
                     options.GroupName = "legacy-push-cluster-it";
                     options.MaxConcurrency = 4;
@@ -1120,7 +1120,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.PollNameServerInterval = TimeSpan.FromMilliseconds(250);
             })
             .AddRemotingProducer(options => options.GroupName = $"legacy-backlog-producer-{suffix}")
-            .AddTestRemotingPushConsumer<RocketMQContainerTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQContainerTests>(options =>
             {
                 options.GroupName = $"legacy-backlog-consumer-{suffix}";
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -1199,7 +1199,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                     options.HeartbeatBrokerInterval = TimeSpan.FromMilliseconds(250);
                     options.PollNameServerInterval = TimeSpan.FromMilliseconds(250);
                 })
-                .AddTestRemotingPushConsumer<RocketMQContainerTests>(options =>
+                .AddRemotingPushConsumerWithTestHandler<RocketMQContainerTests>(options =>
                 {
                     options.GroupName = group;
                     options.ConsumerMode = ConsumerMode.Broadcasting;

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -44,7 +44,7 @@ public sealed class RocketMQMessageTypesIntegrationTests(RocketMQContainerFixtur
                 options.NamesrvAddr = fixture.NameServerAddress;
             })
             .AddRemotingProducer(options => options.GroupName = scope.CreateProducerGroupName("remoting-delay-producer"))
-            .AddTestRemotingPushConsumer<RocketMQMessageTypesIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQMessageTypesIntegrationTests>(options =>
             {
                 options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
@@ -251,8 +251,10 @@ public sealed class RocketMQMultiBrokerIntegrationTests
 
             var slowCommitted = await admin.GetConsumerOffsetAsync(group, slowQueue, cancellationToken);
             Assert.True(
+                slowCommitted is null ||
                 slowCommitted < expectedOffsets[(slowQueue.BrokerName, slowQueue.QueueId)],
-                $"Blocked queue {slowQueue.BrokerName}/{slowQueue.QueueId} advanced to {slowCommitted} before its handler completed.");
+                $"Blocked queue {slowQueue.BrokerName}/{slowQueue.QueueId} advanced to " +
+                $"{slowCommitted?.ToString() ?? "<none>"} before its handler completed.");
 
             releaseSlow.TrySetResult();
             await allConsumed.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
@@ -101,7 +101,7 @@ public sealed class RocketMQMultiBrokerIntegrationTests
             })
             .AddRemotingAdmin()
             .AddRemotingProducer(options => options.GroupName = $"remoting-multi-broker-producer-{suffix}")
-            .AddTestRemotingPushConsumer<RocketMQMultiBrokerIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQMultiBrokerIntegrationTests>(options =>
             {
                 options.GroupName = group;
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -181,7 +181,7 @@ public sealed class RocketMQMultiBrokerIntegrationTests
             })
             .AddRemotingAdmin()
             .AddRemotingProducer(options => options.GroupName = $"remoting-multi-broker-producer-{suffix}")
-            .AddTestRemotingPushConsumer<RocketMQMultiBrokerIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQMultiBrokerIntegrationTests>(options =>
             {
                 options.GroupName = group;
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -294,7 +294,7 @@ public sealed class RocketMQMultiBrokerIntegrationTests
             })
             .AddRemotingAdmin()
             .AddRemotingProducer(options => options.GroupName = $"remoting-multi-broker-producer-{suffix}")
-            .AddTestRemotingPushConsumer<RocketMQMultiBrokerIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQMultiBrokerIntegrationTests>(options =>
             {
                 options.GroupName = group;
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -453,7 +453,7 @@ public sealed class RocketMQMultiBrokerIntegrationTests
                 options.HeartbeatBrokerInterval = TimeSpan.FromMilliseconds(250);
                 options.PollNameServerInterval = TimeSpan.FromMilliseconds(250);
             })
-            .AddTestRemotingPushConsumer<RocketMQMultiBrokerIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQMultiBrokerIntegrationTests>(options =>
             {
                 options.GroupName = group;
                 options.InitialPosition = ConsumeFromPosition.Beginning;

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRebalanceIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRebalanceIntegrationTests.cs
@@ -94,11 +94,11 @@ public sealed class RocketMQRebalanceIntegrationTests(
         });
         rocketMQ.AddRemotingProducer(options =>
             options.GroupName = scope.CreateProducerGroupName("remoting-push-rebalance-producer"));
-        rocketMQ.AddTestRemotingPushConsumer<FirstPushConsumerMarker>(options =>
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<FirstPushConsumerMarker>(options =>
         {
             ConfigurePushConsumer(options, group, scope.Topic, tag);
         }, CreateHandler(0));
-        rocketMQ.AddTestRemotingPushConsumer<SecondPushConsumerMarker>(options =>
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<SecondPushConsumerMarker>(options =>
         {
             ConfigurePushConsumer(options, group, scope.Topic, tag);
         }, CreateHandler(1));

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
@@ -46,7 +46,7 @@ public sealed class RocketMQRequestReplyIntegrationTests(RocketMQContainerFixtur
                 options.InstanceName = $"request-reply-{suffix}";
             })
             .AddRemotingProducer(options => options.GroupName = scope.CreateProducerGroupName("request-reply-producer"))
-            .AddTestRemotingPushConsumer<RocketMQRequestReplyIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQRequestReplyIntegrationTests>(options =>
             {
                 options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
@@ -43,7 +43,7 @@ public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFi
         services
             .AddRocketMQRemoting(options => options.NamesrvAddr = fixture.NameServerAddress)
             .AddRemotingProducer(options => options.GroupName = producerGroup)
-            .AddTestRemotingPushConsumer<RocketMQTracePropagationIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQTracePropagationIntegrationTests>(options =>
             {
                 options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
@@ -53,7 +53,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests(RocketMQContainerF
                 options.TransactionChecker = static (_, _) =>
                     ValueTask.FromResult(RemotingTransactionResolution.Unknown);
             })
-            .AddTestRemotingPushConsumer<RocketMQTransactionRecallIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQTransactionRecallIntegrationTests>(options =>
             {
                 options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
@@ -118,7 +118,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests(RocketMQContainerF
                 options.TransactionChecker = static (_, _) =>
                     ValueTask.FromResult(RemotingTransactionResolution.Rollback);
             })
-            .AddTestRemotingPushConsumer<RocketMQTransactionRecallIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQTransactionRecallIntegrationTests>(options =>
             {
                 options.GroupName = consumerGroup;
                 options.InitialPosition = ConsumeFromPosition.Beginning;
@@ -180,7 +180,7 @@ public sealed class RocketMQTransactionRecallIntegrationTests(RocketMQContainerF
                 options.InstanceName = $"remoting-recall-{suffix}";
             })
             .AddRemotingProducer(options => options.GroupName = scope.CreateProducerGroupName("remoting-recall-producer"))
-            .AddTestRemotingPushConsumer<RocketMQTransactionRecallIntegrationTests>(options =>
+            .AddRemotingPushConsumerWithTestHandler<RocketMQTransactionRecallIntegrationTests>(options =>
             {
                 options.GroupName = consumerGroup;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);


### PR DESCRIPTION
## Summary
- Rename the internal Remoting integration-test helper from `AddTestRemotingPushConsumer` to `AddRemotingPushConsumerWithTestHandler`.
- Preserve its typed-handler implementation while making clear that the delegate adapter is test-only.
- Correct the blocked-queue multi-Broker assertion: an absent Broker consumer offset is an uncommitted offset, not evidence that the queue advanced.

## Validation
- `dotnet format EventHorizon.RocketMQ.slnx --no-restore`
- Focused multi-Broker integration test: `BlockedQueueDoesNotStallOtherQueuesOrAdvanceItsOffset` passed (1/1)
- CI rerun pending