### PR TITLE
test: clarify integration fixture topology

### DIFF
--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -110,7 +110,7 @@ Keep durable environment, command, source-commit, and result records under the b
 
 ### Integration tests and Testcontainers
 
-[`RocketMQContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixture.cs)
+[`RocketMQSingleBrokerContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs)
 creates an isolated Docker network, starts an Apache RocketMQ 5.5.0 NameServer and Broker, then
 starts a cluster-mode Proxy after the Broker registers. A lazy xUnit v3 assembly-fixture registry
 owns one baseline fixture per integration-test assembly, so independent test classes can share the
@@ -213,6 +213,7 @@ Broker or Proxy requirements.
 
 ## Related Reading
 
+- [Integration-test projects](../../../tests/it/README.md)
 - [Test-environment index](../../../test-environments/README.md)
 - [Runnable samples](../../../samples/README.md)
 - [gRPC consumer model](../grpc/consumer-model.md)

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -95,7 +95,7 @@ test 项目，而不是在 unit test 中偷偷连接本地 `localhost`。
 ### 2. Integration fixture 启动受控的 RocketMQ 集群
 
 共享
-[`RocketMQContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQContainerFixture.cs)
+[`RocketMQSingleBrokerContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs)
 使用 Testcontainers 和 `apache/rocketmq:5.5.0`：
 
 ```text
@@ -210,6 +210,7 @@ Proxy/Broker 配置下覆盖；已移除的 gRPC PullConsumer 没有 sample 或 
 
 ## 延伸阅读
 
+- [集成测试项目](../../../tests/it/README.zh-CN.md)
 - [协议边界](../architecture/protocol-boundaries.md)
 - [依赖注入与生命周期](../architecture/dependency-injection-and-lifetimes.md)
 - [gRPC 消费模型](../grpc/consumer-model.md)

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/AssemblyInfo.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/AssemblyInfo.cs
@@ -16,4 +16,5 @@
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 using Xunit;
 
-[assembly: AssemblyFixture(typeof(RocketMQContainerFixtureRegistry))]
+// The registry defers the single-Broker topology so multi-Broker-only filtered runs do not start it.
+[assembly: AssemblyFixture(typeof(RocketMQSingleBrokerContainerFixtureRegistry))]

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQContainerTests.cs
@@ -26,7 +26,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQContainerTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
 
     [Fact]

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-public sealed class RocketMQDeadLetterIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
 
     [Fact]

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-public sealed class RocketMQLiteIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQLiteIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-public sealed class RocketMQMessageTypesIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQMessageTypesIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
 
     [Fact]

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerCollection.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerCollection.cs
@@ -18,6 +18,13 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
+/// <summary>
+/// Defines the test collection that directly owns the gRPC multi-Broker topology.
+/// </summary>
+/// <remarks>
+/// Direct collection ownership lets xUnit create the topology only when selected tests run, so no registry wrapper is
+/// required.
+/// </remarks>
 [CollectionDefinition(Name)]
 public sealed class RocketMQMultiBrokerCollection : ICollectionFixture<RocketMQMultiBrokerGrpcContainerFixture>
 {

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQTracePropagationIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTransactionIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQTransactionIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
-public sealed class RocketMQTransactionIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQTransactionIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
 
     [Fact]

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQHostPortReservation.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQHostPortReservation.cs
@@ -18,6 +18,13 @@ using System.Net.Sockets;
 
 namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 
+/// <summary>
+/// Coordinates dynamic host-port choices between container fixtures in the current test process.
+/// </summary>
+/// <remarks>
+/// The probe listener closes after selecting a candidate, so this type records a process-local logical reservation; it
+/// does not retain an operating-system socket lock.
+/// </remarks>
 internal sealed class RocketMQHostPortReservation : IDisposable
 {
     private static readonly object SyncRoot = new();

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs
@@ -25,6 +25,12 @@ namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 /// <summary>
 /// Provides a cluster-mode Proxy and three network-addressable Brokers for gRPC integration tests.
 /// </summary>
+/// <remarks>
+/// The Brokers advertise Docker network aliases at a fixed internal port so the separate Proxy container can reach
+/// them. Those routes are not resolvable by a host Remoting client, so this topology remains separate from
+/// <see cref="RocketMQMultiBrokerRemotingContainerFixture"/>. xUnit owns this type directly as a collection fixture;
+/// an additional lazy registry would not extend its lifecycle.
+/// </remarks>
 public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
 {
     private const string Image = "apache/rocketmq:5.5.0";

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
@@ -24,6 +24,12 @@ namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 /// <summary>
 /// Provides a NameServer and three host-reachable classic Remoting Brokers for integration tests.
 /// </summary>
+/// <remarks>
+/// Each Broker advertises loopback with a distinct dynamically allocated host port. A separate Proxy container would
+/// resolve loopback to itself rather than to these three Brokers, so this topology remains separate from
+/// <see cref="RocketMQMultiBrokerGrpcContainerFixture"/>. xUnit owns this type directly as a collection fixture; an
+/// additional lazy registry would not extend its lifecycle.
+/// </remarks>
 public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime
 {
     private const string Image = "apache/rocketmq:5.5.0";

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs
@@ -21,7 +21,15 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 
-public sealed class RocketMQContainerFixture : IAsyncLifetime
+/// <summary>
+/// Provides the shared single-Broker baseline topology for protocol-specific integration tests.
+/// </summary>
+/// <remarks>
+/// The Broker and Proxy run in the same container so a loopback Broker route is reachable from both a host Remoting
+/// client through the matching port binding and the co-located Proxy process. Each integration-test assembly owns an
+/// independent runtime instance through <see cref="RocketMQSingleBrokerContainerFixtureRegistry"/>.
+/// </remarks>
+public sealed class RocketMQSingleBrokerContainerFixture : IAsyncLifetime
 {
     private const string Image = "apache/rocketmq:5.5.0";
     private const int NameServerPort = 9876;
@@ -60,7 +68,10 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
     private readonly int _brokerPort;
     private readonly int _grpcPort;
 
-    public RocketMQContainerFixture()
+    /// <summary>
+    /// Initializes the container definitions and reserves their host ports without starting Docker resources.
+    /// </summary>
+    public RocketMQSingleBrokerContainerFixture()
     {
         _portReservation = RocketMQHostPortReservation.Reserve(3, minimumPortDistance: 10);
         _nameServerHostPort = _portReservation[0];
@@ -95,6 +106,7 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
             "  \"useEndpointPortFromRequest\": true\n" +
             "}\n");
 
+        // Co-location makes the advertised 127.0.0.1 Broker route valid for both host Remoting and Proxy traffic.
         _broker = new ContainerBuilder(Image)
             .WithNetwork(_network)
             .WithPortBinding(_brokerPort, _brokerPort)
@@ -120,10 +132,19 @@ public sealed class RocketMQContainerFixture : IAsyncLifetime
             .Build();
     }
 
+    /// <summary>
+    /// Gets the host-reachable NameServer address for classic Remoting clients.
+    /// </summary>
     public string NameServerAddress => $"{_nameServer.Hostname}:{_nameServer.GetMappedPublicPort(NameServerPort)}";
 
+    /// <summary>
+    /// Gets the host-reachable address of the single classic Remoting Broker.
+    /// </summary>
     public string BrokerAddress => $"{_broker.Hostname}:{_broker.GetMappedPublicPort(_brokerPort)}";
 
+    /// <summary>
+    /// Gets the host-reachable gRPC endpoint of the co-located cluster-mode Proxy.
+    /// </summary>
     public string GrpcEndpoint => $"{_broker.Hostname}:{_broker.GetMappedPublicPort(_grpcPort)}";
 
     /// <summary>

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixtureRegistry.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixtureRegistry.cs
@@ -20,10 +20,15 @@ namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 /// <summary>
 /// Lazily creates one single-Broker fixture for an integration-test assembly.
 /// </summary>
-public sealed class RocketMQContainerFixtureRegistry : IAsyncLifetime
+/// <remarks>
+/// Registering this holder instead of the container fixture keeps xUnit assembly initialization inexpensive and avoids
+/// starting the baseline topology for a multi-Broker-only filtered run. Multi-Broker collection fixtures do not need
+/// this indirection because xUnit already creates them only when their collection runs.
+/// </remarks>
+public sealed class RocketMQSingleBrokerContainerFixtureRegistry : IAsyncLifetime
 {
     private readonly SemaphoreSlim _initializationGate = new(1, 1);
-    private RocketMQContainerFixture? _fixture;
+    private RocketMQSingleBrokerContainerFixture? _fixture;
 
     /// <inheritdoc />
     public ValueTask InitializeAsync()
@@ -36,7 +41,7 @@ public sealed class RocketMQContainerFixtureRegistry : IAsyncLifetime
     /// </summary>
     /// <param name="cancellationToken">The token used to cancel waiting for fixture initialization.</param>
     /// <returns>The initialized fixture.</returns>
-    public async Task<RocketMQContainerFixture> GetFixtureAsync(CancellationToken cancellationToken = default)
+    public async Task<RocketMQSingleBrokerContainerFixture> GetFixtureAsync(CancellationToken cancellationToken = default)
     {
         if (Volatile.Read(ref _fixture) is { } fixture)
         {
@@ -51,7 +56,7 @@ public sealed class RocketMQContainerFixtureRegistry : IAsyncLifetime
                 return existingFixture;
             }
 
-            var createdFixture = new RocketMQContainerFixture();
+            var createdFixture = new RocketMQSingleBrokerContainerFixture();
             try
             {
                 await createdFixture.InitializeAsync().ConfigureAwait(false);

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
@@ -18,12 +18,16 @@ namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 /// <summary>
 /// Provides test-specific Broker resource names for one integration test.
 /// </summary>
+/// <remarks>
+/// A scope does not own Broker resources and therefore has no disposal lifecycle. Its topics and groups remain until
+/// the owning <see cref="RocketMQSingleBrokerContainerFixture"/> is disposed.
+/// </remarks>
 public sealed class RocketMQTestScope
 {
-    private readonly RocketMQContainerFixture _fixture;
+    private readonly RocketMQSingleBrokerContainerFixture _fixture;
     private readonly string _suffix;
 
-    internal RocketMQTestScope(RocketMQContainerFixture fixture, string topic, string suffix)
+    internal RocketMQTestScope(RocketMQSingleBrokerContainerFixture fixture, string topic, string suffix)
     {
         _fixture = fixture;
         Topic = topic;

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/AssemblyInfo.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/AssemblyInfo.cs
@@ -16,4 +16,5 @@
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 using Xunit;
 
-[assembly: AssemblyFixture(typeof(RocketMQContainerFixtureRegistry))]
+// The registry defers the single-Broker topology so multi-Broker-only filtered runs do not start it.
+[assembly: AssemblyFixture(typeof(RocketMQSingleBrokerContainerFixtureRegistry))]

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQAdminIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQAdminIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-public sealed class RocketMQAdminIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQAdminIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQContainerTests.cs
@@ -33,9 +33,9 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry registry) : IAsyncLifetime
+public sealed class RocketMQContainerTests(RocketMQSingleBrokerContainerFixtureRegistry registry) : IAsyncLifetime
 {
-    private RocketMQContainerFixture _fixture = null!;
+    private RocketMQSingleBrokerContainerFixture _fixture = null!;
 
     public async ValueTask InitializeAsync()
     {
@@ -68,7 +68,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
 
         var nameServer = provider.GetRequiredKeyedService<INameServer>(Options.DefaultName);
         var route = await nameServer.GetTopicRouteInfoAsync(
-            RocketMQContainerFixture.TestTopic,
+            RocketMQSingleBrokerContainerFixture.TestTopic,
             TimeSpan.FromSeconds(10),
             cancellationToken: cancellationToken);
         Assert.NotEmpty(route.BrokerDatas);
@@ -78,15 +78,15 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         try
         {
             var result = await producer.SendAsync(new Message(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 "hello from dotnet"u8.ToArray()), cancellationToken);
             Assert.Equal(RemotingSendStatus.SendOk, result.Status);
             Assert.NotEmpty(result.MessageId);
             Assert.NotEmpty(result.OffsetMessageId);
-            Assert.Equal(RocketMQContainerFixture.TestTopic, result.MessageQueue.Topic);
+            Assert.Equal(RocketMQSingleBrokerContainerFixture.TestTopic, result.MessageQueue.Topic);
 
             await producer.SendOnewayAsync(new Message(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 "one way"u8.ToArray()), cancellationToken);
         }
         finally
@@ -111,7 +111,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
             {
                 options.GroupName = "remoting-pull-consumer-it";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("remoting-pull"));
+                options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression("remoting-pull"));
             });
 
         await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
@@ -122,7 +122,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         try
         {
             var queues = await consumer.GetMessageQueuesAsync(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 cancellationToken);
             var endOffsets = new Dictionary<(string Broker, int QueueId), long>();
             foreach (var candidate in queues)
@@ -135,7 +135,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
             }
 
             var body = $"remoting-pull-{Guid.NewGuid():N}";
-            var sent = await producer.SendAsync(new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body))
+            var sent = await producer.SendAsync(new Message(RocketMQSingleBrokerContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body))
             {
                 Tag = "remoting-pull"
             }, cancellationToken);
@@ -184,7 +184,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
             {
                 options.GroupName = $"legacy-lite-pull-consumer-{suffix}";
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("remoting-lite-pull"));
+                options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression("remoting-lite-pull"));
             });
 
         await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
@@ -196,7 +196,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         {
             Assert.NotEmpty(consumer.Assignment);
             var body = $"remoting-lite-pull-{suffix}";
-            await producer.SendAsync(new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body))
+            await producer.SendAsync(new Message(RocketMQSingleBrokerContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body))
             {
                 Tag = "remoting-lite-pull"
             }, cancellationToken);
@@ -253,10 +253,10 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         try
         {
             var queues = await consumer.GetMessageQueuesAsync(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 cancellationToken);
             var sent = await producer.SendAsync(
-                new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
+                new Message(RocketMQSingleBrokerContainerFixture.TestTopic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
                 cancellationToken);
             var queue = queues.Single(value =>
                 value.QueueId == sent.MessageQueue.QueueId && value.BrokerName == sent.MessageQueue.BrokerName);
@@ -321,7 +321,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(3);
                 options.RetryDelay = TimeSpan.FromMilliseconds(100);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression("legacy-push"));
+                options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression("legacy-push"));
             }, (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
@@ -343,7 +343,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         await consumer.StartAsync(cancellationToken);
         try
         {
-            var sent = await producer.SendAsync(new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(expected))
+            var sent = await producer.SendAsync(new Message(RocketMQSingleBrokerContainerFixture.TestTopic, Encoding.UTF8.GetBytes(expected))
             {
                 Tag = "legacy-push"
             }, cancellationToken);
@@ -368,7 +368,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
             Assert.True(delivery.DeliveryAttempt >= 2);
             var commit = await _fixture.WaitForConsumerCommitAsync(
                 "legacy-push-consumer-it",
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 sent.MessageQueue.BrokerName,
                 sent.MessageQueue.QueueId,
                 TimeSpan.FromSeconds(10),
@@ -679,7 +679,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.BatchSize = messageCount;
                 options.ConsumeMessageBatchSize = messageCount;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression(tag));
             }, (messages, _, _) =>
                 {
                     var bodies = messages.Select(message => Encoding.UTF8.GetString(message.Body)).ToArray();
@@ -698,11 +698,11 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         try
         {
             var queue = (await producer.GetPublishMessageQueuesAsync(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 cancellationToken)).First();
             var sent = await producer.SendAsync(
                 expectedBodies.Select(body => new Message(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 Encoding.UTF8.GetBytes(body))
                 {
                     Tag = tag
@@ -717,7 +717,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
 
             var commit = await _fixture.WaitForConsumerCommitAsync(
                 group,
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 queue.BrokerName,
                 queue.QueueId,
                 TimeSpan.FromSeconds(10),
@@ -766,7 +766,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.MaxCachedMessages = messageCount;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.RetryDelay = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression(tag));
             }, (messages, context, _) =>
                 {
                     var deliveries = messages
@@ -804,11 +804,11 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         try
         {
             var queue = (await producer.GetPublishMessageQueuesAsync(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 cancellationToken)).First();
             var sent = await producer.SendAsync(
                 expectedBodies.Select(body => new Message(
-                    RocketMQContainerFixture.TestTopic,
+                    RocketMQSingleBrokerContainerFixture.TestTopic,
                     Encoding.UTF8.GetBytes(body))
                 {
                     Tag = tag
@@ -841,7 +841,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
 
             var commit = await _fixture.WaitForConsumerCommitAsync(
                 group,
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 queue.BrokerName,
                 queue.QueueId,
                 TimeSpan.FromSeconds(10),
@@ -882,7 +882,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.ConsumeOrderly = true;
                 options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression(tag));
             }, (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
@@ -907,7 +907,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         try
         {
             var queue = (await producer.GetPublishMessageQueuesAsync(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 cancellationToken)).First();
             lockBody = Encoding.UTF8.GetBytes(new
             {
@@ -952,7 +952,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
 
             lockHeld = true;
             await consumer.StartAsync(cancellationToken);
-            await producer.SendAsync(new Message(RocketMQContainerFixture.TestTopic, Encoding.UTF8.GetBytes(expected))
+            await producer.SendAsync(new Message(RocketMQSingleBrokerContainerFixture.TestTopic, Encoding.UTF8.GetBytes(expected))
             {
                 Tag = tag
             }, queue, cancellationToken);
@@ -1028,7 +1028,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                     options.GroupName = "legacy-push-cluster-it";
                     options.MaxConcurrency = 4;
                     options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                    options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                    options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression(tag));
                 }, (messages, _, _) =>
                     {
                         foreach (var message in messages)
@@ -1078,7 +1078,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
             foreach (var body in expectedBodies)
             {
                 await producer.SendAsync(new Message(
-                    RocketMQContainerFixture.TestTopic,
+                    RocketMQSingleBrokerContainerFixture.TestTopic,
                     Encoding.UTF8.GetBytes(body))
                 {
                     Tag = tag
@@ -1125,7 +1125,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                 options.GroupName = $"legacy-backlog-consumer-{suffix}";
                 options.InitialPosition = ConsumeFromPosition.Beginning;
                 options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression(tag));
             }, (messages, _, _) =>
                 {
                     var message = Assert.Single(messages);
@@ -1145,7 +1145,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         try
         {
             await producer.SendAsync(new Message(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 Encoding.UTF8.GetBytes(expectedBody))
             {
                 Tag = tag
@@ -1206,7 +1206,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
                     options.LocalOffsetStorePath = offsetPath;
                     options.InitialPosition = ConsumeFromPosition.Beginning;
                     options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                    options.Subscribe(RocketMQContainerFixture.TestTopic, new FilterExpression(tag));
+                    options.Subscribe(RocketMQSingleBrokerContainerFixture.TestTopic, new FilterExpression(tag));
                 }, (messages, _, _) =>
                     {
                         var message = Assert.Single(messages);
@@ -1245,7 +1245,7 @@ public sealed class RocketMQContainerTests(RocketMQContainerFixtureRegistry regi
         {
             await producer.StartAsync(cancellationToken);
             await producer.SendAsync(new Message(
-                RocketMQContainerFixture.TestTopic,
+                RocketMQSingleBrokerContainerFixture.TestTopic,
                 Encoding.UTF8.GetBytes(expectedBody))
             {
                 Tag = tag

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQCrossProcessRebalanceIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQCrossProcessRebalanceIntegrationTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
 public sealed class RocketMQCrossProcessRebalanceIntegrationTests(
-    RocketMQContainerFixtureRegistry registry)
+    RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     private static readonly TimeSpan ProcessStartupTimeout = TimeSpan.FromSeconds(20);
     private static readonly TimeSpan RebalanceTimeout = TimeSpan.FromSeconds(10);
@@ -207,7 +207,7 @@ public sealed class RocketMQCrossProcessRebalanceIntegrationTests(
     }
 
     private static async Task WaitForCommitsAsync(
-        RocketMQContainerFixture fixture,
+        RocketMQSingleBrokerContainerFixture fixture,
         string group,
         IReadOnlyList<RemotingMessageQueue> queues,
         TimeSpan timeout,

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-public sealed class RocketMQMessageTypesIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQMessageTypesIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerCollection.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQMultiBrokerCollection.cs
@@ -18,6 +18,13 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
+/// <summary>
+/// Defines the test collection that directly owns the Remoting multi-Broker topology.
+/// </summary>
+/// <remarks>
+/// Direct collection ownership lets xUnit create the topology only when selected tests run, so no registry wrapper is
+/// required.
+/// </remarks>
 [CollectionDefinition(Name)]
 public sealed class RocketMQMultiBrokerCollection : ICollectionFixture<RocketMQMultiBrokerRemotingContainerFixture>
 {

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRebalanceIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRebalanceIntegrationTests.cs
@@ -27,10 +27,10 @@ using Xunit;
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
 public sealed class RocketMQRebalanceIntegrationTests(
-    RocketMQContainerFixtureRegistry registry) : IAsyncLifetime
+    RocketMQSingleBrokerContainerFixtureRegistry registry) : IAsyncLifetime
 {
     private static readonly TimeSpan RebalanceTimeout = TimeSpan.FromSeconds(10);
-    private RocketMQContainerFixture _fixture = null!;
+    private RocketMQSingleBrokerContainerFixture _fixture = null!;
 
     public async ValueTask InitializeAsync()
     {

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQRequestReplyIntegrationTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-public sealed class RocketMQRequestReplyIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQRequestReplyIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTracePropagationIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-public sealed class RocketMQTracePropagationIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQTracePropagationIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/RocketMQTransactionRecallIntegrationTests.cs
@@ -24,7 +24,7 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests;
 
-public sealed class RocketMQTransactionRecallIntegrationTests(RocketMQContainerFixtureRegistry registry)
+public sealed class RocketMQTransactionRecallIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]

--- a/tests/it/README.md
+++ b/tests/it/README.md
@@ -1,0 +1,196 @@
+# Integration Tests
+
+[English](README.md) | [Simplified Chinese](README.zh-CN.md)
+
+`tests/it` contains the `net10.0` Docker-backed integration-test projects. They validate protocol-specific behavior
+against real RocketMQ NameServer, Broker, and Proxy processes while keeping container orchestration separate from
+production client code.
+
+## Projects
+
+| Project | Responsibility |
+| --- | --- |
+| `EventHorizon.RocketMQ.Grpc.IntegrationTests` | Exercises the gRPC client through a real cluster-mode Proxy. |
+| `EventHorizon.RocketMQ.Remoting.IntegrationTests` | Exercises classic NameServer and Broker Remoting behavior. |
+| `EventHorizon.RocketMQ.IntegrationTestInfrastructure` | Owns reusable Testcontainers topologies, host-port allocation, and test resource names. |
+| `EventHorizon.RocketMQ.Remoting.CrossProcessTestHost` | Runs test-only Remoting consumers in separate operating-system processes for cross-process Rebalance coverage. |
+
+The infrastructure project is a non-packable support library, not a test assembly. It deliberately has no reference
+to either production client project and contains no protocol client assertions. Each protocol test project references
+the infrastructure project and its own production client; the Remoting tests also own the cross-process test host:
+
+```text
+Grpc.IntegrationTests ------> EventHorizon.RocketMQ.Grpc
+    `-----------------------> IntegrationTestInfrastructure
+
+Remoting.IntegrationTests --> EventHorizon.RocketMQ.Remoting
+    |-----------------------> IntegrationTestInfrastructure
+    `-----------------------> Remoting.CrossProcessTestHost
+                                  `--> EventHorizon.RocketMQ.Remoting
+
+IntegrationTestInfrastructure --> Testcontainers
+                              --> xUnit lifecycle abstractions
+```
+
+See [Local and Integration Testing](../../docs/en-US/testing/local-and-integration-testing.md) for the repository-wide
+test topology and CI policy.
+
+## Infrastructure structure
+
+`EventHorizon.RocketMQ.IntegrationTestInfrastructure` has six public top-level types and one internal helper.
+
+| Type | Responsibility |
+| --- | --- |
+| `RocketMQSingleBrokerContainerFixtureRegistry` | Lazily owns the shared single-Broker fixture for one test assembly. |
+| `RocketMQSingleBrokerContainerFixture` | Runs the ordinary NameServer, single Broker, and cluster-mode Proxy topology. |
+| `RocketMQTestScope` | Produces test-specific topic and producer or consumer group names. |
+| `RocketMQTestTopicType` | Selects normal, transaction, FIFO, delay, or Lite topic provisioning. |
+| `RocketMQHostPortReservation` | Coordinates dynamic host-port choices within the current test process. |
+| `RocketMQMultiBrokerGrpcContainerFixture` | Runs three Docker-network Brokers behind a cluster-mode Proxy. |
+| `RocketMQMultiBrokerRemotingContainerFixture` | Runs three host-reachable classic Remoting Brokers. |
+
+The internal type dependencies are:
+
+```text
+RocketMQSingleBrokerContainerFixtureRegistry
+    `-- lazily owns --> RocketMQSingleBrokerContainerFixture
+                           |-- uses --> RocketMQHostPortReservation
+                           |-- consumes --> RocketMQTestTopicType
+                           `-- creates --> RocketMQTestScope
+                                              `-- calls back --> RocketMQSingleBrokerContainerFixture
+
+RocketMQMultiBrokerGrpcContainerFixture
+    `-- uses --> RocketMQHostPortReservation
+
+RocketMQMultiBrokerRemotingContainerFixture
+    `-- uses --> RocketMQHostPortReservation
+```
+
+`RocketMQTestScope` calls back into `RocketMQSingleBrokerContainerFixture` only when it must create a Lite consumer group with a
+Broker-side parent-topic binding. It does not own or dispose Broker resources. Topics and groups live until the owning
+container fixture is disposed.
+
+## Fixture ownership and lifecycle
+
+### Single-Broker baseline
+
+Both protocol integration-test assemblies register `RocketMQSingleBrokerContainerFixtureRegistry` as an xUnit assembly fixture.
+xUnit therefore creates one registry per test assembly. The two assemblies do not share a registry instance or a live
+Docker topology.
+
+The registry is intentionally a lazy holder rather than a general-purpose fixture catalog:
+
+```text
+Test assembly starts
+    -> xUnit creates RocketMQSingleBrokerContainerFixtureRegistry
+    -> registry InitializeAsync completes without starting Docker
+    -> first GetFixtureAsync call wins the initialization gate
+    -> registry creates and initializes RocketMQSingleBrokerContainerFixture
+         -> reserve three host ports
+         -> create Docker network
+         -> start NameServer
+         -> start the Broker and Proxy container
+         -> provision predefined topics and legacy Remoting groups
+    -> independent test classes share the initialized fixture
+Test assembly finishes
+    -> registry disposes the fixture, initialization gate, and owned resources
+```
+
+`GetFixtureAsync` uses a semaphore and double-checked access so parallel test classes initialize exactly one fixture.
+If initialization fails, the registry disposes the partially initialized fixture before propagating the failure. A
+multi-Broker-only filtered run still creates the inexpensive assembly registry, but never starts the single-Broker
+topology because it does not call `GetFixtureAsync`.
+
+`RocketMQSingleBrokerContainerFixture` provisions a unique normal topic for each scope. Transaction, FIFO, delay, and Lite topics
+are predefined because their Broker semantics require configuration, but every scope still receives a unique suffix
+for group and message identity isolation. Broker administration is limited to four concurrent operations to match the
+parallel integration-test workload without serializing the entire assembly.
+
+### Multi-Broker collections
+
+The multi-Broker fixtures are registered directly as xUnit collection fixtures:
+
+```text
+gRPC multi-Broker collection
+    `-- RocketMQMultiBrokerGrpcContainerFixture
+
+Remoting multi-Broker collection
+    `-- RocketMQMultiBrokerRemotingContainerFixture
+```
+
+xUnit creates each fixture only when its collection has selected tests, calls `InitializeAsync`, injects the same
+instance into that collection's tests, and calls `DisposeAsync` after the collection finishes. A registry wrapper would
+not add laziness or sharing because the collection fixture already provides both.
+
+The gRPC multi-Broker initialization order is:
+
+```text
+reserve one Proxy host port
+    -> network -> NameServer -> Broker A/B/C in parallel
+    -> wait for all Broker registrations
+    -> create the topic on every Broker and wait for the complete route
+    -> start Proxy
+```
+
+Disposal runs in the reverse ownership direction: Proxy, Brokers, NameServer, network, then the port reservation.
+
+The Remoting multi-Broker initialization order is:
+
+```text
+reserve one NameServer and three Broker host ports
+    -> network -> NameServer -> Broker A/B/C in parallel
+    -> wait for all Broker registrations
+    -> create a three-read-queue and three-write-queue topic on every Broker
+    -> wait for the complete route
+```
+
+Disposal releases the Brokers, NameServer, network, and port reservation.
+
+## Why the single-Broker fixture is shared
+
+The single-Broker fixture can provide one valid superset topology for both protocols because the Broker and Proxy run
+inside the same container. The Broker advertises `127.0.0.1` and uses the same numeric port inside the container and on
+the host:
+
+```text
+host Remoting client -> mapped Broker port -> Broker
+
+host gRPC client -> mapped Proxy port -> Proxy
+                                      -> loopback Broker port in the same container
+```
+
+All exposed endpoints are valid for the fixture's entire lifetime. The protocol test assemblies reuse the fixture type
+and provisioning implementation, while their production clients and assertions remain separate. Each assembly still
+starts its own containers at runtime. The Remoting assembly consequently starts an otherwise unused Proxy, which is an
+accepted cost of the simple shared baseline topology.
+
+## Why the multi-Broker fixtures remain separate
+
+The multi-Broker topologies have incompatible Broker address-advertisement requirements:
+
+| Concern | gRPC multi-Broker | Remoting multi-Broker |
+| --- | --- | --- |
+| Client entry point | Proxy | NameServer and Brokers |
+| Advertised Broker host | Docker alias such as `broker-a` | `127.0.0.1` |
+| Broker ports | Fixed `10911` in separate containers | Distinct dynamically allocated host ports |
+| Host mappings | Proxy only | NameServer and every Broker |
+| Additional behavior | Proxy startup and per-Broker offset inspection | Explicit queue counts and host-reachable routes |
+
+A separate Proxy container can resolve `broker-a`, `broker-b`, and `broker-c`, while a host Remoting client cannot. If
+the Brokers advertise `127.0.0.1`, the host can reach them through distinct mapped ports, but `127.0.0.1` inside the
+Proxy container refers to the Proxy container itself and cannot identify three other Broker containers.
+
+Combining the public fixtures would therefore produce a mode-switched type with conditional construction and members
+that are invalid in one mode, such as a gRPC endpoint in Remoting mode. It would reduce type count without unifying the
+runtime topology. Keep the two protocol-specific public fixtures. Shared registration polling, route polling, or
+container orchestration may be extracted into a focused internal collaborator if repeated maintenance demonstrates a
+real benefit; do not replace the explicit fixtures with a generic mode selector merely to remove similar code.
+
+## Running integration tests
+
+Docker must be available. Run the protocol-specific integration-test project from the repository root:
+
+```shell
+dotnet test tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj --no-restore
+dotnet test tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj --no-restore
+```

--- a/tests/it/README.zh-CN.md
+++ b/tests/it/README.zh-CN.md
@@ -1,0 +1,187 @@
+# 集成测试
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+`tests/it` 包含 `net10.0` Docker 集成测试项目。它们通过真实的 RocketMQ NameServer、Broker 和 Proxy
+进程验证各协议行为，同时使容器编排与生产客户端代码保持分离。
+
+## 项目
+
+| 项目 | 职责 |
+| --- | --- |
+| `EventHorizon.RocketMQ.Grpc.IntegrationTests` | 通过真实的 cluster-mode Proxy 验证 gRPC 客户端。 |
+| `EventHorizon.RocketMQ.Remoting.IntegrationTests` | 验证经典 NameServer 和 Broker Remoting 行为。 |
+| `EventHorizon.RocketMQ.IntegrationTestInfrastructure` | 管理可复用的 Testcontainers 拓扑、主机端口分配和测试资源名称。 |
+| `EventHorizon.RocketMQ.Remoting.CrossProcessTestHost` | 在独立操作系统进程中运行测试专用 Remoting consumer，用于跨进程 Rebalance 覆盖。 |
+
+基础设施项目是不可打包的支持类库，而不是测试程序集。它刻意不引用任一生产客户端项目，也不包含协议客户端
+断言。每个协议测试项目分别引用基础设施项目和自己的生产客户端；Remoting 测试还持有跨进程测试 Host：
+
+```text
+Grpc.IntegrationTests ------> EventHorizon.RocketMQ.Grpc
+    `-----------------------> IntegrationTestInfrastructure
+
+Remoting.IntegrationTests --> EventHorizon.RocketMQ.Remoting
+    |-----------------------> IntegrationTestInfrastructure
+    `-----------------------> Remoting.CrossProcessTestHost
+                                  `--> EventHorizon.RocketMQ.Remoting
+
+IntegrationTestInfrastructure --> Testcontainers
+                              --> xUnit 生命周期抽象
+```
+
+仓库级测试拓扑和 CI 规则请参阅[本地测试与集成测试](../../docs/zh-CN/testing/local-and-integration-testing.md)。
+
+## 基础设施结构
+
+`EventHorizon.RocketMQ.IntegrationTestInfrastructure` 包含六个 public 顶层类型和一个 internal 辅助类型。
+
+| 类型 | 职责 |
+| --- | --- |
+| `RocketMQSingleBrokerContainerFixtureRegistry` | 为单个测试程序集惰性持有共享的单 Broker Fixture。 |
+| `RocketMQSingleBrokerContainerFixture` | 运行普通测试使用的 NameServer、单 Broker 和 cluster-mode Proxy 拓扑。 |
+| `RocketMQTestScope` | 生成测试专用 topic 以及 producer 或 consumer group 名称。 |
+| `RocketMQTestTopicType` | 选择普通、事务、FIFO、延时或 Lite topic 的预配方式。 |
+| `RocketMQHostPortReservation` | 在当前测试进程内协调动态主机端口选择。 |
+| `RocketMQMultiBrokerGrpcContainerFixture` | 运行位于 cluster-mode Proxy 后面的三个 Docker 网络 Broker。 |
+| `RocketMQMultiBrokerRemotingContainerFixture` | 运行三个可从主机访问的经典 Remoting Broker。 |
+
+内部类型依赖如下：
+
+```text
+RocketMQSingleBrokerContainerFixtureRegistry
+    `-- 惰性持有 --> RocketMQSingleBrokerContainerFixture
+                         |-- 使用 --> RocketMQHostPortReservation
+                         |-- 接收 --> RocketMQTestTopicType
+                         `-- 创建 --> RocketMQTestScope
+                                          `-- 回调 --> RocketMQSingleBrokerContainerFixture
+
+RocketMQMultiBrokerGrpcContainerFixture
+    `-- 使用 --> RocketMQHostPortReservation
+
+RocketMQMultiBrokerRemotingContainerFixture
+    `-- 使用 --> RocketMQHostPortReservation
+```
+
+只有在创建需要 Broker 端 parent-topic 绑定的 Lite consumer group 时，`RocketMQTestScope` 才会回调
+`RocketMQSingleBrokerContainerFixture`。它不持有也不释放 Broker 资源；topic 和 group 会一直存在，直到其所属容器
+Fixture 被释放。
+
+## Fixture 所有权与生命周期
+
+### 单 Broker 基线拓扑
+
+两个协议集成测试程序集都把 `RocketMQSingleBrokerContainerFixtureRegistry` 注册为 xUnit assembly fixture。因此 xUnit
+会为每个测试程序集创建一个 Registry；两个程序集不会共享 Registry 实例或正在运行的 Docker 拓扑。
+
+Registry 刻意设计为惰性持有者，而不是通用的 Fixture 目录：
+
+```text
+测试程序集启动
+    -> xUnit 创建 RocketMQSingleBrokerContainerFixtureRegistry
+    -> Registry.InitializeAsync 完成，但不启动 Docker
+    -> 第一次 GetFixtureAsync 调用取得初始化锁
+    -> Registry 创建并初始化 RocketMQSingleBrokerContainerFixture
+         -> 预留三个主机端口
+         -> 创建 Docker network
+         -> 启动 NameServer
+         -> 启动 Broker 和 Proxy 容器
+         -> 预配固定 topic 和旧版 Remoting group
+    -> 相互独立的测试类共享已初始化的 Fixture
+测试程序集结束
+    -> Registry 释放 Fixture、初始化锁及其持有的资源
+```
+
+`GetFixtureAsync` 使用 semaphore 和双重检查，确保并行测试类只初始化一套 Fixture。初始化失败时，Registry
+会先释放部分初始化的 Fixture，再向上传递异常。只筛选 multi-Broker 测试时，xUnit 仍会创建开销很小的
+assembly Registry，但由于没有调用 `GetFixtureAsync`，单 Broker 拓扑不会启动。
+
+`RocketMQSingleBrokerContainerFixture` 会为每个 scope 预配唯一的普通 topic。事务、FIFO、延时和 Lite topic 因 Broker
+语义需要配置而预先创建，但每个 scope 仍通过唯一 suffix 隔离 group 和消息标识。Broker 管理操作的并发数
+限制为四，与集成测试的并行负载一致，同时避免串行化整个测试程序集。
+
+### 多 Broker collection
+
+两个多 Broker Fixture 都直接注册为 xUnit collection fixture：
+
+```text
+gRPC multi-Broker collection
+    `-- RocketMQMultiBrokerGrpcContainerFixture
+
+Remoting multi-Broker collection
+    `-- RocketMQMultiBrokerRemotingContainerFixture
+```
+
+只有 collection 中存在被选中的测试时，xUnit 才会创建对应 Fixture，调用 `InitializeAsync`，向该 collection
+的测试注入同一个实例，并在 collection 结束后调用 `DisposeAsync`。collection fixture 已经同时提供按需创建和
+共享能力，再包装 Registry 不会增加生命周期能力。
+
+gRPC 多 Broker 初始化顺序为：
+
+```text
+预留一个 Proxy 主机端口
+    -> network -> NameServer -> 并行启动 Broker A/B/C
+    -> 等待全部 Broker 注册
+    -> 在每个 Broker 上创建 topic 并等待完整路由
+    -> 启动 Proxy
+```
+
+释放按所有权的反方向执行：Proxy、各 Broker、NameServer、network，最后释放端口记录。
+
+Remoting 多 Broker 初始化顺序为：
+
+```text
+预留一个 NameServer 和三个 Broker 主机端口
+    -> network -> NameServer -> 并行启动 Broker A/B/C
+    -> 等待全部 Broker 注册
+    -> 在每个 Broker 上创建具有三个读队列和三个写队列的 topic
+    -> 等待完整路由
+```
+
+释放时依次清理各 Broker、NameServer、network 和端口记录。
+
+## 为什么单 Broker Fixture 可以复用
+
+单 Broker Fixture 可以为两种协议提供一套始终有效的超集拓扑，因为 Broker 和 Proxy 运行在同一个容器中。
+Broker 通告 `127.0.0.1`，并且容器内和主机上的 Broker 端口数字保持一致：
+
+```text
+主机 Remoting client -> 映射后的 Broker 端口 -> Broker
+
+主机 gRPC client -> 映射后的 Proxy 端口 -> Proxy
+                                          -> 同容器内的 loopback Broker 端口
+```
+
+Fixture 暴露的所有 endpoint 在整个生命周期内都有效。两个协议测试程序集复用 Fixture 类型和资源预配实现，
+但生产客户端和断言仍保持分离；运行时每个程序集仍会启动自己的容器。Remoting 程序集也会启动一个基本不使用
+的 Proxy，这是保持单 Broker 基线拓扑简单统一所接受的成本。
+
+## 为什么多 Broker Fixture 保持分离
+
+两个多 Broker 拓扑对 Broker 地址通告有互不兼容的要求：
+
+| 关注点 | gRPC multi-Broker | Remoting multi-Broker |
+| --- | --- | --- |
+| 客户端入口 | Proxy | NameServer 和 Broker |
+| Broker 通告主机 | `broker-a` 等 Docker alias | `127.0.0.1` |
+| Broker 端口 | 各容器固定使用 `10911` | 各自使用动态分配的主机端口 |
+| 主机端口映射 | 只映射 Proxy | 映射 NameServer 和每个 Broker |
+| 附加行为 | 启动 Proxy 并检查各 Broker offset | 显式队列数和主机可达路由 |
+
+独立 Proxy 容器可以解析 `broker-a`、`broker-b` 和 `broker-c`，但主机上的 Remoting client 无法解析这些
+地址。如果 Broker 通告 `127.0.0.1`，主机可以通过不同的映射端口访问它们，但 Proxy 容器中的
+`127.0.0.1` 指向 Proxy 容器自身，无法表示另外三个 Broker 容器。
+
+合并 public Fixture 只会得到一个按模式切换的类型：其构造过程充满条件分支，并且会出现只在部分模式有效的
+成员，例如 Remoting 模式下的 gRPC endpoint。这样只减少了类型数量，并没有统一运行时拓扑。因此应保留两个
+协议专用 public Fixture。如果重复维护证明有实际收益，可以把注册轮询、路由轮询或容器编排提取到职责明确的
+internal 协作者；不要只为删除相似代码而用通用模式选择器替代当前显式 Fixture。
+
+## 运行集成测试
+
+运行前必须确保 Docker 可用。在仓库根目录执行对应协议的集成测试项目：
+
+```shell
+dotnet test tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj --no-restore
+dotnet test tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj --no-restore
+```


### PR DESCRIPTION
## Summary

- add bilingual tests/it documentation for integration-test projects, fixture ownership, and lifecycle
- rename the shared baseline types to RocketMQSingleBrokerContainerFixture and RocketMQSingleBrokerContainerFixtureRegistry
- document why the single-Broker topology is reusable and why the gRPC and Remoting multi-Broker topologies remain separate
- add focused lifecycle and address-model comments and update the bilingual testing guide links

## Validation

- dotnet format EventHorizon.RocketMQ.slnx
- dotnet build tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/EventHorizon.RocketMQ.IntegrationTestInfrastructure.csproj --no-restore --tl:off -m:1 -p:UseSharedCompilation=false
- dotnet build tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj --no-restore --tl:off -m:1 -p:UseSharedCompilation=false
- dotnet build tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/EventHorizon.RocketMQ.Remoting.IntegrationTests.csproj --no-restore --tl:off -m:1 -p:UseSharedCompilation=false

Docker-backed integration tests were not run because the implementation change is a mechanical test-infrastructure type rename with documentation and comments; runtime behavior is unchanged.