### PR TITLE
refactor(grpc): align consumer model with Java client

### DIFF
--- a/docs/en-US/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/en-US/architecture/dependency-injection-and-lifetimes.md
@@ -195,8 +195,9 @@ invoke their `IGrpcPushMessageHandler` for each message. Remoting Push invokes i
 otherwise. For a concurrent non-FIFO batch, a handler can return `Success` with `AckIndex` set to confirm a
 contiguous prefix and retry its tail; `Retry` and `DeadLetter` remain whole-batch outcomes.
 
-For non-FIFO gRPC Push and LitePush messages, `ConsumeTimeout` cancels the handler token, stops client-side
-invisibility renewal, and requests retry when the configured limit elapses. The dispatcher ignores a late result and
+For non-FIFO gRPC Push and LitePush messages, `ConsumeTimeout` cancels the handler token and requests retry when the
+configured limit elapses. Receipt renewal while the handler is active belongs to the Proxy requested by `AutoRenew`,
+not to the handler scope or a client timer. The dispatcher ignores a late result and
 releases its consume-loop slot, but it cannot terminate application code. A timed-out invocation can overlap redelivery and must
 be idempotent. Its typed-handler async scope remains alive until that invocation returns, so scoped dependencies are
 not disposed while handler code is still running. FIFO message groups are excluded to preserve ordering.

--- a/docs/en-US/architecture/opentelemetry-instrumentation.md
+++ b/docs/en-US/architecture/opentelemetry-instrumentation.md
@@ -89,9 +89,10 @@ are preserved.
 
 For gRPC, Proxy-managed renewal requested by `ReceiveMessageRequest.AutoRenew` is not a separate client wire operation
 and must not create a client settlement span. A client-issued `ChangeInvisibleDuration` must be classified by intent:
-`renew` for handler-active or SimpleConsumer lease extension, and `nack` for retry scheduling. Consolidating gRPC
-renewal ownership is incomplete if both Proxy auto-renewal and a client renewal loop remain active, or if renewal and
-retry are reported with the same settlement outcome.
+`renew` when SimpleConsumer explicitly extends a lease, and `nack` when Push or LitePush schedules redelivery after a
+retry result, handler timeout, or corrupted message. The shared receive engine keeps these intent-specific internal
+operations separate even though they use the same RPC. Proxy-managed handler renewal creates no duplicate client
+timer, span, or metric.
 
 Classic Remoting instrumentation follows the wire-operation owner. `PullWireClient` owns receive completion for
 non-empty, empty, canceled, and failed PULL operations. `RemotingConsumerOffsetClient` owns commit settlement, while

--- a/docs/en-US/architecture/protocol-boundaries.md
+++ b/docs/en-US/architecture/protocol-boundaries.md
@@ -9,8 +9,9 @@ RocketMQ Proxy through an `Endpoint`; a classic client asks a NameServer for rou
 the advertised Brokers. Their discovery, wire contracts, Consumer semantics, result types, and
 server requirements are therefore different.
 
-The protocols also use a few models with similar behavior: `Message`, filters, `ConsumeResult`,
-`ConsumerOptions`, and the client exception base. Putting those models in a third production Project
+The protocols also use a few models with similar behavior: `Message`, filters, `ConsumerOptions`, and the client
+exception base. Both protocols define a `ConsumeResult`, but its outcomes follow the owning consumer model rather
+than a cross-protocol shape. Putting those models in a third production Project
 would add another MSBuild boundary, Package version, and release dependency for a very small API
 surface.
 
@@ -56,6 +57,12 @@ The small foundational models are declared separately in each protocol namespace
 | Filter expression | `EventHorizon.RocketMQ.Grpc.Consumer.FilterExpression` | `EventHorizon.RocketMQ.Remoting.Consumer.FilterExpression` |
 | Filter type | `EventHorizon.RocketMQ.Grpc.Consumer.FilterExpressionType` | `EventHorizon.RocketMQ.Remoting.Consumer.FilterExpressionType` |
 | Client exception base | `EventHorizon.RocketMQ.Grpc.Exceptions.RocketMQClientException` | `EventHorizon.RocketMQ.Remoting.Exceptions.RocketMQClientException` |
+
+The two `ConsumeResult` types intentionally differ. gRPC Push and LitePush follow the Apache Java gRPC listener
+contract and expose `Success` and `Failure`; the service owns non-FIFO retry and dead-letter progression, while FIFO
+dead-letter forwarding is internal client behavior. Classic Remoting exposes `Success`, `Retry`, and `DeadLetter`
+because its callback settlement contract lets the application select those outcomes. Compatibility tests therefore
+lock each protocol's enum independently instead of requiring parity.
 
 Classic Remoting `ConsumerOptions.InitialPosition` uses the protocol-owned `ConsumeFromPosition` type. LitePull and
 Push apply it only when an assigned queue has no committed group position; a timestamp start also uses

--- a/docs/en-US/grpc/consumer-model.md
+++ b/docs/en-US/grpc/consumer-model.md
@@ -19,7 +19,7 @@ The gRPC project exposes the consumer models that the supported Proxy path can p
 
 | API | Application controls | Receive model |
 | --- | --- | --- |
-| `IGrpcSimpleConsumer` | Receive timing, acknowledgement, invisible duration, dead-letter forwarding, and subscriptions | The caller invokes `ReceiveAsync`. |
+| `IGrpcSimpleConsumer` | Receive timing, acknowledgement, invisible duration, and subscriptions | The caller invokes `ReceiveAsync`. |
 | `IGrpcPushConsumer` | Subscription and handler configuration; the client manages dispatch and completion | Assignment queries plus repeated `ReceiveMessage` long polls. |
 | `IGrpcLitePushConsumer` | LiteTopic subscriptions under a configured bind topic | The same client-initiated long-poll dispatcher, with Lite subscription synchronization. |
 
@@ -60,8 +60,8 @@ gRPC endpoint and is not a substitute for a Proxy.
 SimpleConsumer is the explicit-control model. After it starts and has at least one subscription,
 `ReceiveAsync` selects a subscription and assignment, issues a long-poll receive request, and gives
 the returned `GrpcMessageView` values to the application. The application decides when to call
-`AckAsync`, whether to extend invisibility, and when to forward a failed message to the dead-letter
-queue.
+`AckAsync` and whether to change invisibility. Leaving a message unsettled allows it to become visible again after its
+current invisible duration.
 
 This is often the right model when application code needs to control batching, commit timing, or
 retry boundaries. It is not classic queue Pull: it uses the gRPC receive and acknowledgement
@@ -77,7 +77,7 @@ subscriptions
     -> ReceiveMessage long poll
     -> bounded client dispatch queue
     -> concurrent or FIFO message handler
-    -> acknowledgement, retry, dead-letter action, or invisibility renewal
+    -> acknowledgement or failure handling
 ```
 
 The implementation in
@@ -87,16 +87,17 @@ dispatches work according to the configured concurrency and FIFO settings. It is
 long polling from end to end. Calling it protocol-level Broker push would give the wrong operational
 model.
 
-Ordinary Push receive requests set `AutoRenew=true`, asking a compatible Proxy to own receipt renewal for the client
-connection. SimpleConsumer sets `AutoRenew=false`; its caller owns the initial invisible duration and any explicit
-`ChangeInvisibleDurationAsync` call. The current .NET Push dispatcher also starts a client-side half-lease renewal loop
-while its handler is active. Proxy renewal and client-side renewal are two distinct owners of the same receipt lifetime;
-the gRPC follow-up refactor must consolidate that ownership and its telemetry rather than copying either mechanism into
-classic Remoting. Apache's Java gRPC Push client requests Proxy auto-renewal, while classic Remoting Push uses a fixed
-POP deadline.
+Ordinary Push and LitePush receive requests set `AutoRenew=true`. A compatible Proxy with `enableProxyAutoRenew`
+enabled owns receipt renewal through the client connection while a handler is active; the .NET dispatcher does not
+run a second client-side renewal timer. SimpleConsumer sets `AutoRenew=false`, so its caller owns the initial invisible
+duration and every explicit `ChangeInvisibleDurationAsync` call. This follows the
+[Apache Java gRPC client](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java#L263-L278),
+while the [Proxy registers auto-renew receipts](https://github.com/apache/rocketmq/blob/2238256de1d227a4384ba969dfa31473187b4d08/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140)
+only when both its configuration and the request enable the feature. Classic Remoting Push remains a separate model
+with a fixed POP deadline.
 
 For non-FIFO dispatch, `ConsumeTimeout` defaults to 15 minutes. When it expires, the dispatcher cancels the handler
-token, stops client-side invisibility renewal, and requests retry; a late successful result is ignored. This recovers
+token and requests retry; a late successful result is ignored. This recovers
 consume-loop capacity even when application code ignores cancellation, but the client cannot forcibly terminate that code.
 Retried delivery can overlap an invocation that ignored cancellation, so handlers must be idempotent. FIFO message
 groups are intentionally excluded because detaching a timed-out handler could break their ordering.
@@ -122,10 +123,19 @@ method. There is no delegate handler on the options object. A `Scoped` or `Trans
 async DI scope for each handling attempt, allowing normal scoped application dependencies such as database contexts;
 a `Singleton` handler is owned by its Consumer instance and must be safe for concurrent calls.
 
+The handler returns only `ConsumeResult.Success` or `ConsumeResult.Failure`, matching the public outcomes in the
+[Apache Java gRPC client](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java).
+For concurrent non-FIFO delivery, `Failure` changes invisibility according to the effective retry policy and leaves
+retry and dead-letter progression to the service. For FIFO delivery, the client retries the handler locally and uses
+the protocol's dead-letter RPC internally after the maximum attempts are exhausted, matching the
+[Java process-queue behavior](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445).
+Neither the handler result nor SimpleConsumer exposes that internal RPC. The OpenTelemetry settlement operation for
+retry scheduling remains `nack`; that telemetry term is not a RocketMQ handler result.
+
 ### LitePushConsumer
 
 LitePush wraps the automatic dispatcher with a
-[`GrpcLiteSubscriptionManager`](../../../src/EventHorizon.RocketMQ.Grpc/Consumer/Lite/GrpcLiteSubscriptionManager.cs).
+[`GrpcLiteSubscriptionManager`](../../../src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLiteSubscriptionManager.cs).
 It receives LiteTopic messages under one configured bind topic and synchronizes the Lite
 subscriptions with the Proxy.
 
@@ -144,7 +154,7 @@ and [local environment guide](../../../test-environments/rocketmq/README.md).
 - gRPC consumer capability depends on Proxy behavior as well as client code. Test against the exact
   Proxy deployment used in production.
 - Push reduces application orchestration but does not remove acknowledgement, invisibility, retry,
-  dead-letter, concurrency, or FIFO decisions. Those remain operational choices.
+  concurrency, or FIFO decisions. Those remain operational choices.
 - SimpleConsumer exposes explicit control but requires the caller to make completion and failure
   decisions for every delivered message.
 - The lack of a public gRPC Pull API is deliberate. Use `IGrpcSimpleConsumer` or

--- a/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
@@ -203,8 +203,9 @@ gRPC Push 和 LitePush 会为每条消息调用 handler。Remoting Push 则通�
 单消息投递。对于并发、非 FIFO 批次，handler 可以返回 `Success` 并设置 `AckIndex`，以确认连续前缀并重试
 尾部；`Retry` 和 `DeadLetter` 仍是整批结果。
 
-对于非 FIFO 的 gRPC Push 和 LitePush 消息，`ConsumeTimeout` 到期后会取消 handler token、停止客户端不可见时间续期，并请求
-重新投递。dispatcher 会忽略延迟返回的结果并释放消费循环的并发槽位，但无法终止应用代码。超时调用可能与重新投递重叠，因此必须保持幂等。
+对于非 FIFO 的 gRPC Push 和 LitePush 消息，`ConsumeTimeout` 到期后会取消 handler token 并请求重新投递。handler
+执行期间的 receipt 续期由 `AutoRenew` 请求的 Proxy 负责，不属于 handler scope，也不由客户端定时器承担。
+dispatcher 会忽略延迟返回的结果并释放消费循环的并发槽位，但无法终止应用代码。超时调用可能与重新投递重叠，因此必须保持幂等。
 对应 typed handler 的异步 scope 会一直存活到该调用返回，因此 handler 代码仍在运行时不会提前释放 scoped 依赖。FIFO message group
 为了保持顺序而不会应用此机制。
 

--- a/docs/zh-CN/architecture/opentelemetry-instrumentation.md
+++ b/docs/zh-CN/architecture/opentelemetry-instrumentation.md
@@ -81,9 +81,10 @@ listener 时才会注入上下文，并且不会覆盖消息中已有的传播�
 | Consumer 完结操作 | 确认、负确认和转发死信。 | LitePull 与 Push PULL 位点提交、重试/死信 send-back，以及 Push 内部 POP 确认和不可见时间变更。 |
 
 对于 gRPC，`ReceiveMessageRequest.AutoRenew` 请求的 Proxy 托管续约不是独立的客户端 wire operation，不能创建客户端
-settlement span。客户端主动发送 `ChangeInvisibleDuration` 时，必须根据意图区分：handler 活跃期间或 SimpleConsumer
-延长租期使用 `renew`，安排重试使用 `nack`。如果 Proxy 自动续约与客户端续期循环同时存在，或续约与重试记录为相同
-settlement outcome，gRPC 续约 owner 的职责仍未明确收敛。
+settlement span。客户端主动发送 `ChangeInvisibleDuration` 时，必须根据意图区分：SimpleConsumer 显式延长租期使用
+`renew`；Push 或 LitePush 因重试结果、handler 超时或消息损坏而安排重新投递时使用 `nack`。共享接收引擎必须保留
+这两种内部操作的意图区分，即使它们最终使用同一个 RPC。Proxy 托管的 handler 续期不会在客户端重复创建定时器、
+span 或 metric。
 
 classic Remoting 的埋点归属应跟随实际 wire operation。`PullWireClient` 负责记录并完成非空、空结果、取消与失败 PULL 的
 receive 埋点；`RemotingConsumerOffsetClient` 负责 commit settlement；`RemotingSettlementClient` 负责 PULL 重试与

--- a/docs/zh-CN/architecture/protocol-boundaries.md
+++ b/docs/zh-CN/architecture/protocol-boundaries.md
@@ -7,8 +7,9 @@
 RocketMQ 5 protobuf/gRPC 客户端连接 Proxy；classic Remoting 客户端则先向 NameServer 查询路由，再连接
 Broker。两条路径的服务发现、wire contract、Consumer 语义、结果类型和服务端要求都不相同。
 
-两种协议仍有少量行为相近的模型，例如 `Message`、过滤表达式、`ConsumeResult`、`ConsumerOptions` 和客户端
-异常基类。如果为这些类型增加第三个生产 Project，就会为了很小的 API 范围引入额外的 MSBuild 边界、
+两种协议仍有少量行为相近的模型，例如 `Message`、过滤表达式、`ConsumerOptions` 和客户端异常基类。两边都定义了
+`ConsumeResult`，但其结果值应服从各自的消费模型，而不是强制保持跨协议一致。如果为这些类型增加第三个生产 Project，
+就会为了很小的 API 范围引入额外的 MSBuild 边界、
 Package 版本和发布依赖。
 
 ## 决策
@@ -49,6 +50,11 @@ Package 版本和发布依赖。
 | 过滤表达式 | `EventHorizon.RocketMQ.Grpc.Consumer.FilterExpression` | `EventHorizon.RocketMQ.Remoting.Consumer.FilterExpression` |
 | 过滤类型 | `EventHorizon.RocketMQ.Grpc.Consumer.FilterExpressionType` | `EventHorizon.RocketMQ.Remoting.Consumer.FilterExpressionType` |
 | 客户端异常基类 | `EventHorizon.RocketMQ.Grpc.Exceptions.RocketMQClientException` | `EventHorizon.RocketMQ.Remoting.Exceptions.RocketMQClientException` |
+
+两个 `ConsumeResult` 有意采用不同结果。gRPC Push 与 LitePush 遵循 Apache Java gRPC listener 契约，只公开
+`Success` 和 `Failure`；非 FIFO 的重试与死信推进由服务端负责，FIFO 死信转发则是客户端内部行为。classic Remoting
+的 callback 结算契约允许应用选择 `Success`、`Retry` 或 `DeadLetter`，因此继续公开这三个结果。兼容性测试分别锁定
+两边的枚举，而不再要求它们完全相同。
 
 classic Remoting 的 `ConsumerOptions.InitialPosition` 使用协议自有的 `ConsumeFromPosition` 类型。LitePull 与
 Push 只在已分配队列不存在消费组已提交位点时应用该配置；从时间戳开始时还会读取

--- a/docs/zh-CN/grpc/consumer-model.md
+++ b/docs/zh-CN/grpc/consumer-model.md
@@ -20,7 +20,7 @@ gRPC Project 公开以下 Consumer 角色：
 
 | 角色 | 由谁驱动接收 | 适用场景 |
 | --- | --- | --- |
-| `IGrpcSimpleConsumer` | 应用调用 `ReceiveAsync` | 应用需要自行决定批量、确认、不可见时间和死信时机。 |
+| `IGrpcSimpleConsumer` | 应用调用 `ReceiveAsync` | 应用需要自行决定批量、确认和不可见时间。 |
 | `IGrpcPushConsumer` | 客户端后台循环 | 应用希望自动接收、并发/FIFO 分发、重试和死信处理。 |
 | `IGrpcLitePushConsumer` | 客户端后台循环与 Lite 订阅同步 | 使用 LiteTopic，且部署已配置 bind topic 和 Lite 能力。 |
 
@@ -58,8 +58,7 @@ SimpleConsumer 的调用流程是：
 1. 使用 `SubscribeAsync` 建立主题订阅和过滤表达式。
 2. 调用 `ReceiveAsync` 获取一批 `GrpcMessageView`。
 3. 在消息持久化或业务副作用完成后调用 `AckAsync`。
-4. 工作时间超过不可见期时调用 `ChangeInvisibleDurationAsync`；不能继续处理时可调用
-   `ForwardToDeadLetterQueueAsync`。
+4. 工作时间超过不可见期时调用 `ChangeInvisibleDurationAsync`；消息未结算时，会在当前不可见时间结束后重新可见。
 
 这种方式适合需要将确认与本地事务、批处理或自定义并发调度绑定的应用。它不替调用方处理异常、重复
 投递或幂等性。收到的 `GrpcMessageView` 还可能标记为损坏消息，应用应先决定是否跳过或转入死信，而不是
@@ -79,29 +78,36 @@ PushConsumer 启动后大致执行如下循环：
                   有界消息缓存与消费循环
                          │
                          ▼
-              handler 返回 Success / Retry / DeadLetter
+                  handler 返回 Success / Failure
                          │
-        ┌────────────────┼────────────────┐
-        ▼                ▼                ▼
-       确认             重试             转发死信
+                    ┌────┴────┐
+                    ▼         ▼
+                   确认      失败处理
 ```
 
-`ConsumeResult.Success` 表示可以确认；`Retry` 表示应交给重试策略；`DeadLetter` 表示转发到死信队列。
-只有业务处理真正完成后才应返回 `Success`。网络超时、进程终止或确认失败仍可能造成重复投递，因此 handler
-必须具备幂等性。
+handler 只返回 `ConsumeResult.Success` 或 `ConsumeResult.Failure`，与
+[Apache Java gRPC 客户端的公开结果](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java)
+一致。对于并发、非 FIFO 投递，`Failure` 会按当前重试策略调整不可见时间，后续重试和死信推进由服务端负责。
+对于 FIFO 投递，客户端会在本地重试 handler，并在达到最大次数后通过内部协议 RPC 转入死信队列；这一行为与
+[Java process queue](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445)
+一致。handler 结果和 SimpleConsumer 都不暴露内部死信 RPC。重试调度对应的 OpenTelemetry 结算 operation 仍为
+`nack`，但它不是 RocketMQ handler 结果。只有业务处理真正完成后才应返回 `Success`。网络超时、进程终止或确认
+失败仍可能造成重复投递，因此 handler 必须具备幂等性。
 
-普通 Push 的 receive request 会设置 `AutoRenew=true`，让兼容的 Proxy 通过客户端连接托管 receipt 续期。
-SimpleConsumer 设置 `AutoRenew=false`，初始不可见时间和显式 `ChangeInvisibleDurationAsync` 都由调用方负责。
-当前 .NET Push dispatcher 还会在 handler 执行期间启动客户端侧的半租期续期循环。Proxy 续期和客户端侧续期是同一
-receipt 生命周期的两个不同 owner；后续 gRPC 重构必须合并这两个 owner 及对应 telemetry，不能把任一机制照搬到
-classic Remoting。Apache Java gRPC Push 会请求 Proxy 自动续约，而 classic Remoting Push 使用固定 POP deadline。
+普通 Push 与 LitePush 的 receive request 会设置 `AutoRenew=true`。目标 Proxy 启用 `enableProxyAutoRenew` 后，会在
+handler 执行期间通过客户端连接托管 receipt 续期；.NET dispatcher 不再额外启动一套客户端续期定时器。
+SimpleConsumer 设置 `AutoRenew=false`，因此初始不可见时间以及每次显式 `ChangeInvisibleDurationAsync` 都由调用方负责。
+这一职责划分与
+[Apache Java gRPC 客户端](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java#L263-L278)
+一致；[Proxy 只有在配置和请求都启用自动续期时才会登记 receipt](https://github.com/apache/rocketmq/blob/2238256de1d227a4384ba969dfa31473187b4d08/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140)。
+classic Remoting Push 仍使用固定 POP deadline，不沿用这套续期机制。
 
 `MaxConcurrency` 控制消费循环数量，`MaxCachedMessages` 与 `MaxCachedMessageBytes` 限制本地缓冲。开启
 FIFO 分发时，客户端为同一消息组维持顺序尾链并阻塞同组后续消息；这是应用处理顺序的约束，不应被理解为
 跨消费组、跨队列或跨消费者的全局顺序保证。
 
-对于非 FIFO 分发，`ConsumeTimeout` 默认值为 15 分钟。到期后 dispatcher 会取消 handler token、停止客户端的
-不可见时间续期并请求重新投递；延迟返回的成功结果会被忽略。即使应用代码忽略取消，dispatcher 也会释放消费循环的并发槽位，
+对于非 FIFO 分发，`ConsumeTimeout` 默认值为 15 分钟。到期后 dispatcher 会取消 handler token 并请求重新投递；
+延迟返回的成功结果会被忽略。即使应用代码忽略取消，dispatcher 也会释放消费循环的并发槽位，
 但客户端无法强制终止这段代码。重新投递可能与仍在执行、但忽略取消的调用重叠，因此 handler 必须具备幂等性。FIFO message
 group 会刻意排除在此机制之外，因为脱离一个超时 handler 可能破坏顺序。
 
@@ -126,7 +132,7 @@ scoped 应用服务；`Singleton` handler 归当前 Consumer 实例所有，并�
 ### LitePush：Push 调度器加上 Lite 订阅控制面
 
 LitePush 复用 Push 的接收和分发机制，但消息来自 LiteTopic。它在普通 dispatcher 外增加
-[`GrpcLiteSubscriptionManager`](../../../src/EventHorizon.RocketMQ.Grpc/Consumer/Lite/GrpcLiteSubscriptionManager.cs)，
+[`GrpcLiteSubscriptionManager`](../../../src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLiteSubscriptionManager.cs)，
 用来同步 LiteTopic 订阅与起始位点。
 
 部署端至少需要满足以下条件：

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -66,7 +66,7 @@ dotnet run -c Release --project tests/benchmarks/EventHorizon.RocketMQ.Remoting.
 - options 验证、默认客户端注册、keyed 客户端注册与重复角色注册；
 - message 编解码、frame 长度限制、ACL 签名和 response correlation；
 - route cache、重试、取消、连接故障和 handler 生命周期；
-- Consumer 对 `Success`、部分批量确认、`Retry`、`DeadLetter` 的处理决策。
+- Consumer 对 gRPC `Success` / `Failure`，以及 Remoting `Success`、部分批量确认、`Retry`、`DeadLetter` 的处理决策。
 
 对于客户端能够确定性验证的行为，IT 覆盖不能替代 UT。即使 IT 已覆盖完整工作流，底层状态转换、分配、调度、
 offset、重试和失败不变量仍必须保留聚焦的 UT；IT 只在此基础上补充真实 Broker、NameServer、Proxy、transport、

--- a/samples/grpc/GenericHost/LitePushConsumer/README.md
+++ b/samples/grpc/GenericHost/LitePushConsumer/README.md
@@ -65,15 +65,16 @@ delivery still uses client-initiated long polling.
 ## Delivery and failure semantics
 
 LitePush uses the same `IGrpcPushMessageHandler` contract and dependency-injection lifetime rules as standard Push.
-`ConsumeResult.Success` acknowledges the message, `Retry` requests another attempt, and `DeadLetter` forwards it to the
-consumer group's dead-letter queue. Handler exceptions are treated as retry requests, and failed completion calls can
-produce duplicate delivery, so processing must be idempotent.
+`ConsumeResult.Success` acknowledges the message; `Failure` lets the effective retry policy schedule another delivery.
+Handler exceptions are treated as failures, and failed completion calls can produce duplicate delivery, so processing
+must be idempotent.
 
 Corrupted messages bypass the application handler. The client retries non-FIFO corrupted messages and dead-letters
 corrupted FIFO messages before releasing the next member of that message group.
 
-The client renews invisibility while handling a message. For non-FIFO work, `ConsumeTimeout` cancels the handler token,
-stops renewal, and requests retry; it cannot forcibly terminate code that ignores cancellation. FIFO message groups
+LitePush requests set `AutoRenew=true`, so a compatible Proxy renews the receipt while the handler runs; the .NET
+client does not run a second renewal timer. For non-FIFO work, `ConsumeTimeout` cancels the handler token and requests
+another delivery; it cannot forcibly terminate code that ignores cancellation. FIFO message groups
 remain attached to preserve order. The same local concurrency, bounded-cache, and server-policy fallback behavior as
 `IGrpcPushConsumer` applies.
 
@@ -101,7 +102,7 @@ service with a Broker.
 | `SubscriptionSyncInterval` | Periodic reconciliation interval for the complete LiteTopic set. |
 | `MaxConcurrency`, `BatchSize`, and cache limits | Local handler parallelism, receive batch size, and bounded buffering inherited from Push. |
 | `InvisibleDuration` / `ConsumeTimeout` | Initial invisibility and the non-FIFO handler timeout behavior inherited from Push. |
-| `MaxDeliveryAttempts` / `RetryDelay` | Fallback delivery policy when the Proxy does not supply one. |
+| `MaxDeliveryAttempts` / `RetryDelay` | Fallback FIFO local-attempt limit and retry delay when the Proxy does not supply a policy. Non-FIFO dead-letter progression remains service-owned. |
 | `LongPollingTimeout` | Maximum server wait for each receive long poll. |
 
 ## Run the sample

--- a/samples/grpc/GenericHost/LitePushConsumer/README.zh-CN.md
+++ b/samples/grpc/GenericHost/LitePushConsumer/README.zh-CN.md
@@ -58,14 +58,15 @@ LiteTopic 订阅时生效。
 ## 投递与失败语义
 
 LitePush 与标准 Push 使用同一个 `IGrpcPushMessageHandler` 契约和依赖注入生命周期规则。
-`ConsumeResult.Success` 会确认消息，`Retry` 会请求再次投递，`DeadLetter` 会将消息转入该 consumer group 的死信队列。
-handler 异常会被当作重试请求，完成操作失败也可能造成重复投递，因此处理逻辑必须幂等。
+`ConsumeResult.Success` 会确认消息；`Failure` 交由当前生效的重试策略安排再次投递。handler 异常会被当作失败结果，
+完成操作失败也可能造成重复投递，因此处理逻辑必须幂等。
 
 损坏的消息不会进入应用 handler。客户端会重试非 FIFO 损坏消息；FIFO 损坏消息会在释放同一 message group 的下一条消息前
 转入死信队列。
 
-客户端会在 handler 运行期间续期消息的不可见时间。对于非 FIFO 工作，`ConsumeTimeout` 会取消 handler token、停止续期并
-请求重试，但无法强制终止忽略取消的代码。FIFO message group 会继续保持关联以维持顺序。它还继承
+LitePush 请求会设置 `AutoRenew=true`，由兼容的 Proxy 在 handler 运行期间续期 receipt；.NET 客户端不会再启动
+一套续期定时器。对于非 FIFO 工作，`ConsumeTimeout` 会取消 handler token 并请求再次投递，但无法强制终止忽略取消的
+代码。FIFO message group 会继续保持关联以维持顺序。它还继承
 `IGrpcPushConsumer` 的本地并发、有界缓存和服务端策略回退行为。
 
 ## RocketMQ 能力要求
@@ -91,7 +92,7 @@ LitePush 要求客户端、Proxy、Broker、Topic 和 consumer group 的配置�
 | `SubscriptionSyncInterval` | 定期协调完整 LiteTopic 集合的间隔。 |
 | `MaxConcurrency`、`BatchSize` 和缓存限制 | 从 Push 继承的本地 handler 并发、Receive 批量和有界缓冲。 |
 | `InvisibleDuration` / `ConsumeTimeout` | 从 Push 继承的初始不可见时长和非 FIFO handler 超时行为。 |
-| `MaxDeliveryAttempts` / `RetryDelay` | Proxy 没有提供投递策略时使用的回退值。 |
+| `MaxDeliveryAttempts` / `RetryDelay` | Proxy 没有提供策略时使用的 FIFO 本地尝试次数与重试延迟回退值；非 FIFO 的死信推进仍由服务端负责。 |
 | `LongPollingTimeout` | 每次 Receive 长轮询允许服务端等待的最长时间。 |
 
 ## 运行示例

--- a/samples/grpc/GenericHost/PushConsumer/README.md
+++ b/samples/grpc/GenericHost/PushConsumer/README.md
@@ -9,7 +9,7 @@ application API: the Broker does not open a server-initiated connection to the a
 ## When to use it
 
 Use PushConsumer when message processing naturally fits a handler and the SDK should own the receive loops,
-backpressure, concurrency, invisibility renewal, and settlement calls. It is usually the simpler choice for continuously
+backpressure, concurrency, Proxy renewal requests, and settlement calls. It is usually the simpler choice for continuously
 running services whose handler can return one delivery outcome per message.
 
 Use `IGrpcSimpleConsumer` when the application must choose when to receive, control batches directly, or coordinate
@@ -63,17 +63,17 @@ Each handler result asks the consumer to perform a specific settlement operation
 | Result | SDK action |
 | --- | --- |
 | `ConsumeResult.Success` | Acknowledge the message. Return it only after the business effect is durable. |
-| `ConsumeResult.Retry` | Make the message eligible for another attempt according to the effective retry policy. |
-| `ConsumeResult.DeadLetter` | Forward the message to the consumer group's dead-letter queue. |
+| `ConsumeResult.Failure` | Let the effective retry policy schedule another delivery. |
 
-An unhandled handler exception is treated as `Retry`. If acknowledgement, retry, or dead-letter completion fails, the
+An unhandled handler exception is treated as `Failure`. If acknowledgement or retry scheduling fails, the
 message may be delivered again. Handlers must therefore be idempotent even when they return `Success`.
 
 Corrupted messages do not reach `IGrpcPushMessageHandler`. A non-FIFO corrupted message is made eligible for retry;
 a corrupted FIFO message is dead-lettered before the next member of its message group is released.
 
-While a handler is active, the client renews message invisibility. For non-FIFO messages, `ConsumeTimeout` bounds how
-long the dispatcher waits: expiry cancels the handler token, stops renewal, requests retry, and ignores a late success.
+Push requests set `AutoRenew=true`, so a compatible Proxy renews the receipt while the handler is active; the .NET
+client does not run a second renewal timer. For non-FIFO messages, `ConsumeTimeout` bounds how long the dispatcher
+waits: expiry cancels the handler token, requests another delivery, and ignores a late success.
 The SDK cannot forcibly stop code that ignores cancellation, so the old invocation can overlap a redelivery. FIFO
 message groups do not use this timeout-detach behavior because releasing the next message could break ordering.
 
@@ -96,9 +96,9 @@ different subscriptions.
 | `MaxConcurrency` | Maximum scheduled handler dispatches. A timed-out handler that ignores cancellation can still remain in process. |
 | `BatchSize` | Maximum messages requested by one receive operation. |
 | `MaxCachedMessages` / `MaxCachedMessageBytes` | Count and body-byte limits for the bounded local message buffer. |
-| `InvisibleDuration` | Initial message invisibility; the client renews it during active processing. |
+| `InvisibleDuration` | Initial message invisibility; a compatible Proxy renews the receipt during active processing. |
 | `ConsumeTimeout` | Maximum non-FIFO handler time before cancellation and retry are requested. |
-| `MaxDeliveryAttempts` / `RetryDelay` | Fallback dead-letter threshold and retry delay when the Proxy does not supply a policy. |
+| `MaxDeliveryAttempts` / `RetryDelay` | Fallback FIFO local-attempt limit and retry delay when the Proxy does not supply a policy. Non-FIFO dead-letter progression remains service-owned. |
 | `LongPollingTimeout` | Maximum server wait for each receive long poll. |
 
 ## Run the sample

--- a/samples/grpc/GenericHost/PushConsumer/README.zh-CN.md
+++ b/samples/grpc/GenericHost/PushConsumer/README.zh-CN.md
@@ -7,7 +7,7 @@
 
 ## 适用场景
 
-当消息处理适合表示成 handler，并希望 SDK 负责接收循环、背压、并发、不可见时间续期及完成操作时，适合使用
+当消息处理适合表示成 handler，并希望 SDK 负责接收循环、背压、并发、请求 Proxy 续期及完成操作时，适合使用
 PushConsumer。对于持续运行、每条消息都能由 handler 返回一个处理结果的服务，它通常是更简单的选择。
 
 如果应用必须自行决定何时接收、直接控制批量，或者将确认交给自己的调度器，请改用 `IGrpcSimpleConsumer`。如果应用必须选择
@@ -57,17 +57,17 @@ Generic Host 集成会为已注册角色调用 `StartAsync` 和 `StopAsync`。�
 | 结果 | SDK 行为 |
 | --- | --- |
 | `ConsumeResult.Success` | 确认消息。只有业务副作用已经持久化后才能返回该结果。 |
-| `ConsumeResult.Retry` | 按当前生效的重试策略，让消息可以再次投递。 |
-| `ConsumeResult.DeadLetter` | 将消息转入该 consumer group 的死信队列。 |
+| `ConsumeResult.Failure` | 由当前生效的重试策略安排再次投递。 |
 
-未处理的 handler 异常会被当作 `Retry`。如果确认、重试或死信完成操作失败，消息可能再次投递。因此，即使 handler 返回
+未处理的 handler 异常会被当作 `Failure`。如果确认或重试调度失败，消息可能再次投递。因此，即使 handler 返回
 `Success`，处理逻辑仍必须幂等。
 
 损坏的消息不会进入 `IGrpcPushMessageHandler`。非 FIFO 损坏消息会重新变为可投递状态；FIFO 损坏消息会在释放同一
 message group 的下一条消息前转入死信队列。
 
-handler 运行期间，客户端会续期消息的不可见时间。对于非 FIFO 消息，`ConsumeTimeout` 限制 dispatcher 等待 handler
-的时长：超时后会取消 handler token、停止续期、请求重试，并忽略延迟返回的成功结果。SDK 无法强制停止忽略取消的代码，
+Push 请求会设置 `AutoRenew=true`，由兼容的 Proxy 在 handler 运行期间续期 receipt；.NET 客户端不会再启动一套续期
+定时器。对于非 FIFO 消息，`ConsumeTimeout` 限制 dispatcher 等待 handler 的时长：超时后会取消 handler token、
+请求再次投递，并忽略延迟返回的成功结果。SDK 无法强制停止忽略取消的代码，
 因此旧调用可能与重新投递重叠。FIFO message group 不使用这种超时后脱离 handler 的行为，因为释放下一条消息可能破坏顺序。
 
 `MaxConcurrency` 控制本地 handler 并发，不代表 Broker queue 数量。FIFO 顺序只在一个 message group 内成立，不是跨
@@ -87,9 +87,9 @@ queue、consumer group 或 Consumer 实例的全局顺序。使用相同 consume
 | `MaxConcurrency` | 最大 handler 调度并发数。已经超时且忽略取消的 handler 仍可能留在进程中。 |
 | `BatchSize` | 单次 Receive 请求的最大消息数。 |
 | `MaxCachedMessages` / `MaxCachedMessageBytes` | 有界本地消息缓冲的数量和消息体字节数限制。 |
-| `InvisibleDuration` | 初始消息不可见时长；处理期间客户端会续期。 |
+| `InvisibleDuration` | 初始消息不可见时长；处理期间由兼容的 Proxy 续期 receipt。 |
 | `ConsumeTimeout` | 非 FIFO handler 在请求取消和重试前允许运行的最长时间。 |
-| `MaxDeliveryAttempts` / `RetryDelay` | Proxy 没有提供策略时使用的死信阈值和重试延迟回退值。 |
+| `MaxDeliveryAttempts` / `RetryDelay` | Proxy 没有提供策略时使用的 FIFO 本地尝试次数与重试延迟回退值；非 FIFO 的死信推进仍由服务端负责。 |
 | `LongPollingTimeout` | 每次 Receive 长轮询允许服务端等待的最长时间。 |
 
 ## 运行示例

--- a/samples/grpc/GenericHost/README.md
+++ b/samples/grpc/GenericHost/README.md
@@ -10,8 +10,8 @@ the same role's `StartAsync` or `StopAsync` manually.
 | --- | --- | --- |
 | [Producer](Producer/README.md) | `IGrpcProducer` | Exposes a small HTTP API that sends through a RocketMQ 5 Proxy. |
 | [LiteProducer](LiteProducer/README.md) | `IGrpcProducer` | Publishes Lite messages to a LITE parent topic and logical LiteTopic through a small HTTP API. |
-| [SimpleConsumer](SimpleConsumer/README.md) | `IGrpcSimpleConsumer` | Receives, acknowledges, and dead-letters in an application-owned receive loop. |
-| [PushConsumer](PushConsumer/README.md) | `IGrpcPushConsumer` | Lets the SDK own assignment polling, handler dispatch, invisibility renewal, and settlement. |
+| [SimpleConsumer](SimpleConsumer/README.md) | `IGrpcSimpleConsumer` | Receives, acknowledges, and changes invisibility in an application-owned receive loop. |
+| [PushConsumer](PushConsumer/README.md) | `IGrpcPushConsumer` | Lets the SDK own assignment polling, handler dispatch, Proxy renewal requests, and settlement. |
 | [LitePushConsumer](LitePushConsumer/README.md) | `IGrpcLitePushConsumer` | Synchronizes LiteTopics and dispatches messages in a LITE-enabled deployment. |
 
 For a process that only builds a plain `ServiceProvider`, use the sibling [non-Host samples](../NonHost/README.md).

--- a/samples/grpc/GenericHost/README.zh-CN.md
+++ b/samples/grpc/GenericHost/README.zh-CN.md
@@ -9,8 +9,8 @@
 | --- | --- | --- |
 | [Producer](Producer/README.zh-CN.md) | `IGrpcProducer` | 通过小型 HTTP API 经 RocketMQ 5 Proxy 发送消息。 |
 | [LiteProducer](LiteProducer/README.zh-CN.md) | `IGrpcProducer` | 通过小型 HTTP API 向 LITE parent topic 和逻辑 LiteTopic 发布 Lite message。 |
-| [SimpleConsumer](SimpleConsumer/README.zh-CN.md) | `IGrpcSimpleConsumer` | 在应用自有接收循环中接收、确认和转入死信。 |
-| [PushConsumer](PushConsumer/README.zh-CN.md) | `IGrpcPushConsumer` | 由 SDK 负责分配轮询、handler 分发、不可见期续期和结算。 |
+| [SimpleConsumer](SimpleConsumer/README.zh-CN.md) | `IGrpcSimpleConsumer` | 在应用自有接收循环中接收、确认和调整不可见时间。 |
+| [PushConsumer](PushConsumer/README.zh-CN.md) | `IGrpcPushConsumer` | 由 SDK 负责分配轮询、handler 分发、请求 Proxy 续期和结算。 |
 | [LitePushConsumer](LitePushConsumer/README.zh-CN.md) | `IGrpcLitePushConsumer` | 在启用 LITE 的部署中同步 LiteTopic 并分发消息。 |
 
 只构造普通 `ServiceProvider` 的进程应使用同级[非 Host 示例](../NonHost/README.zh-CN.md)，其中展示了必需的显式

--- a/samples/grpc/GenericHost/SimpleConsumer/MessageReceiveLoop.cs
+++ b/samples/grpc/GenericHost/SimpleConsumer/MessageReceiveLoop.cs
@@ -34,7 +34,7 @@ internal sealed class MessageReceiveLoop(
             try
             {
                 // ReceiveAsync long-polls the Proxy. Each result remains invisible for the configured duration
-                // unless it is acknowledged or forwarded to the DLQ.
+                // unless it is acknowledged.
                 messages = await consumer.ReceiveAsync(16, cancellationToken: stoppingToken)
                     .ConfigureAwait(false);
             }
@@ -56,16 +56,10 @@ internal sealed class MessageReceiveLoop(
                 {
                     if (message.IsCorrupted)
                     {
-                        // SimpleConsumer never auto-settles messages; explicitly forward unsafe payloads to the DLQ.
                         logger.LogWarning(
-                            "Forwarding corrupted message {MessageId} to the dead-letter queue: {Reason}",
+                            "Leaving corrupted message {MessageId} unsettled so the service retry policy can handle it: {Reason}",
                             message.MessageId,
                             message.CorruptionReason);
-                        await consumer.ForwardToDeadLetterQueueAsync(
-                                message,
-                                16,
-                                stoppingToken)
-                            .ConfigureAwait(false);
                         continue;
                     }
 

--- a/samples/grpc/GenericHost/SimpleConsumer/README.md
+++ b/samples/grpc/GenericHost/SimpleConsumer/README.md
@@ -45,7 +45,6 @@ The public API keeps reception and settlement separate:
 | `ReceiveAsync` | Long-poll the Proxy and return up to the requested number of `GrpcMessageView` values. An empty result is valid. |
 | `AckAsync` | Confirm one message after its business effect is durable. |
 | `ChangeInvisibleDurationAsync` | Replace the current invisibility duration when processing needs more time. |
-| `ForwardToDeadLetterQueueAsync` | Explicitly move a message to the consumer group's dead-letter queue using the supplied delivery-attempt threshold. |
 
 Check `GrpcMessageView.IsCorrupted` before reading the body. A corrupted payload still requires an explicit settlement
 decision; it is not acknowledged automatically by SimpleConsumer.
@@ -57,8 +56,7 @@ stops, or `AckAsync` does not complete successfully, the message can become visi
 duration. Applications must therefore make handlers idempotent and acknowledge only after durable processing.
 
 If work can outlive the current invisibility window, call `ChangeInvisibleDurationAsync` before the window expires.
-Forwarding to the dead-letter queue is also an explicit application decision; an ordinary processing exception does
-not invoke `ForwardToDeadLetterQueueAsync` on the application's behalf.
+If processing cannot complete, leave the message unsettled so it becomes visible again after that window.
 
 Consumer groups own acknowledgement and retry state. Multiple instances using the same group share the work; a
 different group observes the topic independently.

--- a/samples/grpc/GenericHost/SimpleConsumer/README.zh-CN.md
+++ b/samples/grpc/GenericHost/SimpleConsumer/README.zh-CN.md
@@ -42,7 +42,6 @@ Generic Host 集成会启动和停止已注册的角色。不使用 Host 时，�
 | `ReceiveAsync` | 向 Proxy 发起长轮询，最多返回请求数量的 `GrpcMessageView`；返回空集合是正常结果。 |
 | `AckAsync` | 在业务副作用已经持久化后确认一条消息。 |
 | `ChangeInvisibleDurationAsync` | 处理需要更多时间时，替换消息当前的不可见时长。 |
-| `ForwardToDeadLetterQueueAsync` | 使用传入的投递次数阈值，将消息显式转入该 consumer group 的死信队列。 |
 
 读取消息体前应检查 `GrpcMessageView.IsCorrupted`。损坏的 payload 仍需由应用明确决定如何处理，SimpleConsumer 不会自动
 确认它。
@@ -52,8 +51,8 @@ Generic Host 集成会启动和停止已注册的角色。不使用 Host 时，�
 `ReceiveAsync` 只会让消息暂时不可见，不会确认消息。如果业务处理失败、进程停止，或者 `AckAsync` 没有成功完成，消息可能在
 不可见时长结束后再次可见。因此，应用必须保证处理逻辑幂等，并且只在持久化处理完成后确认。
 
-如果任务可能超过当前不可见窗口，应在窗口到期前调用 `ChangeInvisibleDurationAsync`。转入死信队列同样是应用的显式决定；
-普通处理异常不会让 SDK 代替应用调用 `ForwardToDeadLetterQueueAsync`。
+如果任务可能超过当前不可见窗口，应在窗口到期前调用 `ChangeInvisibleDurationAsync`。处理无法完成时，不要结算该消息；
+当前不可见时间结束后，消息会重新可见。
 
 consumer group 保存确认和重试状态。使用同一个 group 的多个实例会分摊消息；使用不同 group 才会独立观察同一个 topic。
 

--- a/samples/grpc/NonHost/LitePushConsumer/Program.cs
+++ b/samples/grpc/NonHost/LitePushConsumer/Program.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 using EventHorizon.RocketMQ.Grpc;
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Samples.Grpc.NonHost.LitePushConsumer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/grpc/NonHost/LitePushConsumer/README.md
+++ b/samples/grpc/NonHost/LitePushConsumer/README.md
@@ -20,8 +20,8 @@ in this non-Host process.
 
 `BindTopic` identifies the LITE parent topic. `LiteTopics` is the complete initial logical subscription set; it is not
 a list of ordinary topics or filters. The sample's scoped `IGrpcPushMessageHandler` logs a message and returns
-`ConsumeResult.Success`, which makes the SDK acknowledge it. `Retry` requests another attempt and `DeadLetter` moves
-the message to the consumer group's dead-letter queue. Handler exceptions are retried, so processing must be idempotent.
+`ConsumeResult.Success`, which makes the SDK acknowledge it. `Failure` lets the effective retry policy schedule another
+delivery. Handler exceptions are retried, so processing must be idempotent.
 
 Do not call ordinary `ConsumerOptions.Subscribe` for LitePush. Use `LiteTopics`, `SubscribeLiteAsync`, and
 `UnsubscribeLiteAsync` with one bind topic instead. Lite delivery still uses client-initiated long polling through a

--- a/samples/grpc/NonHost/LitePushConsumer/README.zh-CN.md
+++ b/samples/grpc/NonHost/LitePushConsumer/README.zh-CN.md
@@ -17,8 +17,8 @@ LiteTopic 集合，持续运行 handler 直到 Ctrl+C，显式停止角色，并
 ## 投递与 Lite 订阅
 
 `BindTopic` 指定 LITE parent topic。`LiteTopics` 是完整的初始逻辑订阅集合，不是普通 topic 或 filter 的列表。示例的 scoped
-`IGrpcPushMessageHandler` 记录消息并返回 `ConsumeResult.Success`，SDK 随后会确认消息。`Retry` 请求再次投递，`DeadLetter`
-会将消息转入 consumer group 的死信队列。handler 异常会触发重试，因此处理必须是幂等的。
+`IGrpcPushMessageHandler` 记录消息并返回 `ConsumeResult.Success`，SDK 随后会确认消息。`Failure` 交由当前生效的重试
+策略安排再次投递。handler 异常会触发重试，因此处理必须是幂等的。
 
 不要为 LitePush 调用普通的 `ConsumerOptions.Subscribe`。应通过一个 bind topic 下的 `LiteTopics`、`SubscribeLiteAsync` 和
 `UnsubscribeLiteAsync` 管理订阅。Lite 投递仍通过 RocketMQ 5 Proxy 的客户端发起长轮询完成。

--- a/samples/grpc/NonHost/PushConsumer/README.md
+++ b/samples/grpc/NonHost/PushConsumer/README.md
@@ -17,8 +17,8 @@ Use this pattern only when the application owns a non-Generic-Host lifetime, for
 existing process host. A normal .NET Generic Host should use the [companion Host sample](../../GenericHost/PushConsumer/README.md): its `RunAsync`
 invokes the SDK's registered lifecycle service, so application code must not call `StartAsync` or `StopAsync` again.
 
-The consumer itself still owns assignment polling, long-poll receives, handler concurrency, acknowledgement, retry,
-and dead-letter settlement. The scoped handler returns `Success` only after its sample processing completes.
+The consumer itself still owns assignment polling, long-poll receives, handler concurrency, acknowledgement, and
+failure settlement. The scoped handler returns `Success` only after its sample processing completes.
 
 ## Run the sample
 
@@ -34,8 +34,7 @@ Use the [non-Host gRPC Producer sample](../Producer/README.md) to send the messa
 shutdown; the sample calls `StopAsync` even when startup is cancelled or fails part-way through.
 
 The default Proxy endpoint is `localhost:8081`. External deployments must expose a RocketMQ 5 Proxy, create
-`eventhorizon-test-topic`, and grant route-query and consume permissions, including retry and dead-letter access when
-those outcomes are enabled. Standard .NET configuration overrides apply, such as
+`eventhorizon-test-topic`, and grant route-query and consume permissions. Standard .NET configuration overrides apply, such as
 `RocketMQ__Client__Endpoint=proxy.example:8081`.
 
 See the [gRPC protocol guide](../../../../src/EventHorizon.RocketMQ.Grpc/README.md) for the complete API and delivery

--- a/samples/grpc/NonHost/PushConsumer/README.zh-CN.md
+++ b/samples/grpc/NonHost/PushConsumer/README.zh-CN.md
@@ -15,7 +15,7 @@
 应使用[对应的 Host 示例](../../GenericHost/PushConsumer/README.zh-CN.md)：其 `RunAsync` 会调用 SDK 注册的生命周期服务，所以应用代码不能再次调用
 `StartAsync` 或 `StopAsync`。
 
-Consumer 本身仍负责分配轮询、长轮询接收、handler 并发、确认、重试和死信结算。scoped handler 只会在示例处理完成后返回
+Consumer 本身仍负责分配轮询、长轮询接收、handler 并发、确认和失败结算。scoped handler 只会在示例处理完成后返回
 `Success`。
 
 ## 运行示例
@@ -32,7 +32,7 @@ dotnet run --project samples/grpc/NonHost/PushConsumer
 示例仍会调用 `StopAsync`。
 
 默认 Proxy 端点为 `localhost:8081`。外部部署必须暴露 RocketMQ 5 Proxy、创建 `eventhorizon-test-topic`，并授予路由查询和
-消费权限；启用重试和死信结果时还需要相应访问权限。可使用标准 .NET 配置覆盖，例如
+消费权限。可使用标准 .NET 配置覆盖，例如
 `RocketMQ__Client__Endpoint=proxy.example:8081`。
 
 完整 API 和投递契约请参阅 [gRPC 协议指南](../../../../src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md)。

--- a/samples/grpc/NonHost/README.md
+++ b/samples/grpc/NonHost/README.md
@@ -15,7 +15,7 @@ same role lifecycle.
 | Sample | Public role | Demonstrated workflow |
 | --- | --- | --- |
 | [Producer](Producer/README.md) | `IGrpcProducer` | Start, send one tagged message, await the receipt, stop. |
-| [SimpleConsumer](SimpleConsumer/README.md) | `IGrpcSimpleConsumer` | Start, long-poll, acknowledge valid messages, dead-letter corrupted messages, stop. |
+| [SimpleConsumer](SimpleConsumer/README.md) | `IGrpcSimpleConsumer` | Start, long-poll, acknowledge valid messages, leave failed messages unsettled, stop. |
 | [PushConsumer](PushConsumer/README.md) | `IGrpcPushConsumer` | Start, dispatch messages to a scoped handler until Ctrl+C, then stop. |
 | [LitePushConsumer](LitePushConsumer/README.md) | `IGrpcLitePushConsumer` | Start, synchronize LiteTopics, dispatch to a scoped handler until Ctrl+C, then stop. |
 

--- a/samples/grpc/NonHost/README.zh-CN.md
+++ b/samples/grpc/NonHost/README.zh-CN.md
@@ -13,7 +13,7 @@ Host 会拥有同一角色的生命周期。
 | 示例 | 公开角色 | 演示的工作流 |
 | --- | --- | --- |
 | [Producer](Producer/README.zh-CN.md) | `IGrpcProducer` | 启动，发送一条带 tag 的消息，等待回执，停止。 |
-| [SimpleConsumer](SimpleConsumer/README.zh-CN.md) | `IGrpcSimpleConsumer` | 启动，长轮询，确认正常消息，将损坏消息转入死信队列，停止。 |
+| [SimpleConsumer](SimpleConsumer/README.zh-CN.md) | `IGrpcSimpleConsumer` | 启动，长轮询，确认正常消息，不结算失败消息，停止。 |
 | [PushConsumer](PushConsumer/README.zh-CN.md) | `IGrpcPushConsumer` | 启动，持续向 scoped handler 分发消息直到 Ctrl+C，再停止。 |
 | [LitePushConsumer](LitePushConsumer/README.zh-CN.md) | `IGrpcLitePushConsumer` | 启动，同步 LiteTopic，持续向 scoped handler 分发消息直到 Ctrl+C，再停止。 |
 

--- a/samples/grpc/NonHost/SimpleConsumer/Program.cs
+++ b/samples/grpc/NonHost/SimpleConsumer/Program.cs
@@ -62,7 +62,7 @@ Console.CancelKeyPress += cancelHandler;
 try
 {
     // BuildServiceProvider does not run the IHostedService registered by AddGrpcSimpleConsumer.
-    // This non-Host process owns the Consumer lifecycle and the Receive/Ack/DLQ loop.
+    // This non-Host process owns the Consumer lifecycle and the Receive/Ack loop.
     await consumer.StartAsync(stoppingSource.Token).ConfigureAwait(false);
     Console.WriteLine("gRPC SimpleConsumer started. Press Ctrl+C to stop.");
 
@@ -92,16 +92,10 @@ try
             {
                 if (message.IsCorrupted)
                 {
-                    // SimpleConsumer never auto-settles: explicitly dead-letter an unsafe payload.
                     logger.LogWarning(
-                        "Forwarding corrupted message {MessageId} to the dead-letter queue: {Reason}",
+                        "Leaving corrupted message {MessageId} unsettled so the service retry policy can handle it: {Reason}",
                         message.MessageId,
                         message.CorruptionReason);
-                    await consumer.ForwardToDeadLetterQueueAsync(
-                            message,
-                            maxDeliveryAttempts: 16,
-                            cancellationToken: stoppingSource.Token)
-                        .ConfigureAwait(false);
                     continue;
                 }
 

--- a/samples/grpc/NonHost/SimpleConsumer/README.md
+++ b/samples/grpc/NonHost/SimpleConsumer/README.md
@@ -4,7 +4,7 @@
 
 This console sample drives gRPC `IGrpcSimpleConsumer` directly without constructing a Generic Host. It builds an
 ordinary `ServiceProvider`, explicitly starts the Consumer, long-polls the Proxy, acknowledges normal messages,
-forwards corrupted messages to the dead-letter queue, explicitly stops the Consumer, and asynchronously disposes the
+leaves corrupted messages unsettled, explicitly stops the Consumer, and asynchronously disposes the
 service provider.
 
 ## When to use this shape
@@ -21,9 +21,9 @@ manual lifecycle calls in this sample are required.
 
 `ReceiveAsync` long-polls a RocketMQ 5 Proxy and returns temporarily invisible `GrpcMessageView` values. It does not
 acknowledge them. The sample logs each valid message and calls `AckAsync`; real applications must acknowledge only
-after the business effect is durable. It checks `IsCorrupted` before reading the body and calls
-`ForwardToDeadLetterQueueAsync` for corrupted payloads. A failed or omitted settlement lets the message become visible
-again after its invisibility window, so processing must be idempotent.
+after the business effect is durable. It checks `IsCorrupted` before reading the body and leaves corrupted payloads
+unsettled. A failed or omitted settlement lets the message become visible again after its invisibility window, so
+processing must be idempotent.
 
 SimpleConsumer is application-driven: the process controls receive batch size, receive concurrency, and settlement.
 Choose `IGrpcPushConsumer` when handler-oriented automatic dispatch and settlement are the better fit.
@@ -43,4 +43,4 @@ already been cancelled. The configured Proxy endpoint can be overridden with nor
 `RocketMQ__Client__Endpoint=proxy.example:8081`.
 
 See the [gRPC protocol guide](../../../../src/EventHorizon.RocketMQ.Grpc/README.md) for live subscription changes,
-invisibility renewal, and the complete SimpleConsumer contract.
+invisibility changes, and the complete SimpleConsumer contract.

--- a/samples/grpc/NonHost/SimpleConsumer/README.zh-CN.md
+++ b/samples/grpc/NonHost/SimpleConsumer/README.zh-CN.md
@@ -3,7 +3,7 @@
 [English](README.md) | [简体中文](README.zh-CN.md)
 
 此控制台示例不构造 Generic Host，而是直接驱动 gRPC `IGrpcSimpleConsumer`。它构建普通 `ServiceProvider`，显式启动
-Consumer，对 Proxy 执行长轮询，确认正常消息，将损坏消息转入死信队列，显式停止 Consumer，并异步释放 service provider。
+Consumer，对 Proxy 执行长轮询，确认正常消息，不结算损坏消息，显式停止 Consumer，并异步释放 service provider。
 
 ## 何时使用这种形式
 
@@ -16,8 +16,8 @@ Consumer，对 Proxy 执行长轮询，确认正常消息，将损坏消息转�
 ## 接收与结算
 
 `ReceiveAsync` 会长轮询 RocketMQ 5 Proxy，返回暂时不可见的 `GrpcMessageView`，但不会确认它们。示例记录每条正常消息后调用
-`AckAsync`；真实应用只能在业务效果已持久化后确认。它会在读取 body 前检查 `IsCorrupted`，并对损坏 payload 调用
-`ForwardToDeadLetterQueueAsync`。结算失败或未结算时，消息会在不可见窗口结束后再次可见，因此处理必须是幂等的。
+`AckAsync`；真实应用只能在业务效果已持久化后确认。它会在读取 body 前检查 `IsCorrupted`，并让损坏 payload 保持
+未结算。结算失败或未结算时，消息会在不可见窗口结束后再次可见，因此处理必须是幂等的。
 
 SimpleConsumer 由应用驱动：进程控制接收批量、接收并发和结算。需要 handler 风格的自动分发和结算时，应选择
 `IGrpcPushConsumer`。
@@ -35,5 +35,5 @@ dotnet run --project samples/grpc/NonHost/SimpleConsumer
 按 Ctrl+C 会取消接收循环。Ctrl+C token 已被取消，因此示例使用未取消的 token 调用 `StopAsync`。可以使用正常 .NET 配置覆盖
 Proxy 端点，例如 `RocketMQ__Client__Endpoint=proxy.example:8081`。
 
-运行时订阅变更、不可见时间续期和完整 SimpleConsumer 契约请参阅
+运行时订阅变更、不可见时间调整和完整 SimpleConsumer 契约请参阅
 [gRPC 协议指南](../../../../src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md)。

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/ConsumeResult.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/ConsumeResult.cs
@@ -26,12 +26,7 @@ public enum ConsumeResult
     Success,
 
     /// <summary>
-    /// Indicates that message processing should be retried.
+    /// Indicates that message processing failed and the effective retry policy should schedule another delivery.
     /// </summary>
-    Retry,
-
-    /// <summary>
-    /// Indicates that the message should be forwarded to the dead-letter queue.
-    /// </summary>
-    DeadLetter
+    Failure
 }

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcConsumerGroupCompatibilityValidator.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcConsumerGroupCompatibilityValidator.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
@@ -323,7 +323,23 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
         }, cancellationToken);
     }
 
-    public Task ChangeInvisibleDurationAsync(GrpcMessageView message, TimeSpan invisibleDuration, CancellationToken cancellationToken)
+    public Task ChangeInvisibleDurationAsync(
+        GrpcMessageView message,
+        TimeSpan invisibleDuration,
+        CancellationToken cancellationToken) =>
+        SetInvisibleDurationAsync(message, invisibleDuration, "renew", cancellationToken);
+
+    public Task ScheduleRetryAsync(
+        GrpcMessageView message,
+        TimeSpan invisibleDuration,
+        CancellationToken cancellationToken) =>
+        SetInvisibleDurationAsync(message, invisibleDuration, "nack", cancellationToken);
+
+    private Task SetInvisibleDurationAsync(
+        GrpcMessageView message,
+        TimeSpan invisibleDuration,
+        string telemetryOperation,
+        CancellationToken cancellationToken)
     {
         var endpoint = ValidateCompletionMessage(message);
         if (invisibleDuration <= TimeSpan.Zero)
@@ -331,7 +347,7 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
             throw new ArgumentOutOfRangeException(nameof(invisibleDuration), "Invisible duration must be positive.");
         }
 
-        return ExecuteCompletionAsync("change invisible duration for", "nack", message, async token =>
+        return ExecuteCompletionAsync("change invisible duration for", telemetryOperation, message, async token =>
         {
             var request = new Proto.ChangeInvisibleDurationRequest
             {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/IGrpcReceiveConsumerEngine.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/IGrpcReceiveConsumerEngine.cs
@@ -52,6 +52,11 @@ internal interface IGrpcReceiveConsumerEngine : IAsyncDisposable
         TimeSpan invisibleDuration,
         CancellationToken cancellationToken);
 
+    Task ScheduleRetryAsync(
+        GrpcMessageView message,
+        TimeSpan invisibleDuration,
+        CancellationToken cancellationToken);
+
     Task ForwardToDeadLetterQueueAsync(
         GrpcMessageView message,
         int maxDeliveryAttempts,

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLiteOffsetOption.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLiteOffsetOption.cs
@@ -15,7 +15,7 @@
 
 using Proto = Apache.Rocketmq.V2;
 
-namespace EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+namespace EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 
 /// <summary>
 /// Selects the initial offset used when a LiteTopic subscription is created.

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLitePushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLitePushConsumer.cs
@@ -15,7 +15,7 @@
 
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 
-namespace EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+namespace EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 
 internal sealed class GrpcLitePushConsumer : IGrpcLitePushConsumer
 {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLitePushConsumerHostedService.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLitePushConsumerHostedService.cs
@@ -15,7 +15,7 @@
 
 using Microsoft.Extensions.Hosting;
 
-namespace EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+namespace EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 
 internal sealed class GrpcLitePushConsumerHostedService(IGrpcLitePushConsumer consumer) : IHostedService
 {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLitePushConsumerOptions.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLitePushConsumerOptions.cs
@@ -15,7 +15,7 @@
 
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 
-namespace EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+namespace EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 
 /// <summary>
 /// Configures a RocketMQ gRPC Lite Push consumer.

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLiteSubscriptionManager.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/GrpcLiteSubscriptionManager.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Proto = Apache.Rocketmq.V2;
 
-namespace EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+namespace EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 
 internal sealed class GrpcLiteSubscriptionManager : IAsyncDisposable
 {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/IGrpcLitePushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/LitePush/IGrpcLitePushConsumer.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+namespace EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 
 /// <summary>
 /// Provides automatic LiteTopic message dispatch through the RocketMQ gRPC Lite Push protocol.

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
@@ -651,18 +651,14 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         var fifoRetryCancellationToken = fifo
             ? Volatile.Read(ref _fifoRetryCts)?.Token ?? CancellationToken.None
             : CancellationToken.None;
-        using var renewalCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        var renewal = RenewInvisibleDurationAsync(message, renewalCts.Token);
-        ConsumeResult result;
-        var fifoRetryStopped = false;
+        HandlerCompletion completion;
         try
         {
-            result = await HandleMessageAsync(
+            completion = await HandleMessageAsync(
                 message,
                 fifo,
                 maxDeliveryAttempts,
                 fifoRetryCancellationToken,
-                renewalCts,
                 cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -671,44 +667,23 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         }
         catch (OperationCanceledException) when (fifo && fifoRetryCancellationToken.IsCancellationRequested)
         {
-            fifoRetryStopped = true;
-            result = ConsumeResult.Retry;
-        }
-        finally
-        {
-            renewalCts.Cancel();
-            try
-            {
-                await renewal.ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-            }
-            catch (Exception exception)
-            {
-                _logger.LogWarning(exception, "Failed to renew invisible duration for message {MessageId}; processing will continue", message.MessageId);
-            }
-        }
-
-        if (fifoRetryStopped)
-        {
             return false;
         }
 
         try
         {
-            if (result == ConsumeResult.Success)
+            if (completion.Result == ConsumeResult.Success)
             {
                 await _engine.AckAsync(message, cancellationToken).ConfigureAwait(false);
             }
-            else if (result == ConsumeResult.DeadLetter || message.DeliveryAttempt >= maxDeliveryAttempts)
+            else if (completion.ForwardToDeadLetterQueue)
             {
                 await _engine.ForwardToDeadLetterQueueAsync(message, maxDeliveryAttempts, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 var retryDelay = _engine.GetRetryDelay(message, _options.RetryDelay);
-                await _engine.ChangeInvisibleDurationAsync(message, retryDelay, cancellationToken).ConfigureAwait(false);
+                await _engine.ScheduleRetryAsync(message, retryDelay, cancellationToken).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -720,7 +695,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             _logger.LogWarning(
                 exception,
                 "Failed to complete {ConsumeResult} processing for message {MessageId}; the message may be redelivered",
-                result,
+                completion.Result,
                 message.MessageId);
             return false;
         }
@@ -750,7 +725,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             }
             else
             {
-                await _engine.ChangeInvisibleDurationAsync(
+                await _engine.ScheduleRetryAsync(
                     message,
                     _engine.GetRetryDelay(message, _options.RetryDelay),
                     cancellationToken).ConfigureAwait(false);
@@ -772,12 +747,11 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         }
     }
 
-    private async ValueTask<ConsumeResult> HandleMessageAsync(
+    private async ValueTask<HandlerCompletion> HandleMessageAsync(
         GrpcMessageView message,
         bool fifo,
         int maxDeliveryAttempts,
         CancellationToken fifoRetryCancellationToken,
-        CancellationTokenSource renewalCts,
         CancellationToken cancellationToken)
     {
         var attempt = Math.Max(1, message.DeliveryAttempt);
@@ -799,7 +773,6 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 {
                     execution = await InvokeConcurrentMessageHandlerAsync(
                         message,
-                        renewalCts,
                         cancellationToken).ConfigureAwait(false);
                 }
 
@@ -822,21 +795,21 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             {
                 CompleteMessageProcessingTelemetry(telemetry, message, exception);
                 _logger.LogError(exception, "Message handler failed for message {MessageId}", message.MessageId);
-                result = ConsumeResult.Retry;
+                result = ConsumeResult.Failure;
             }
             finally
             {
                 DisposeMessageProcessingTelemetry(telemetry, message);
             }
 
-            if (!fifo || result != ConsumeResult.Retry)
+            if (!fifo || result != ConsumeResult.Failure)
             {
-                return result;
+                return new HandlerCompletion(result, false);
             }
 
             if (attempt >= maxDeliveryAttempts)
             {
-                return ConsumeResult.DeadLetter;
+                return new HandlerCompletion(result, true);
             }
 
             var retryDelay = _engine.GetRetryDelay(message, attempt, _options.RetryDelay);
@@ -946,7 +919,6 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
 
     private async ValueTask<HandlerExecution> InvokeConcurrentMessageHandlerAsync(
         GrpcMessageView message,
-        CancellationTokenSource renewalCts,
         CancellationToken cancellationToken)
     {
         var handlerCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -992,12 +964,11 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
 
             _ = ObserveTimedOutMessageHandlerAsync(handlerTask, message.MessageId, activeHandlerCancellation);
             handlerCancellation = null;
-            renewalCts.Cancel();
             _logger.LogWarning(
                 "Message handler for message {MessageId} exceeded consume timeout {ConsumeTimeout}; cancellation was requested and the message will be retried",
                 message.MessageId,
                 _options.ConsumeTimeout);
-            return new HandlerExecution(ConsumeResult.Retry, true);
+            return new HandlerExecution(ConsumeResult.Failure, true);
         }
         finally
         {
@@ -1076,19 +1047,6 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             fifoRetryCancellationToken,
             cancellationToken);
         await Task.Delay(delay, linked.Token).ConfigureAwait(false);
-    }
-
-    private async Task RenewInvisibleDurationAsync(GrpcMessageView message, CancellationToken cancellationToken)
-    {
-        var invisibleDuration = message.InvisibleDuration is { } brokerInvisibleDuration && brokerInvisibleDuration > TimeSpan.Zero
-            ? brokerInvisibleDuration
-            : _options.InvisibleDuration;
-        var delay = TimeSpan.FromTicks(Math.Max(TimeSpan.FromSeconds(1).Ticks, invisibleDuration.Ticks / 2));
-        while (true)
-        {
-            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-            await _engine.ChangeInvisibleDurationAsync(message, invisibleDuration, cancellationToken).ConfigureAwait(false);
-        }
     }
 
     private Channel<GrpcMessageView> CreateMessageChannel() =>
@@ -1255,6 +1213,8 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         int MessageBytes);
 
     private readonly record struct HandlerExecution(ConsumeResult Result, bool TimedOut);
+
+    private readonly record struct HandlerCompletion(ConsumeResult Result, bool ForwardToDeadLetterQueue);
 
     private sealed class ByteCapacityGate
     {

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumerOptions.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumerOptions.cs
@@ -46,8 +46,12 @@ public class GrpcPushConsumerOptions : ConsumerOptions
     public int MaxCachedMessageBytes { get; set; } = 32 * 1024 * 1024;
 
     /// <summary>
-    /// Gets or sets the fallback maximum number of delivery attempts before a message is dead-lettered.
+    /// Gets or sets the fallback maximum number of local FIFO handler attempts before the message is dead-lettered.
     /// </summary>
+    /// <remarks>
+    /// The service owns retry and dead-letter progression for non-FIFO messages. A retry policy supplied by the
+    /// Proxy takes precedence over this fallback.
+    /// </remarks>
     public int MaxDeliveryAttempts { get; set; } = 16;
 
     /// <summary>
@@ -60,8 +64,9 @@ public class GrpcPushConsumerOptions : ConsumerOptions
     /// retry.
     /// </summary>
     /// <remarks>
-    /// When this timeout expires, the consumer cancels the handler token, stops client-side invisibility renewal,
-    /// and requests redelivery. A handler that does not observe cancellation cannot be forcibly stopped, and a late
+    /// When this timeout expires, the consumer cancels the handler token and requests redelivery. Receipt renewal is
+    /// owned by a compatible Proxy because Push receive requests set <c>AutoRenew=true</c>; the client does not run a
+    /// second renewal timer. A handler that does not observe cancellation cannot be forcibly stopped, and a late
     /// successful result is ignored. FIFO message groups are excluded so that their ordering is not broken.
     /// </remarks>
     public TimeSpan ConsumeTimeout { get; set; } = TimeSpan.FromMinutes(15);

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Simple/GrpcSimpleConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Simple/GrpcSimpleConsumer.cs
@@ -109,17 +109,6 @@ internal sealed class GrpcSimpleConsumer : IGrpcSimpleConsumer
         return _engine.ChangeInvisibleDurationAsync(message, invisibleDuration, cancellationToken);
     }
 
-    public Task ForwardToDeadLetterQueueAsync(GrpcMessageView message, int maxDeliveryAttempts, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(message);
-        if (maxDeliveryAttempts <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxDeliveryAttempts), "Maximum delivery attempts must be positive.");
-        }
-
-        return _engine.ForwardToDeadLetterQueueAsync(message, maxDeliveryAttempts, cancellationToken);
-    }
-
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Simple/IGrpcSimpleConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Simple/IGrpcSimpleConsumer.cs
@@ -92,12 +92,4 @@ public interface IGrpcSimpleConsumer : IAsyncDisposable
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task ChangeInvisibleDurationAsync(GrpcMessageView message, TimeSpan invisibleDuration, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Forwards a received message to the consumer group's dead-letter queue.
-    /// </summary>
-    /// <param name="message">The message to forward.</param>
-    /// <param name="maxDeliveryAttempts">The positive maximum delivery-attempt threshold.</param>
-    /// <param name="cancellationToken">A token that cancels the operation.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task ForwardToDeadLetterQueueAsync(GrpcMessageView message, int maxDeliveryAttempts, CancellationToken cancellationToken = default);
 }

--- a/src/EventHorizon.RocketMQ.Grpc/GrpcRocketMQBuilderExtensions.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/GrpcRocketMQBuilderExtensions.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 using EventHorizon.RocketMQ.Grpc.Consumer;
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using EventHorizon.RocketMQ.Grpc.Consumer.Simple;
 using EventHorizon.RocketMQ.Grpc.Producer;

--- a/src/EventHorizon.RocketMQ.Grpc/README.md
+++ b/src/EventHorizon.RocketMQ.Grpc/README.md
@@ -41,8 +41,8 @@ Register one client with `AddRocketMQGrpc`, then add one or more roles to the re
 | Priority messages | `Message.Priority` | The destination must support priority messages. |
 | Lite messages | `Message.LiteTopic` | Requires compatible Proxy and Broker support. |
 | Transactional messages | `IGrpcProducer.SendTransactionAsync` | Declare transactional topics and configure a transaction checker before startup. |
-| Explicit receive and settlement | `IGrpcSimpleConsumer` | The application calls `ReceiveAsync`, `AckAsync`, invisibility, and dead-letter APIs. |
-| Automatic dispatch | `IGrpcPushConsumer` | Typed handlers return `Success`, `Retry`, or `DeadLetter`. |
+| Explicit receive and settlement | `IGrpcSimpleConsumer` | The application calls `ReceiveAsync`, `AckAsync`, and invisibility APIs. |
+| Automatic dispatch | `IGrpcPushConsumer` | Typed handlers return `Success` or `Failure`. |
 | Lite automatic dispatch | `IGrpcLitePushConsumer` | Dispatches LiteTopics under one configured bind topic. |
 | Tag and SQL filters | `FilterExpression` | SQL filtering requires matching server configuration. |
 | Runtime subscriptions | `SubscribeAsync` / `UnsubscribeAsync` and Lite equivalents | Supported by the applicable Consumer role. |
@@ -189,16 +189,17 @@ public sealed class OrderReceiver(IGrpcSimpleConsumer consumer)
 ```
 
 Call `SubscribeAsync` or `UnsubscribeAsync` to change subscriptions after startup. `ReceiveAsync` does not acknowledge
-messages and does not enable automatic renewal; acknowledge only after durable processing, extend invisibility for
-long-running work, or call
-`ForwardToDeadLetterQueueAsync` when the application chooses to dead-letter a message. RocketMQ 5.5.0 Proxy requires a
-five-second minimum receive long-poll interval.
+messages and does not enable automatic renewal; acknowledge only after durable processing and extend invisibility for
+long-running work. An unsettled message becomes visible again after its current invisible duration. RocketMQ 5.5.0
+Proxy requires a five-second minimum receive long-poll interval.
 
 ## PushConsumer
 
 Use `IGrpcPushConsumer` for automatic receive, handler dispatch, and settlement. Register a typed
 `IGrpcPushMessageHandler`; `Scoped` is appropriate when the handler uses scoped application services.
-Push also manages message invisibility while the handler is active; applications do not renew receipts themselves.
+Push requests Proxy-managed message invisibility while the handler is active; applications do not renew receipts
+themselves. The target Proxy must support and enable automatic renewal (`enableProxyAutoRenew`, enabled by default in
+compatible RocketMQ 5 Proxy releases).
 
 ```csharp
 using System.Text;
@@ -225,8 +226,8 @@ public sealed class OrderHandler : IGrpcPushMessageHandler
 }
 ```
 
-Return `ConsumeResult.Success` to acknowledge, `Retry` for redelivery, or `DeadLetter` to forward to the consumer
-group's dead-letter queue. Handlers should be idempotent because retries and duplicate delivery are possible.
+Return `ConsumeResult.Success` to acknowledge or `Failure` to let the effective retry policy schedule another
+delivery. Handlers should be idempotent because retries and duplicate delivery are possible.
 `SubscribeAsync` and `UnsubscribeAsync` update ordinary Push subscriptions at runtime.
 
 ## LitePushConsumer
@@ -234,7 +235,7 @@ group's dead-letter queue. Handlers should be idempotent because retries and dup
 Use `IGrpcLitePushConsumer` for automatic dispatch from LiteTopics under one LITE parent (bind) topic:
 
 ```csharp
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md
+++ b/src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md
@@ -38,8 +38,8 @@ using RemotingMessage = EventHorizon.RocketMQ.Remoting.Producer.Message;
 | 优先级消息 | `Message.Priority` | 目标端必须支持优先级消息。 |
 | Lite 消息 | `Message.LiteTopic` | 需要 Proxy 和 Broker 提供兼容支持。 |
 | 事务消息 | `IGrpcProducer.SendTransactionAsync` | 在启动前声明事务 topic，并配置事务检查器。 |
-| 显式接收和结算 | `IGrpcSimpleConsumer` | 应用调用 `ReceiveAsync`、`AckAsync`、不可见时间和死信 API。 |
-| 自动分发 | `IGrpcPushConsumer` | typed handler 返回 `Success`、`Retry` 或 `DeadLetter`。 |
+| 显式接收和结算 | `IGrpcSimpleConsumer` | 应用调用 `ReceiveAsync`、`AckAsync` 和不可见时间 API。 |
+| 自动分发 | `IGrpcPushConsumer` | typed handler 返回 `Success` 或 `Failure`。 |
 | Lite 自动分发 | `IGrpcLitePushConsumer` | 在一个已配置的 bind topic 下分发 `LiteTopics`。 |
 | Tag 和 SQL 过滤器 | `FilterExpression` | SQL 过滤需要匹配的服务端配置。 |
 | 运行时订阅 | `SubscribeAsync` / `UnsubscribeAsync` 及 Lite 等效 API | 由适用的 Consumer 角色支持。 |
@@ -178,14 +178,15 @@ public sealed class OrderReceiver(IGrpcSimpleConsumer consumer)
 ```
 
 调用 `SubscribeAsync` 或 `UnsubscribeAsync` 可在启动后修改订阅。`ReceiveAsync` 既不会确认消息，也不会启用自动续约；
-只有在消息完成持久化处理后才确认。对于长时间运行的处理，需要显式延长不可见时间；应用决定将消息转入死信时，
-调用 `ForwardToDeadLetterQueueAsync`。RocketMQ 5.5.0 Proxy 要求接收长轮询间隔至少为五秒。
+只有在消息完成持久化处理后才确认。对于长时间运行的处理，需要显式延长不可见时间。消息未结算时，会在当前
+不可见时间结束后重新可见。RocketMQ 5.5.0 Proxy 要求接收长轮询间隔至少为五秒。
 
 ## PushConsumer
 
 需要自动接收、分发和结算时，请使用 `IGrpcPushConsumer`。注册 typed
 `IGrpcPushMessageHandler`；如果 handler 使用 scoped 应用服务，适合选择 `Scoped`。
-Push 还会在 handler 执行期间管理消息的不可见时间，应用无需自行续租 receipt。
+Push 会请求 Proxy 在 handler 执行期间托管消息的不可见时间，应用无需自行续租 receipt。目标 Proxy 必须支持并启用
+自动续期；兼容的 RocketMQ 5 Proxy 默认开启 `enableProxyAutoRenew`。
 
 ```csharp
 using System.Text;
@@ -212,16 +213,15 @@ public sealed class OrderHandler : IGrpcPushMessageHandler
 }
 ```
 
-返回 `ConsumeResult.Success` 表示确认消息，返回 `Retry` 请求重新投递，返回 `DeadLetter` 将消息转入消费组的
-死信队列。由于可能发生重试和重复投递，handler 应保持幂等。`SubscribeAsync` 和 `UnsubscribeAsync` 可在运行时
-更新普通 Push 订阅。
+返回 `ConsumeResult.Success` 表示确认消息；返回 `Failure` 后，由当前生效的重试策略安排再次投递。由于可能发生
+重试和重复投递，handler 应保持幂等。`SubscribeAsync` 和 `UnsubscribeAsync` 可在运行时更新普通 Push 订阅。
 
 ## LitePushConsumer
 
 需要从一个 LITE parent（bind）topic 下的 LiteTopic 自动分发消息时，请使用 `IGrpcLitePushConsumer`：
 
 ```csharp
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
@@ -29,12 +29,15 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GrpcPushConsumer_DeadLetterQueue_ForwardsMessage()
+    public async Task GrpcPushConsumer_FifoFailureExhaustsRetries_ForwardsToDeadLetterQueue()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var fixture = await registry.GetFixtureAsync(cancellationToken);
-        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
-        var consumerGroup = scope.CreateConsumerGroupName("grpc-push-dlq-consumer");
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Fifo, cancellationToken);
+        var consumerGroup = await scope.CreateConsumerGroupAsync(
+            "grpc-push-dlq-consumer",
+            retryMaxTimes: 1,
+            cancellationToken);
         var handled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var expected = $"grpc-dlq-{Guid.NewGuid():N}";
         var services = new ServiceCollection();
@@ -45,6 +48,8 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
             .AddGrpcPushConsumer<DeadLetterMessageHandler>(ServiceLifetime.Singleton, options =>
             {
                 options.GroupName = consumerGroup;
+                options.MaxDeliveryAttempts = 2;
+                options.RetryDelay = TimeSpan.FromMilliseconds(100);
                 options.Subscribe(scope.Topic, new FilterExpression("grpc-dlq"));
             });
 
@@ -59,7 +64,8 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
                 scope.Topic,
                 Encoding.UTF8.GetBytes(expected))
             {
-                Tag = "grpc-dlq"
+                Tag = "grpc-dlq",
+                MessageGroup = $"grpc-dlq-{Guid.NewGuid():N}"
             }, cancellationToken);
             await handled.Task.WaitAsync(TimeSpan.FromSeconds(20), cancellationToken);
 
@@ -115,7 +121,7 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
             if (Encoding.UTF8.GetString(message.Body) == observation.ExpectedBody)
             {
                 observation.Handled.TrySetResult();
-                return ValueTask.FromResult(ConsumeResult.DeadLetter);
+                return ValueTask.FromResult(ConsumeResult.Failure);
             }
 
             return ValueTask.FromResult(ConsumeResult.Success);

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
@@ -15,7 +15,7 @@
 
 using System.Text;
 using EventHorizon.RocketMQ.Grpc.Consumer;
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using EventHorizon.RocketMQ.Grpc.Producer;
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using System.Text;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
@@ -283,7 +284,7 @@ public sealed class RocketMQSingleBrokerContainerFixture : IAsyncLifetime
                      "legacy-push-cluster-it"
                  })
         {
-            await CreateConsumerGroupAsync(group, null, CancellationToken.None).ConfigureAwait(false);
+            await CreateConsumerGroupAsync(group, null, null, CancellationToken.None).ConfigureAwait(false);
         }
     }
 
@@ -305,6 +306,7 @@ public sealed class RocketMQSingleBrokerContainerFixture : IAsyncLifetime
     internal async Task CreateConsumerGroupAsync(
         string group,
         string? liteParentTopic,
+        int? retryMaxTimes,
         CancellationToken cancellationToken)
     {
         await _administrationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -321,6 +323,12 @@ public sealed class RocketMQSingleBrokerContainerFixture : IAsyncLifetime
             {
                 createGroupCommand.Add("--attributes");
                 createGroupCommand.Add($"+lite.bind.topic={liteParentTopic}");
+            }
+
+            if (retryMaxTimes is not null)
+            {
+                createGroupCommand.Add("--retryMaxTimes");
+                createGroupCommand.Add(retryMaxTimes.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             var createGroup = await _broker.ExecAsync(createGroupCommand, cancellationToken).ConfigureAwait(false);

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
@@ -60,6 +60,24 @@ public sealed class RocketMQTestScope
     }
 
     /// <summary>
+    /// Creates an isolated consumer group with a configured maximum retry count.
+    /// </summary>
+    /// <param name="role">The role label included in the group name.</param>
+    /// <param name="retryMaxTimes">The non-negative maximum number of consumption retries.</param>
+    /// <param name="cancellationToken">The token used to cancel the Broker administration request.</param>
+    /// <returns>The created consumer group name.</returns>
+    public async Task<string> CreateConsumerGroupAsync(
+        string role,
+        int retryMaxTimes,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(retryMaxTimes);
+        var group = CreateGroupName(role);
+        await _fixture.CreateConsumerGroupAsync(group, null, retryMaxTimes, cancellationToken).ConfigureAwait(false);
+        return group;
+    }
+
+    /// <summary>
     /// Creates and configures an isolated LitePush consumer group bound to this scope's parent topic.
     /// </summary>
     /// <param name="role">The role label included in the group name.</param>
@@ -68,7 +86,7 @@ public sealed class RocketMQTestScope
     public async Task<string> CreateLiteConsumerGroupAsync(string role, CancellationToken cancellationToken = default)
     {
         var group = CreateGroupName(role);
-        await _fixture.CreateConsumerGroupAsync(group, Topic, cancellationToken).ConfigureAwait(false);
+        await _fixture.CreateConsumerGroupAsync(group, Topic, null, cancellationToken).ConfigureAwait(false);
         return group;
     }
 

--- a/tests/ut/EventHorizon.RocketMQ.Compatibility.Tests/ProtocolModelParityTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Compatibility.Tests/ProtocolModelParityTests.cs
@@ -34,10 +34,16 @@ public sealed class ProtocolModelParityTests
     public void ProtocolNeutralModelCopies_PublicApiParity_Matches()
     {
         AssertEquivalentPublicApi(typeof(GrpcMessage), typeof(RemotingMessage));
-        AssertEquivalentPublicApi(typeof(GrpcConsumeResult), typeof(RemotingConsumeResult));
         AssertEquivalentPublicApi(typeof(GrpcFilterExpression), typeof(RemotingFilterExpression));
         AssertEquivalentPublicApi(typeof(GrpcFilterExpressionType), typeof(RemotingFilterExpressionType));
         AssertEquivalentPublicApi(typeof(GrpcRocketMQClientException), typeof(RemotingRocketMQClientException));
+    }
+
+    [Fact]
+    public void ConsumeResults_ProtocolSpecificSemantics_ExposeExpectedOutcomes()
+    {
+        Assert.Equal(["Success", "Failure"], Enum.GetNames<GrpcConsumeResult>());
+        Assert.Equal(["Success", "Retry", "DeadLetter"], Enum.GetNames<RemotingConsumeResult>());
     }
 
     [Theory]

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/LitePush/GrpcLitePushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/LitePush/GrpcLitePushConsumerTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 using EventHorizon.RocketMQ.Grpc.Consumer;
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using EventHorizon.RocketMQ.Grpc.Exceptions;
 using EventHorizon.RocketMQ.Grpc.Protocol;
@@ -28,7 +28,7 @@ using Moq;
 using Xunit;
 using Proto = Apache.Rocketmq.V2;
 
-namespace EventHorizon.RocketMQ.Grpc.Tests.Consumer.Lite;
+namespace EventHorizon.RocketMQ.Grpc.Tests.Consumer.LitePush;
 
 public sealed class GrpcLitePushConsumerTests
 {

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
@@ -119,7 +119,7 @@ public sealed class GrpcPushConsumerTests
                 {
                     if (Interlocked.Increment(ref firstCalls) == 1)
                     {
-                        return ConsumeResult.Retry;
+                        return ConsumeResult.Failure;
                     }
 
                     firstSecondAttempt.TrySetResult();
@@ -180,7 +180,7 @@ public sealed class GrpcPushConsumerTests
             {
                 processingOrder.Enqueue($"{message.MessageId}:{message.DeliveryAttempt}");
                 return ValueTask.FromResult(
-                    message.MessageId == "first" ? ConsumeResult.Retry : ConsumeResult.Success);
+                    message.MessageId == "first" ? ConsumeResult.Failure : ConsumeResult.Success);
             },
             out var engine,
             options =>
@@ -646,7 +646,7 @@ public sealed class GrpcPushConsumerTests
                 if (message.MessageId == "first")
                 {
                     firstHandled.TrySetResult();
-                    return ValueTask.FromResult(ConsumeResult.Retry);
+                    return ValueTask.FromResult(ConsumeResult.Failure);
                 }
 
                 secondHandled.TrySetResult();
@@ -1029,7 +1029,7 @@ public sealed class GrpcPushConsumerTests
     }
 
     [Fact]
-    public async Task ConsumeLoop_ChangeInvisibleAfterTransientFailure_RetriesAndContinues()
+    public async Task ConsumeLoop_RetrySchedulingAfterTransientFailure_RetriesAndContinues()
     {
         var client = new FakeGrpcClient();
         var calls = 0;
@@ -1040,7 +1040,7 @@ public sealed class GrpcPushConsumerTests
         await using var consumer = CreateConsumer(client, (_, _) =>
         {
             Interlocked.Increment(ref handlerCalls);
-            return ValueTask.FromResult(ConsumeResult.Retry);
+            return ValueTask.FromResult(ConsumeResult.Failure);
         }, out var engine);
 
         await RunConsumeLoopAsync(
@@ -1058,10 +1058,10 @@ public sealed class GrpcPushConsumerTests
     }
 
     [Fact]
-    public async Task ConsumeLoop_RetryResult_RecordsFailedProcessTelemetry()
+    public async Task ConsumeLoop_FailureResult_RecordsFailedProcessTelemetry()
     {
         var operation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
-        operation.Setup(value => value.Complete(false, ConsumeResult.Retry.ToString()));
+        operation.Setup(value => value.Complete(false, ConsumeResult.Failure.ToString()));
         operation.Setup(value => value.Dispose());
         var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
         telemetry
@@ -1077,7 +1077,7 @@ public sealed class GrpcPushConsumerTests
         var client = new FakeGrpcClient();
         await using var consumer = CreateConsumer(
             client,
-            static (_, _) => ValueTask.FromResult(ConsumeResult.Retry),
+            static (_, _) => ValueTask.FromResult(ConsumeResult.Failure),
             out var engine,
             telemetry: telemetry.Object);
 
@@ -1087,61 +1087,40 @@ public sealed class GrpcPushConsumerTests
             TestContext.Current.CancellationToken,
             Message("message-1"));
 
-        operation.Verify(value => value.Complete(false, ConsumeResult.Retry.ToString()), Times.Once);
+        operation.Verify(value => value.Complete(false, ConsumeResult.Failure.ToString()), Times.Once);
         operation.Verify(value => value.Dispose(), Times.Once);
         telemetry.VerifyAll();
     }
 
     [Fact]
-    public async Task ConsumeLoop_DeadLetterAfterTransientFailure_RetriesAndContinues()
+    public async Task ConsumeLoop_FailureAtMaximumDeliveryAttempts_SchedulesRetryWithoutClientDeadLetter()
     {
         var client = new FakeGrpcClient();
-        var calls = 0;
-        client.DeadLetterHandler = _ => Interlocked.Increment(ref calls) == 1
-            ? Task.FromException<Proto.ForwardMessageToDeadLetterQueueResponse>(new IOException("dead letter failed"))
-            : Task.FromResult(DeadLetterSuccess());
         await using var consumer = CreateConsumer(
             client,
-            static (_, _) => ValueTask.FromResult(ConsumeResult.DeadLetter),
-            out var engine);
+            static (_, _) => ValueTask.FromResult(ConsumeResult.Failure),
+            out var engine,
+            options => options.MaxDeliveryAttempts = 3);
 
         await RunConsumeLoopAsync(
             consumer,
             engine,
             TestContext.Current.CancellationToken,
-            Message("first"),
-            Message("second"));
+            Message("first", deliveryAttempt: 3));
 
-        Assert.Equal(3, calls);
+        Assert.Single(client.ChangeInvisibleRequests);
+        Assert.Empty(client.DeadLetterRequests);
     }
 
     [Fact]
-    public async Task ConsumeLoop_RenewalFailure_AcknowledgesAndContinues()
+    public async Task ConsumeLoop_HandlerExceedsHalfLease_DoesNotRenewFromClient()
     {
-        var renewalAttempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var client = new FakeGrpcClient
-        {
-            ChangeInvisibleHandler = _ =>
-            {
-                renewalAttempted.TrySetResult();
-                return Task.FromException<Proto.ChangeInvisibleDurationResponse>(new IOException("renewal failed"));
-            }
-        };
-        var ackCalls = 0;
-        client.AckHandler = _ =>
-        {
-            Interlocked.Increment(ref ackCalls);
-            return Task.FromResult(AckSuccess());
-        };
+        var client = new FakeGrpcClient();
         await using var consumer = CreateConsumer(
             client,
-            async (message, cancellationToken) =>
+            async (_, cancellationToken) =>
             {
-                if (message.MessageId == "first")
-                {
-                    await renewalAttempted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
-                }
-
+                await Task.Delay(TimeSpan.FromMilliseconds(1250), cancellationToken);
                 return ConsumeResult.Success;
             },
             out var engine,
@@ -1151,10 +1130,10 @@ public sealed class GrpcPushConsumerTests
             consumer,
             engine,
             TestContext.Current.CancellationToken,
-            Message("first"),
-            Message("second"));
+            Message("message-1"));
 
-        Assert.Equal(2, ackCalls);
+        Assert.Single(client.AckRequests);
+        Assert.Empty(client.ChangeInvisibleRequests);
     }
 
     [Fact]
@@ -1222,6 +1201,7 @@ public sealed class GrpcPushConsumerTests
         Assert.Equal(7, request.BatchSize);
         Assert.Equal(TimeSpan.FromSeconds(6), request.LongPollingTimeout.ToTimeSpan());
         Assert.True(request.HasAttemptId);
+        Assert.True(request.AutoRenew);
         Assert.Equal(TimeSpan.FromSeconds(9), client.LastReceiveTimeout);
         Assert.Equal(TimeSpan.FromSeconds(15), Assert.Single(client.OpenSettings).Subscription.LongPollingTimeout.ToTimeSpan());
         var message = Assert.Single(messages);
@@ -1258,6 +1238,66 @@ public sealed class GrpcPushConsumerTests
         Assert.Equal("lite-orders", Assert.Single(client.DeadLetterRequests).LiteTopic);
         Assert.Equal("receipt-updated", message.ReceiptHandle);
         Assert.Equal(TimeSpan.FromSeconds(12), message.InvisibleDuration);
+    }
+
+    [Fact]
+    public async Task ChangeInvisibleDurationAsync_ExplicitLeaseExtension_RecordsRenewSettlement()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var operation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete());
+        operation.Setup(value => value.Dispose());
+        var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartSettle(
+                "renew",
+                "orders",
+                "tests",
+                "message-1",
+                0,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Returns(operation.Object);
+        var client = new FakeGrpcClient();
+        var message = Message("message-1");
+        await using var engine = CreateEngine(client, telemetry.Object);
+        engine.BindMessage(message);
+
+        await engine.ChangeInvisibleDurationAsync(message, TimeSpan.FromSeconds(12), cancellationToken);
+
+        Assert.Single(client.ChangeInvisibleRequests);
+        operation.Verify(value => value.Complete(), Times.Once);
+        operation.Verify(value => value.Dispose(), Times.Once);
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ScheduleRetryAsync_RetryScheduling_RecordsNackSettlementAndChangesInvisibility()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var operation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete());
+        operation.Setup(value => value.Dispose());
+        var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartSettle(
+                "nack",
+                "orders",
+                "tests",
+                "message-1",
+                0,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Returns(operation.Object);
+        var client = new FakeGrpcClient();
+        var message = Message("message-1");
+        await using var engine = CreateEngine(client, telemetry.Object);
+        engine.BindMessage(message);
+
+        await engine.ScheduleRetryAsync(message, TimeSpan.FromSeconds(12), cancellationToken);
+
+        Assert.Single(client.ChangeInvisibleRequests);
+        operation.Verify(value => value.Complete(), Times.Once);
+        operation.Verify(value => value.Dispose(), Times.Once);
+        telemetry.VerifyAll();
     }
 
     [Fact]
@@ -1436,7 +1476,9 @@ public sealed class GrpcPushConsumerTests
             telemetry: telemetry);
     }
 
-    private static GrpcReceiveConsumerEngine CreateEngine(FakeGrpcClient client)
+    private static GrpcReceiveConsumerEngine CreateEngine(
+        FakeGrpcClient client,
+        IGrpcRocketMQTelemetry? telemetry = null)
     {
         var options = PushOptions();
         return new GrpcReceiveConsumerEngine(
@@ -1448,7 +1490,8 @@ public sealed class GrpcPushConsumerTests
             Proto.ClientType.PushConsumer,
             options.LongPollingTimeout,
             NullLogger<GrpcReceiveConsumerEngine>.Instance,
-            NullLogger<GrpcSessionManager>.Instance);
+            NullLogger<GrpcSessionManager>.Instance,
+            telemetry: telemetry);
     }
 
     private static IGrpcRouteService CreateRouteService(Proto.MessageQueue queue)

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushMessageHandlerFactoryTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushMessageHandlerFactoryTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 using EventHorizon.RocketMQ.Grpc.Consumer;
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Simple/GrpcSimpleConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Simple/GrpcSimpleConsumerTests.cs
@@ -118,8 +118,6 @@ public sealed class GrpcSimpleConsumerTests
                 TimeSpan.FromSeconds(20),
                 cancellationToken))
             .Returns(Task.CompletedTask);
-        engine.Setup(value => value.ForwardToDeadLetterQueueAsync(message, 5, cancellationToken))
-            .Returns(Task.CompletedTask);
         engine.Setup(value => value.DisposeAsync()).Returns(ValueTask.CompletedTask);
         var consumer = new GrpcSimpleConsumer(
             Options.Create(new GrpcSimpleConsumerOptions()),
@@ -130,14 +128,8 @@ public sealed class GrpcSimpleConsumerTests
             () => consumer.ChangeInvisibleDurationAsync(null!, TimeSpan.FromSeconds(1), cancellationToken));
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
             () => consumer.ChangeInvisibleDurationAsync(message, TimeSpan.Zero, cancellationToken));
-        await Assert.ThrowsAsync<ArgumentNullException>(
-            () => consumer.ForwardToDeadLetterQueueAsync(null!, 1, cancellationToken));
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-            () => consumer.ForwardToDeadLetterQueueAsync(message, 0, cancellationToken));
-
         await consumer.AckAsync(message, cancellationToken);
         await consumer.ChangeInvisibleDurationAsync(message, TimeSpan.FromSeconds(20), cancellationToken);
-        await consumer.ForwardToDeadLetterQueueAsync(message, 5, cancellationToken);
         await consumer.DisposeAsync();
         engine.VerifyAll();
         engine.VerifyNoOtherCalls();

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/DependencyInjectionTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/DependencyInjectionTests.cs
@@ -15,7 +15,7 @@
 
 using System.Reflection;
 using EventHorizon.RocketMQ.Grpc.Consumer;
-using EventHorizon.RocketMQ.Grpc.Consumer.Lite;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using EventHorizon.RocketMQ.Grpc.Consumer.Simple;
 using EventHorizon.RocketMQ.Grpc.Instrumentation;


### PR DESCRIPTION
## Summary

- align Push and LitePush receipt renewal ownership with the Apache Java gRPC client by relying on Proxy `AutoRenew` and separating `renew` from `nack` telemetry
- align public consumption outcomes to `Success` / `Failure`, remove the SimpleConsumer dead-letter API, and keep FIFO dead-letter forwarding internal
- rename the gRPC `Consumer.Lite` namespace and source/test folders to `Consumer.LitePush`
- synchronize bilingual design notes, package guides, samples, unit tests, compatibility tests, and live FIFO/LitePush coverage

## Breaking changes

- `EventHorizon.RocketMQ.Grpc.Consumer.Lite` moves to `.Consumer.LitePush`
- `ConsumeResult.Retry` becomes `ConsumeResult.Failure`
- `ConsumeResult.DeadLetter` is removed
- `IGrpcSimpleConsumer.ForwardToDeadLetterQueueAsync` is removed

## Validation

- `dotnet format EventHorizon.RocketMQ.slnx`
- `dotnet build EventHorizon.RocketMQ.slnx --no-restore`
- gRPC unit tests: 206 passed
- Remoting unit tests: 592 passed
- compatibility tests: 27 passed
- focused gRPC FIFO dead-letter and LitePush IT: 3 passed
- complete gRPC single-Broker IT: 13 passed