### PR TITLE
fix(remoting)!: align POP dead-letter behavior with Java

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,19 @@ protocol-owned tracing and metrics together with the behavior and tests. A featu
 corresponding telemetry success, empty-result, cancellation, and failure semantics are missing.
 
 - When an implementation requires a behavioral or design decision, first consult the corresponding official
-  Apache RocketMQ Java and Go client implementations. Use their semantics and underlying approach as a reference,
-  adapting it to this client's architecture and .NET runtime rather than copying implementation details wholesale.
-  Preserve established protocol semantics unless a documented protocol-specific reason requires this client to differ.
+  Apache RocketMQ Java and Go client implementations. Treat the official Java client as the primary behavioral and
+  design reference; use the official Go client as a secondary cross-check for corroboration, protocol-specific insight,
+  and unresolved differences. When their released behavior differs, follow Java by default unless a documented
+  protocol-specific reason requires this client to follow Go or intentionally differ from both. Adapt the selected
+  approach to this client's architecture and .NET runtime rather than copying implementation details wholesale.
+  Use only versions published as official, non-draft, non-prerelease releases: confirm the relevant Java and Go
+  versions from each official repository's release metadata, then inspect the source through the matching repository
+  tags. Do not use `main`, `master`, an arbitrary commit, or an untagged fix as the behavioral source of truth. Such
+  unreleased code may be inspected only to identify a future change or known gap, and must be described explicitly as
+  unreleased rather than implemented as current official behavior. Record the exact release tags in code comments,
+  documentation, tests, or issues whenever the upstream comparison is material to the decision. Issues that track
+  unresolved upstream differences must identify the released Java baseline first, then the released Go comparison,
+  and must keep prerelease or unreleased observations in a clearly separate, non-normative section.
 
 ## Architecture constraints
 

--- a/docs/en-US/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/en-US/architecture/dependency-injection-and-lifetimes.md
@@ -194,7 +194,8 @@ invoke their `IGrpcPushMessageHandler` for each message. Remoting Push invokes i
 `ConsumeMessageBatchSize` defaults to `1`, so existing settings retain singleton delivery unless configured
 otherwise. For a concurrent non-FIFO batch, a handler can return `Success` with `AckIndex` set to confirm a
 contiguous prefix and retry its tail; `Retry` remains a whole-batch outcome. A negative
-`DelayLevelWhenNextConsume` requests direct dead-lettering within that retry outcome.
+`DelayLevelWhenNextConsume` requests direct dead-lettering only on the internal PULL path; POP normalizes it to the
+default retry level.
 
 For non-FIFO gRPC Push and LitePush messages, `ConsumeTimeout` cancels the handler token and requests retry when the
 configured limit elapses. Receipt renewal while the handler is active belongs to the Proxy requested by `AutoRenew`,
@@ -207,9 +208,9 @@ For concurrent clustered non-FIFO Remoting batches, `ConsumeTimeout` cancels the
 redelivery when the configured limit elapses. For POP delivery, the receipt is not renewed while the handler is active;
 the fixed invisible deadline is checked before handler processing and again before settlement. An expired result is
 ignored without settlement. A `Retry` outcome makes one `CHANGE_MESSAGE_INVISIBLETIME` request with `suspend=false`;
-an indeterminate failure is not retried with the old receipt. ACK, including the ACK after dead-letter forwarding, is
-retried only while the original deadline remains valid. A late result is ignored and can overlap redelivery, so the
-handler still owns cancellation cooperation and must be idempotent; the runtime cannot forcibly stop application code.
+an indeterminate failure is not retried with the old receipt. ACK is retried only while the original deadline remains
+valid. A late result is ignored and can overlap redelivery, so the handler still owns cancellation cooperation and
+must be idempotent; the runtime cannot forcibly stop application code.
 FIFO and orderly delivery remain excluded to preserve ordering guarantees.
 
 ## Trade-offs and Constraints

--- a/docs/en-US/architecture/opentelemetry-instrumentation.md
+++ b/docs/en-US/architecture/opentelemetry-instrumentation.md
@@ -103,11 +103,11 @@ a responsibility between internal types must not duplicate or drop its Activity 
 POP settlement telemetry records each actual wire operation independently: `ack` for acknowledgement and `nack` for
 the one-shot retry/defer `CHANGE_MESSAGE_INVISIBLETIME`. A normal `Retry` at the delivery-attempt limit remains `nack`
 while the Java-compatible message-age guard selects another delay, then becomes `ack` after the terminal age threshold;
-it never creates a `reject` operation. Explicit dead-letter forwarding requested by `Retry` with a negative delay and
-its follow-up ACK remain separate operations.
+The .NET adapter normalizes a negative handler delay to level `0` before POP scheduling, so POP retry remains on this
+ordinary invisibility-change path.
 A handler result that arrives after the fixed invisible deadline creates no settlement operation. An indeterminate
-`nack` failure is not retried with the old receipt; acknowledgement and the ACK after explicit dead-letter forwarding
-are retried only while the original deadline remains valid.
+`nack` failure is not retried with the old receipt; acknowledgement is retried only while the original deadline remains
+valid.
 
 Activities use OpenTelemetry messaging semantic-convention attributes such as `messaging.system`,
 `messaging.destination.name`, `messaging.consumer.group.name`, message ID, partition ID, body size, and batch size.

--- a/docs/en-US/architecture/protocol-boundaries.md
+++ b/docs/en-US/architecture/protocol-boundaries.md
@@ -63,10 +63,11 @@ owns non-FIFO retry and dead-letter progression, while FIFO dead-letter forwardi
 Classic Remoting follows the concurrent callback model shared by the
 [Java client](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyStatus.java)
 and the
-[Go client](https://github.com/apache/rocketmq-client-go/blob/99c433634e09f72fa2778ca04411de29d4fc9cff/consumer/consumer.go#L197-L205):
-it exposes `Success` and `Retry`, while a negative `RemotingPushConsumeContext.DelayLevelWhenNextConsume` requests
-direct dead-lettering. Compatibility tests lock each protocol's independently owned enum even though both currently
-contain two members with protocol-specific failure names.
+[Go client](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/consumer.go#L197-L205):
+it exposes `Success` and `Retry`. A negative `RemotingPushConsumeContext.DelayLevelWhenNextConsume` requests direct
+dead-lettering only on the internal PULL path; POP normalizes it to the default retry level. Compatibility tests lock
+each protocol's independently owned enum even though both currently contain two members with protocol-specific
+failure names.
 
 Classic Remoting `ConsumerOptions.InitialPosition` uses the protocol-owned `ConsumeFromPosition` type. LitePull and
 Push apply it only when an assigned queue has no committed group position; a timestamp start also uses

--- a/docs/en-US/grpc/consumer-model.md
+++ b/docs/en-US/grpc/consumer-model.md
@@ -91,8 +91,8 @@ Ordinary Push and LitePush receive requests set `AutoRenew=true`. A compatible P
 enabled owns receipt renewal through the client connection while a handler is active; the .NET dispatcher does not
 run a second client-side renewal timer. SimpleConsumer sets `AutoRenew=false`, so its caller owns the initial invisible
 duration and every explicit `ChangeInvisibleDurationAsync` call. This follows the
-[Apache Java gRPC client](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java#L263-L278),
-while the [Proxy registers auto-renew receipts](https://github.com/apache/rocketmq/blob/2238256de1d227a4384ba969dfa31473187b4d08/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140)
+[Apache Java gRPC client](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java#L263-L278),
+while the [Proxy registers auto-renew receipts](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140)
 only when both its configuration and the request enable the feature. Classic Remoting Push remains a separate model
 with a fixed POP deadline.
 
@@ -124,11 +124,11 @@ async DI scope for each handling attempt, allowing normal scoped application dep
 a `Singleton` handler is owned by its Consumer instance and must be safe for concurrent calls.
 
 The handler returns only `ConsumeResult.Success` or `ConsumeResult.Failure`, matching the public outcomes in the
-[Apache Java gRPC client](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java).
+[Apache Java gRPC client](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java).
 For concurrent non-FIFO delivery, `Failure` changes invisibility according to the effective retry policy and leaves
 retry and dead-letter progression to the service. For FIFO delivery, the client retries the handler locally and uses
 the protocol's dead-letter RPC internally after the maximum attempts are exhausted, matching the
-[Java process-queue behavior](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445).
+[Java process-queue behavior](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445).
 Neither the handler result nor SimpleConsumer exposes that internal RPC. The OpenTelemetry settlement operation for
 retry scheduling remains `nack`; that telemetry term is not a RocketMQ handler result.
 

--- a/docs/en-US/remoting/consumer-model.md
+++ b/docs/en-US/remoting/consumer-model.md
@@ -31,7 +31,7 @@ The audit also found two related implementation problems:
 
 ## Official Baseline
 
-This decision uses the Java client in the Apache RocketMQ main repository as its classic Remoting baseline. The
+This decision uses the released Java client at the Apache RocketMQ `rocketmq-all-5.5.0` tag as its classic Remoting baseline. The
 RocketMQ 5.x website's Java SDK examples describe the separate gRPC SDK in `apache/rocketmq-clients`; their
 PushConsumer load-balancing model must not be projected onto the classic Remoting client. The 4.x PushConsumer guide
 and the `apache/rocketmq` 5.5.0 `client` module describe the Remoting API considered here.
@@ -144,7 +144,7 @@ organized by ownership rather than by a generic Consumer base class:
 | `Coordination/Rebalance` | Shared client-rebalance scheduling, registration, wakeup, and the deterministic average queue allocator. |
 | `Pull` | Stateless internal PULL request/response contracts and wire execution used by LitePull and Push PULL receivers; each pull receives its filter from the current receive target. |
 | `Offset` | Internal queue-position queries and consumer-group offset persistence. |
-| `Settlement` | Classic `CONSUMER_SEND_MSG_BACK` execution shared by Push PULL retry and explicit POP dead-letter forwarding. |
+| `Settlement` | Classic `CONSUMER_SEND_MSG_BACK` execution used by Push PULL retry and retry-topic offset initialization. |
 | `LitePull` and `Push` | The two public role facades and their role-specific assignment, receive, dispatch, and run state. |
 
 The protocol composition root still creates one `IRemotingConsumerEngine` per registered role. The engine owns only
@@ -380,7 +380,7 @@ DI.
 | `Pull/Offset/PullOffsetManager` | PULL initial and committed offsets, broadcasting storage, reset boundaries, and retry-topic initialization boundaries. | POP progress. |
 | `Pull/Receive/PullAssignmentReceiver` | One PULL assignment's identity, cancellation, observed Broker-lock lease, and completion boundary for its receive loop plus active consume requests. | POP wire operations or handler-result policy. |
 | `Pop/PopAssignmentReceiver` | One POP assignment's target-filtered long polling, receive batching, cancellation, and receive-failure isolation. | Handler invocation, receipt lifetime, or settlement. |
-| `Pop/PopDeliveryProcessor` | POP handler invocation, fixed invisible-deadline checks, one-shot retry invisibility, maximum-attempt age handling, and deadline-bounded ACK/explicit-dead-letter settlement. | Assignment reconciliation, receive polling, `PullProcessQueue`, or offset commits. |
+| `Pop/PopDeliveryProcessor` | POP handler invocation, fixed invisible-deadline checks, one-shot retry invisibility, maximum-attempt age handling, and deadline-bounded receipt settlement. | Assignment reconciliation, receive polling, `PullProcessQueue`, or offset commits. |
 | `Pull/Orderly/OrderlyPullQueueLockClient` and `Pop/PopWireClient` | Their respective lock/unlock and POP wire commands. The queue-lock client accepts only physical PULL lock targets. | Assignment policy or application-handler invocation. |
 
 The control and delivery flows are deliberately different:
@@ -405,7 +405,7 @@ orderly PULL receiver -> OrderlyPullReceiveLoop -> PushMessageHandlerInvoker
 
 POP receiver  -> PopDeliveryProcessor -> receipt and lease state
                                     \-> PushMessageHandlerInvoker
-                                    \-> POP ACK / invisible-time change / explicit dead letter
+                                    \-> POP ACK / invisible-time change
 ```
 
 The following ownership rules are part of the behavior, not merely file organization:
@@ -446,7 +446,7 @@ maintains distinct PULL `PullProcessQueue` and Java POP `PopProcessQueue` tables
 and
 [`ConsumeMessagePopConcurrentlyService`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java)
 keep PULL and POP settlement separate. The classic
-[Go Push consumer](https://github.com/apache/rocketmq-client-go/blob/master/consumer/push_consumer.go) likewise describes
+[Go Push consumer](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/push_consumer.go) likewise describes
 Push as a callback facade over PULL and keeps queue/offset state below that facade; it is a PULL lifecycle reference,
 not a source for POP semantics.
 
@@ -458,11 +458,10 @@ consumer result model:
 - `Success` settles the acknowledged prefix selected by `AckIndex`.
 - For concurrent non-FIFO delivery, `Retry` with a non-negative `DelayLevelWhenNextConsume` sends the PULL tail back or
   makes one `CHANGE_MESSAGE_INVISIBLETIME` request with `suspend=false` for the POP tail.
-- For concurrent non-FIFO delivery, `Retry` with a negative delay level forwards a PULL message directly. This client
-  also preserves that explicit request for POP by performing classic dead-letter send-back and ACKing the receipt only
-  after forwarding succeeds.
-  ACK, including the ACK after explicit dead-letter forwarding, is retried only while the original invisible deadline
-  remains valid; after expiry no further settlement is sent.
+- For concurrent non-FIFO delivery, `Retry` with a negative delay level sends a PULL message through classic dead-letter
+  send-back. For a POP delivery, the .NET adapter normalizes a negative value to level `0`; POP then follows its normal
+  Java-compatible `CHANGE_MESSAGE_INVISIBLETIME` retry schedule and never interprets a negative value as direct
+  dead-lettering.
 - `MessageGroup` FIFO and orderly singleton delivery ignore the consume context. Their `Retry` outcome remains locally
   serialized until it succeeds or reaches `MaxDeliveryAttempts`.
 - A PULL `Retry` that reaches `MaxDeliveryAttempts` follows classic send-back into the dead-letter queue. A POP `Retry`
@@ -475,14 +474,14 @@ consumer result model:
 There is no `DeadLetter` handler result. This matches Java's
 [`ConsumeConcurrentlyStatus`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyStatus.java)
 and the classic Go client's
-[`ConsumeResult`](https://github.com/apache/rocketmq-client-go/blob/99c433634e09f72fa2778ca04411de29d4fc9cff/consumer/consumer.go#L197-L205).
+[`ConsumeResult`](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/consumer.go#L197-L205).
 `DelayLevelWhenNextConsume` defaults to `0`, matching Java's
 [`ConsumeConcurrentlyContext`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyContext.java).
-PULL passes the level to classic send-back. POP maps a positive value through Java's POP-specific retry schedule;
-`0` selects that schedule by the zero-based reconsume count (`DeliveryAttempt - 1`). This schedule starts at 10 seconds
-and is distinct from the normal delayed-message level table. Classic PULL clients define a negative value as direct
-dead-lettering; preserving the same explicit request for POP is this client's extension, and the official Java POP
-retry-at-limit path does not use it.
+PULL passes the level to classic send-back. For POP, the adapter normalizes a negative value to level `0`, then maps the
+resulting level through Java's POP-specific retry schedule; `0` selects that schedule by the zero-based reconsume count
+(`DeliveryAttempt - 1`). This schedule starts at 10 seconds and is distinct from the normal delayed-message level table.
+Direct dead-lettering remains a classic PULL-only send-back behavior; POP retry never interprets a negative value as a
+direct dead-letter request.
 
 POP does not renew a receipt while its handler is active. The client checks the fixed invisible deadline before handler
 processing and again before settlement. If the deadline has passed, the late handler result is ignored and the Broker
@@ -537,9 +536,8 @@ Unit coverage must establish:
 - reset-offset serialization, late-handler result rejection, and deterministic shutdown ownership;
 - queue ID `-1`, retry receipt markers, and physical ACK targets;
 - POP in-flight flow control, fixed invisible deadlines with no handler-active renewal, pre/post-handler expiry checks,
-  one-shot Retry invisibility, maximum-attempt age-based defer and terminal ACK without implicit send-back,
-  ACK/explicit-dead-letter settlement retries only before the original deadline, explicit dead-letter ordering, and
-  stale settlement;
+  one-shot Retry invisibility, negative-delay normalization to level `0`, maximum-attempt age-based defer and terminal
+  ACK without implicit send-back, deadline-bounded receipt settlement, and stale settlement;
 - unchanged receive, process, commit, send-back, ACK, and invisible-time telemetry outcomes after responsibility moves;
 - public, Admin-returned, and LitePull-discovered queue identities resolving and heartbeating identically;
 - route replacement and route-refresh failure using resolver-owned latest or last-valid endpoints without queue-carried

--- a/docs/en-US/remoting/transport-and-client-roles.md
+++ b/docs/en-US/remoting/transport-and-client-roles.md
@@ -108,11 +108,13 @@ same Broker physical queue can be grouped and those batches can run in parallel 
 `Success` normally confirms the complete batch. A concurrent non-FIFO handler can set `AckIndex` to the zero-based
 index of the final accepted message before returning `Success`; the client confirms that contiguous prefix and retries
 only its tail. `Retry` applies to every message regardless of `AckIndex`. The context also exposes
-`DelayLevelWhenNextConsume` for the failed batch or unacknowledged tail: `0` delegates retry timing to the Broker, a
-positive value selects a RocketMQ delay level, and a negative value requests direct dead-lettering. This two-result
-contract matches the classic Java and Go concurrent consumers; dead-lettering is a retry-policy terminal choice rather
-than a separate handler result. Broadcasting does not have a Broker retry or dead-letter path, so an unacknowledged
-tail is skipped.
+`DelayLevelWhenNextConsume` for the failed batch or unacknowledged tail: for PULL reception, `0` delegates retry timing
+to the Broker, a positive value selects a RocketMQ delay level, and a negative value requests direct dead-lettering.
+When a Push assignment uses POP, the .NET adapter normalizes a negative value to level `0` and follows the normal
+Java-compatible invisibility retry schedule, including for level `0`; POP never interprets a negative value as direct
+dead-lettering. This two-result contract matches the classic Java and Go concurrent consumers; dead-lettering is a
+retry-policy terminal choice rather than a separate handler result. Broadcasting does not have a Broker retry or
+dead-letter path, so an unacknowledged tail is skipped.
 
 `ConsumeTimeout` defaults to 15 minutes and applies only to concurrent clustered non-FIFO batches. When it elapses,
 the client cancels the handler token and requests Broker redelivery for the whole batch. It cannot forcibly terminate

--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -134,9 +134,11 @@ semantics.
 The single-Broker fixture enables Broker-side assignment and the timer wheel while retaining PULL as the default
 message request mode. Remoting Broker-assigned Push cases use a test-only administrative operation to select POP for
 one unique topic/group, verify delivery, acknowledgement, fixed-deadline expiry, late-result rejection, one-shot retry,
-no-retry-on-indeterminate-failure, maximum-attempt age handling without implicit dead-letter send-back, and explicit
-dead-letter behavior, and restore PULL during cleanup. `SET_MESSAGE_REQUEST_MODE` remains test administration and is never exposed as a production Consumer
-API. Ordinary LitePull and default Push workflows do not depend on Broker-side POP configuration.
+no-retry-on-indeterminate-failure, maximum-attempt age handling without implicit dead-letter send-back, and
+negative-delay normalization without direct dead-lettering. Cleanup restores PULL.
+`SET_MESSAGE_REQUEST_MODE` remains test administration and is never exposed as a production Consumer API. Ordinary
+LitePull and default Push workflows do not depend on Broker-side POP configuration; PULL dead-letter tests cover both
+the explicit negative-delay request and retry-policy exhaustion.
 
 Single-Broker runtime is treated as a measured test-design constraint. On commit `9ef119f`, the local Remoting filter
 `Topology!=MultiBroker` passed 29 tests in 167.7 seconds; approximately 44.6 seconds were shared fixture startup. Test
@@ -161,7 +163,7 @@ The optimized suite keeps the same live-Broker coverage under these rules:
   may be split only after its topics, groups, administrative changes, and offset assertions no longer share mutable
   state; raising the thread limit against the shared Broker is not a substitute for that isolation.
 - Retry, maximum-attempt age-based defer/ACK, fixed-deadline expiry, late-result rejection,
-  no-retry-on-indeterminate-failure, explicit dead-letter ordering,
+  no-retry-on-indeterminate-failure, PULL explicit dead-letter ordering,
   duplicate prevention, rebalance recovery, and persistence coverage remains.
   Runtime work is removed only when a deterministic signal proves the same invariant.
 - Performance changes record the same filtered command and compare test-phase wall time after at least one warm image

--- a/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
@@ -201,7 +201,8 @@ gRPC Push 和 LitePush 会为每条消息调用 handler。Remoting Push 则通�
 `IRemotingPushMessageHandler` API，在每次批量回调中传入 `IReadOnlyList<RemotingMessageView>` 和
 `RemotingPushConsumeContext`；其 `ConsumeMessageBatchSize` 默认值为 `1`，因此除非显式配置，否则仍是
 单消息投递。对于并发、非 FIFO 批次，handler 可以返回 `Success` 并设置 `AckIndex`，以确认连续前缀并重试
-尾部；`Retry` 仍是整批结果。需要直接进入死信队列时，在这个重试结果中把 `DelayLevelWhenNextConsume` 设为负值。
+尾部；`Retry` 仍是整批结果。只有内部 PULL 路径会把负数 `DelayLevelWhenNextConsume` 解释为直接死信；POP 会将其
+归一化为默认重试级别。
 
 对于非 FIFO 的 gRPC Push 和 LitePush 消息，`ConsumeTimeout` 到期后会取消 handler token 并请求重新投递。handler
 执行期间的 receipt 续期由 `AutoRenew` 请求的 Proxy 负责，不属于 handler scope，也不由客户端定时器承担。
@@ -212,9 +213,9 @@ dispatcher 会忽略延迟返回的结果并释放消费循环的并发槽位，
 对于并发集群、非 FIFO 的 Remoting 批次，`ConsumeTimeout` 到期后会取消 handler token，并请求 Broker 重新投递。
 对于 POP 投递，handler 执行期间不会续租 receipt；客户端会在 handler 处理前和结算前检查固定不可见 deadline。
 过期结果会被忽略且不发送结算。`Retry` 结果只发起一次带 `suspend=false` 的
-`CHANGE_MESSAGE_INVISIBLETIME` 请求；对于不确定的失败，不会使用旧 receipt 重试。ACK，包括死信转发后的 ACK，
-只在原始 deadline 内重试。延迟返回的结果会被忽略，并可能与重新投递重叠，因此 handler 仍需自行配合取消并保持
-幂等；运行时不能强制停止应用代码。FIFO 和顺序投递为了保持顺序保证，不应用此机制。
+`CHANGE_MESSAGE_INVISIBLETIME` 请求；对于不确定的失败，不会使用旧 receipt 重试。ACK 只在原始 deadline 内重试。
+延迟返回的结果会被忽略，并可能与重新投递重叠，因此 handler 仍需自行配合取消并保持幂等；运行时不能强制停止
+应用代码。FIFO 和顺序投递为了保持顺序保证，不应用此机制。
 
 对应的 handler scope 逻辑位于
 [`GrpcPushMessageHandlerFactory`](../../../src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushMessageHandlerFactory.cs)

--- a/docs/zh-CN/architecture/opentelemetry-instrumentation.md
+++ b/docs/zh-CN/architecture/opentelemetry-instrumentation.md
@@ -93,9 +93,9 @@ client；内部职责迁移不能让同一个 Activity 或 metric 被重复完�
 
 POP 结算 telemetry 按每次实际的 wire operation 独立记录：确认使用 `ack`，一次性重试/延期
 `CHANGE_MESSAGE_INVISIBLETIME` 使用 `nack`（defer）。普通 `Retry` 达到最大投递次数后，如果 Java 兼容的消息年龄
-判断仍选择延期，继续记录为 `nack`；超过终态年龄阈值后记录为 `ack`，整个过程不会产生 `reject`。由 `Retry` 搭配
-负 delay 请求的显式死信转发与后续 ACK 仍分别记录。handler 结果在固定不可见 deadline 之后到达时，不创建任何结算 operation。不确定的 `nack`
-失败不会使用旧 receipt 重试；确认以及显式死信转发后的 ACK 只在原始 deadline 内重试。
+判断仍选择延期，继续记录为 `nack`；超过终态年龄阈值后记录为 `ack`。在 POP 调度前，.NET 适配器会将负 delay 归一化为 `0`，因此
+POP 重试继续使用这条普通的不可见时间变更路径。handler 结果在固定不可见 deadline 之后到达时，不创建任何结算
+operation。不确定的 `nack` 失败不会使用旧 receipt 重试；确认只在原始 deadline 内重试。
 
 Activity 使用 OpenTelemetry 消息语义约定属性，例如 `messaging.system`、`messaging.destination.name`、
 `messaging.consumer.group.name`、消息 ID、分区 ID、body 大小和 batch 大小。失败时会把 Activity 状态设为 error，

--- a/docs/zh-CN/architecture/protocol-boundaries.md
+++ b/docs/zh-CN/architecture/protocol-boundaries.md
@@ -54,10 +54,10 @@ Package 版本和发布依赖。
 gRPC Push 与 LitePush 遵循 Apache Java gRPC listener 契约，只公开 `Success` 和 `Failure`；非 FIFO 的重试与死信
 推进由服务端负责，FIFO 死信转发则是客户端内部行为。classic Remoting 遵循
 [Java 客户端](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyStatus.java)
-与[Go 客户端](https://github.com/apache/rocketmq-client-go/blob/99c433634e09f72fa2778ca04411de29d4fc9cff/consumer/consumer.go#L197-L205)
-共同采用的并发消费回调模型，只公开 `Success` 和 `Retry`；需要直接进入死信队列时，把
-`RemotingPushConsumeContext.DelayLevelWhenNextConsume` 设为负数。兼容性测试仍分别锁定两边独立拥有的枚举；两者目前
-虽然都只有两个成员，但失败结果名称和协议语义并不相同。
+与[Go 客户端](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/consumer.go#L197-L205)
+共同采用的并发消费回调模型，只公开 `Success` 和 `Retry`。只有内部 PULL 路径会把负数
+`RemotingPushConsumeContext.DelayLevelWhenNextConsume` 解释为直接死信；POP 会将其归一化为默认重试级别。
+兼容性测试仍分别锁定两边独立拥有的枚举；两者目前虽然都只有两个成员，但失败结果名称和协议语义并不相同。
 
 classic Remoting 的 `ConsumerOptions.InitialPosition` 使用协议自有的 `ConsumeFromPosition` 类型。LitePull 与
 Push 只在已分配队列不存在消费组已提交位点时应用该配置；从时间戳开始时还会读取

--- a/docs/zh-CN/grpc/consumer-model.md
+++ b/docs/zh-CN/grpc/consumer-model.md
@@ -86,10 +86,10 @@ PushConsumer 启动后大致执行如下循环：
 ```
 
 handler 只返回 `ConsumeResult.Success` 或 `ConsumeResult.Failure`，与
-[Apache Java gRPC 客户端的公开结果](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java)
+[Apache Java gRPC 客户端的公开结果](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResult.java)
 一致。对于并发、非 FIFO 投递，`Failure` 会按当前重试策略调整不可见时间，后续重试和死信推进由服务端负责。
 对于 FIFO 投递，客户端会在本地重试 handler，并在达到最大次数后通过内部协议 RPC 转入死信队列；这一行为与
-[Java process queue](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445)
+[Java process queue](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445)
 一致。handler 结果和 SimpleConsumer 都不暴露内部死信 RPC。重试调度对应的 OpenTelemetry 结算 operation 仍为
 `nack`，但它不是 RocketMQ handler 结果。只有业务处理真正完成后才应返回 `Success`。网络超时、进程终止或确认
 失败仍可能造成重复投递，因此 handler 必须具备幂等性。
@@ -98,8 +98,8 @@ handler 只返回 `ConsumeResult.Success` 或 `ConsumeResult.Failure`，与
 handler 执行期间通过客户端连接托管 receipt 续期；.NET dispatcher 不再额外启动一套客户端续期定时器。
 SimpleConsumer 设置 `AutoRenew=false`，因此初始不可见时间以及每次显式 `ChangeInvisibleDurationAsync` 都由调用方负责。
 这一职责划分与
-[Apache Java gRPC 客户端](https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java#L263-L278)
-一致；[Proxy 只有在配置和请求都启用自动续期时才会登记 receipt](https://github.com/apache/rocketmq/blob/2238256de1d227a4384ba969dfa31473187b4d08/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140)。
+[Apache Java gRPC 客户端](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ConsumerImpl.java#L263-L278)
+一致；[Proxy 只有在配置和请求都启用自动续期时才会登记 receipt](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140)。
 classic Remoting Push 仍使用固定 POP deadline，不沿用这套续期机制。
 
 `MaxConcurrency` 控制消费循环数量，`MaxCachedMessages` 与 `MaxCachedMessageBytes` 限制本地缓冲。开启

--- a/docs/zh-CN/remoting/consumer-model.md
+++ b/docs/zh-CN/remoting/consumer-model.md
@@ -30,7 +30,7 @@ classic 客户端隐藏在 Push 内部的 Broker 命令直接交给应用。应�
 
 ## 官方基线
 
-本决策以 Apache RocketMQ 主仓库中的 Java 客户端作为 classic Remoting 基线。RocketMQ 5.x 官网的 Java SDK
+本决策以 Apache RocketMQ `rocketmq-all-5.5.0` 发布 tag 中的 Java 客户端作为 classic Remoting 基线。RocketMQ 5.x 官网的 Java SDK
 示例描述的是 `apache/rocketmq-clients` 中另一套 gRPC SDK，不能把其中的 PushConsumer 负载均衡模型直接套用到
 classic Remoting 客户端。本文参考的 Remoting API 来自 4.x PushConsumer 指南和 `apache/rocketmq` 5.5.0 的
 `client` 模块。
@@ -132,7 +132,7 @@ Broker endpoint 与建议 Broker ID 由内部路由解析器保存。topic 快�
 | `Coordination/Rebalance` | 共享的客户端 rebalance 调度、注册、唤醒以及确定性的平均队列分配策略。 |
 | `Pull` | 供 LitePull 与 Push PULL receiver 共用、且不保存订阅状态的内部 PULL request/response 契约和 wire 操作；每次 Pull 都从当前 receive target 获取 filter。 |
 | `Offset` | 内部 queue position 查询与 consumer-group offset 持久化。 |
-| `Settlement` | 供 Push PULL 重试和 POP 显式死信转发共用的 classic `CONSUMER_SEND_MSG_BACK`。 |
+| `Settlement` | 供 Push PULL 重试和 retry topic 位点初始化使用的 classic `CONSUMER_SEND_MSG_BACK`。 |
 | `LitePull` 与 `Push` | 两个公开角色的门面，以及各自的 assignment、receive、dispatch 和运行态。 |
 
 Remoting 组合根仍会为每个已注册角色创建一个 `IRemotingConsumerEngine`。Engine 只管理角色生命周期，并将
@@ -346,7 +346,7 @@ receipt 的 retry marker 还决定 ACK 与不可见时间请求使用的真实 w
 | `Pull/Offset/PullOffsetManager` | PULL 初始与已提交 offset、广播存储、reset boundary 和 retry-topic 初始化 boundary。 | POP 进度。 |
 | `Pull/Receive/PullAssignmentReceiver` | 单个 PULL assignment 的 identity、取消、观察到的 Broker 队列锁 lease，以及覆盖接收循环和活动消费请求的完成边界。 | POP wire 操作或 handler 结果策略。 |
 | `Pop/PopAssignmentReceiver` | 单个 POP assignment 使用自身 target filter 的长轮询、接收分批、取消和接收故障隔离。 | handler 调用、receipt 生命周期或结算。 |
-| `Pop/PopDeliveryProcessor` | POP handler 调用、固定不可见 deadline 检查、一次性重试不可见时间变更、最大投递次数下的消息年龄处理，以及原始 deadline 内的 ACK/显式死信结算。 | assignment reconciliation、接收轮询、`PullProcessQueue` 或 offset commit。 |
+| `Pop/PopDeliveryProcessor` | POP handler 调用、固定不可见 deadline 检查、一次性重试不可见时间变更、最大投递次数下的消息年龄处理，以及原始 deadline 内的 receipt 结算。 | assignment reconciliation、接收轮询、`PullProcessQueue` 或 offset commit。 |
 | `Pull/Orderly/OrderlyPullQueueLockClient` 与 `Pop/PopWireClient` | 分别执行 lock/unlock 与 POP wire command；queue-lock client 只接受物理 PULL lock target。 | assignment 策略或应用 handler 调用。 |
 
 控制链路与投递链路刻意保持不同：
@@ -371,7 +371,7 @@ PULL receiver -> ConcurrentPullReceiveLoop -> PullDeliveryCoordinator -> PullPro
 
 POP receiver  -> PopDeliveryProcessor -> receipt 与 lease 状态
                                     \-> PushMessageHandlerInvoker
-                                    \-> POP ACK / 修改不可见时间 / 显式死信
+                                    \-> POP ACK / 修改不可见时间
 ```
 
 以下规则属于行为契约，而不只是文件布局约定：
@@ -409,7 +409,7 @@ POP receiver  -> PopDeliveryProcessor -> receipt 与 lease 状态
 和
 [`ConsumeMessagePopConcurrentlyService`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessagePopConcurrentlyService.java)
 则分开处理 PULL 与 POP 结算。classic
-[Go Push Consumer](https://github.com/apache/rocketmq-client-go/blob/master/consumer/push_consumer.go) 也把 Push 描述为
+[Go Push Consumer](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/push_consumer.go) 也把 Push 描述为
 PULL 之上的 callback 门面，并把队列与 offset 状态放在门面以下；它只用于校验 PULL 生命周期，不作为 POP
 语义来源。
 
@@ -420,9 +420,9 @@ Push handler 契约继续供两类 receiver 共用，并遵循 classic Java、Go
 - `Success` 根据 `AckIndex` 结算已确认前缀。
 - 对于并发、非 FIFO 投递，`Retry` 搭配非负 `DelayLevelWhenNextConsume` 时，将 PULL 尾部 send-back，或对 POP
   尾部使用一次 `suspend=false` 的 `CHANGE_MESSAGE_INVISIBLETIME`。
-- 对于并发、非 FIFO 投递，`Retry` 搭配负 delay level 时，会让 PULL 直接转入死信。本客户端也为 POP 保留这项
-  显式请求：先执行 classic dead-letter send-back，只有转发成功后才 ACK receipt。ACK，包括显式死信转发后的 ACK，
-  只能在原始不可见 deadline 内重试；deadline 过期后不再发送结算请求。
+- 对于并发、非 FIFO 投递，`Retry` 搭配负 delay level 时，PULL 会通过 classic dead-letter send-back 直接转入死信。
+  对于 POP，.NET 适配器会先将负值归一化为 `0`，再按 Java 兼容的 `CHANGE_MESSAGE_INVISIBLETIME` 重试表处理；
+  POP 不会把负值解释为直接死信。
 - `MessageGroup` FIFO 与 orderly 单消息投递会忽略 consume context；返回 `Retry` 后保持本地串行重试，直到成功或达到
   `MaxDeliveryAttempts`。
 - PULL 的 `Retry` 达到 `MaxDeliveryAttempts` 后继续按 classic send-back 进入死信。POP 的 `Retry` 达到同一上限时，
@@ -433,12 +433,12 @@ Push handler 契约继续供两类 receiver 共用，并遵循 classic Java、Go
 handler 结果中不再包含 `DeadLetter`。这与 Java 的
 [`ConsumeConcurrentlyStatus`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyStatus.java)
 以及 classic Go 客户端的
-[`ConsumeResult`](https://github.com/apache/rocketmq-client-go/blob/99c433634e09f72fa2778ca04411de29d4fc9cff/consumer/consumer.go#L197-L205)
+[`ConsumeResult`](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/consumer.go#L197-L205)
 一致。`DelayLevelWhenNextConsume` 默认为 `0`，与 Java 的
 [`ConsumeConcurrentlyContext`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyContext.java)
-一致。PULL 把该值传给 classic send-back；POP 则把正值映射到 Java 的 POP 专用重试表。值为 `0` 时，根据从零开始
-的重试次数（`DeliveryAttempt - 1`）选择表项。该表从 10 秒开始，并不是普通延迟消息的 level 表。负值是本客户端提供的
-显式 POP 死信扩展；classic PULL 客户端本身就把负值定义为直接死信，但官方 Java POP 达到重试上限时不会使用它。
+一致。PULL 把该值传给 classic send-back；POP 会先将负值归一化为 `0`，再按 Java 的 POP 专用重试表处理。归一化后的
+值根据从零开始的重试次数（`DeliveryAttempt - 1`）选择表项。该表从 10 秒开始，并不是普通延迟消息的 level 表。
+直接死信仍然只适用于 PULL 的 classic send-back；POP 重试不会把负值解释为直接死信请求。
 
 POP handler 执行期间不会自动续租 receipt。客户端会在 handler 处理前和结算前检查固定不可见 deadline；如果已
 过期，则忽略迟到的 handler 结果，不创建结算 operation，并允许 Broker 重新投递。`Retry` 结果只发起一次带
@@ -489,8 +489,8 @@ Solution、单元测试、集成测试、benchmark、Generic Host 与非 Host sa
 - reset-offset 串行化、迟到 handler 结果拒绝和确定性的关闭所有权；
 - `queueId=-1`、retry receipt marker 和真实物理 ACK 目标；
 - POP in-flight 流控、无 handler 续租的固定不可见 deadline、handler 前后过期检查、一次性 Retry 不可见时间变更、
-  最大投递次数下按消息年龄延期或终态 ACK 且不隐式 send-back、仅在原始 deadline 内重试 ACK/显式死信结算、
-  显式死信顺序和迟到结算；
+  负 delay 归一化为 `0`、最大投递次数下按消息年龄延期或终态 ACK 且不隐式 send-back、原始 deadline 内的
+  receipt 结算以及迟到结算；
 - 职责迁移后，receive、process、commit、send-back、ACK 与不可见时间 telemetry 的结果保持不变；
 - 无论 queue identity 来自公开构造、Admin 返回还是 LitePull 发现，都应具有相同的 route 解析和 heartbeat 行为；
 - route 替换或刷新失败时，只使用 resolver 管理的最新或最后有效 endpoint；测试还需覆盖 suggested Broker 选择，以及

--- a/docs/zh-CN/remoting/transport-and-client-roles.md
+++ b/docs/zh-CN/remoting/transport-and-client-roles.md
@@ -94,10 +94,11 @@ Push 唯一的 `IRemotingPushMessageHandler.HandleAsync` API 接收 `IReadOnlyLi
 
 `Success` 默认确认整个批次。并发、非 FIFO handler 可以在返回 `Success` 前把 `AckIndex` 设为最后一条已接受
 消息的从零开始索引；客户端会确认这个连续前缀，并只重试尾部消息。无论 `AckIndex` 为何，`Retry` 都会应用到批次
-中的每条消息。context 还提供 `DelayLevelWhenNextConsume`，用于失败批次或未确认的尾部：`0` 交由 Broker 决定
-重试时间，正值选择 RocketMQ 延迟级别，负值请求直接进入死信队列。这种双结果契约与 classic Java、Go 的并发消费
-设计一致；死信是重试策略的终态选择，不是独立的 handler 结果。广播模式没有 Broker 重试或死信路径，因此未确认的
-尾部消息会被跳过。
+中的每条消息。context 还提供 `DelayLevelWhenNextConsume`，用于失败批次或未确认的尾部：PULL 接收时，`0` 交由
+Broker 决定重试时间，正值选择 RocketMQ 延迟级别，负值请求直接进入死信队列。Push assignment 使用 POP 时，.NET
+适配器会先将负值归一化为 `0`，再按 Java 兼容的不可见时间重试表处理（包括 level `0`）；POP 不会把负值解释为直接死信。
+这种双结果契约与 classic Java、Go 的并发消费设计一致；死信是重试策略的终态选择，不是独立的 handler 结果。广播
+模式没有 Broker 重试或死信路径，因此未确认的尾部消息会被跳过。
 
 `ConsumeTimeout` 默认值为 15 分钟，仅适用于并发集群、非 FIFO 批次。超时后，客户端会取消 handler token，并为
 整批消息请求 Broker 重新投递。它不能强制终止忽略取消信号的应用代码，因此 handler 必须响应该 token，并保持幂等。

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -66,7 +66,8 @@ dotnet run -c Release --project tests/benchmarks/EventHorizon.RocketMQ.Remoting.
 - options 验证、默认客户端注册、keyed 客户端注册与重复角色注册；
 - message 编解码、frame 长度限制、ACL 签名和 response correlation；
 - route cache、重试、取消、连接故障和 handler 生命周期；
-- Consumer 对 gRPC `Success` / `Failure`，以及 Remoting `Success`、部分批量确认、`Retry` 和负 delay 主动死信的处理决策。
+- Consumer 对 gRPC `Success` / `Failure`，以及 Remoting `Success`、部分批量确认、`Retry`、PULL 负 delay 主动死信和
+  POP 负 delay 归一化的处理决策。
 
 对于客户端能够确定性验证的行为，IT 覆盖不能替代 UT。即使 IT 已覆盖完整工作流，底层状态转换、分配、调度、
 offset、重试和失败不变量仍必须保留聚焦的 UT；IT 只在此基础上补充真实 Broker、NameServer、Proxy、transport、
@@ -125,9 +126,10 @@ container suite 刻意继续使用专用 topic，且类内方法串行执行，�
 
 single-Broker fixture 会启用 Broker-side assignment 与 timer wheel，同时把消息请求模式默认保持为 PULL。
 Remoting Broker-assigned Push case 仅通过测试管理操作把一个唯一 topic/group 切换为 POP，验证投递、确认、固定 deadline
-过期、迟到结果拒绝、一次性重试、不对不确定失败重试、最大投递次数下不隐式 send-back 的消息年龄处理，以及显式死信
-行为，并在清理时恢复 PULL。`SET_MESSAGE_REQUEST_MODE` 始终属于测试管理面，不会成为生产 Consumer
-API。普通 LitePull 与默认 Push 工作流不依赖 Broker 侧 POP 配置。
+过期、迟到结果拒绝、一次性重试、不对不确定失败重试、最大投递次数下不隐式 send-back 的消息年龄处理，以及负 delay
+归一化后不直接死信的行为；清理时再恢复为 PULL。`SET_MESSAGE_REQUEST_MODE` 始终属于测试管理面，不会成为生产
+Consumer API。普通 LitePull 与默认 Push 工作流不依赖 Broker 侧 POP 配置；PULL 死信测试会同时覆盖负 delay 显式请求
+和重试策略耗尽。
 
 single-Broker 的运行时间也属于需要持续测量的测试设计约束。在 commit `9ef119f` 上，本地使用
 `Topology!=MultiBroker` 筛选条件运行 Remoting 测试，29 个测试全部通过，测试阶段耗时 167.7 秒，其中共享
@@ -148,7 +150,7 @@ fixture 启动约 44.6 秒。
   校验同一份快照，不能为每个 Queue 分别启动一个 JVM；并发轮询同一个 Group 不会增强证据，只会增加容器争用。
 - 测试并发来自 runner 四个 collection 上限内、状态已经隔离的测试类。只有 topic、group、管理操作和 offset 断言不再
   共享可变状态后，才能继续拆分测试类；直接提高共享 Broker 上的线程上限不能替代状态隔离。
-- 重试、最大投递次数下按消息年龄延期或 ACK、固定 deadline 过期、迟到结果拒绝、不对不确定失败重试、显式死信顺序、
+- 重试、最大投递次数下按消息年龄延期或 ACK、固定 deadline 过期、迟到结果拒绝、不对不确定失败重试、PULL 显式死信顺序、
   防重复、rebalance 恢复与持久化覆盖必须保留。
   只有确定性信号能证明同一不变量时，才可以删除等待时间。
 - 性能改动应使用同一条筛选命令，并至少在镜像已预热的情况下比较测试阶段 wall-clock 时间。即使结果更快，只要

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
@@ -224,7 +224,7 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
             // passes false, leaving every explicit lease extension to its caller.
             // Design: docs/en-US/grpc/consumer-model.md#simpleconsumer and #pushconsumer.
             // Apache Proxy reference:
-            // https://github.com/apache/rocketmq/blob/2238256de1d227a4384ba969dfa31473187b4d08/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140
+            // https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140
             var request = new Proto.ReceiveMessageRequest
             {
                 Group = Resource(_groupName),
@@ -335,7 +335,7 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
     // handler-active renewal.
     // Design: docs/en-US/grpc/consumer-model.md#simpleconsumer.
     // Apache Java reference:
-    // https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImpl.java#L219-L258
+    // https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImpl.java#L219-L258
     public Task ChangeInvisibleDurationAsync(
         GrpcMessageView message,
         TimeSpan invisibleDuration,
@@ -348,7 +348,7 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
     // is deliberately recorded as "nack" telemetry.
     // Design: docs/en-US/grpc/consumer-model.md#pushconsumer.
     // Apache Java reference:
-    // https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445
+    // https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/ProcessQueueImpl.java#L431-L445
     public Task ScheduleRetryAsync(
         GrpcMessageView message,
         TimeSpan invisibleDuration,
@@ -359,7 +359,7 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
     // ChangeInvisibleDuration operation. telemetryOperation classifies the caller's intent locally; the service receives
     // the same wire shape and applies the requested replacement deadline.
     // Apache Proxy reference:
-    // https://github.com/apache/rocketmq/blob/2238256de1d227a4384ba969dfa31473187b4d08/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java#L43-L69
+    // https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ChangeInvisibleDurationActivity.java#L43-L69
     private Task SetInvisibleDurationAsync(
         GrpcMessageView message,
         TimeSpan invisibleDuration,

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumerOptions.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumerOptions.cs
@@ -69,7 +69,7 @@ public class GrpcPushConsumerOptions : ConsumerOptions
     /// second renewal timer. A handler that does not observe cancellation cannot be forcibly stopped, and a late
     /// successful result is ignored. FIFO message groups are excluded so that their ordering is not broken.
     /// </remarks>
-    /// <seealso href="https://github.com/apache/rocketmq/blob/2238256de1d227a4384ba969dfa31473187b4d08/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140">
+    /// <seealso href="https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/proxy/src/main/java/org/apache/rocketmq/proxy/grpc/v2/consumer/ReceiveMessageActivity.java#L100-L140">
     /// Apache RocketMQ Proxy registration of receipts for server-managed automatic renewal.
     /// </seealso>
     public TimeSpan ConsumeTimeout { get; set; } = TimeSpan.FromMinutes(15);

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Simple/IGrpcSimpleConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Simple/IGrpcSimpleConsumer.cs
@@ -97,7 +97,7 @@ public interface IGrpcSimpleConsumer : IAsyncDisposable
     /// <param name="invisibleDuration">The new positive invisible duration.</param>
     /// <param name="cancellationToken">A token that cancels the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    /// <seealso href="https://github.com/apache/rocketmq-clients/blob/9fe1449d19449b41442aa3a97ab168ed6b5bd6b1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImpl.java#L219-L258">
+    /// <seealso href="https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/SimpleConsumerImpl.java#L219-L258">
     /// Apache RocketMQ Java SimpleConsumer invisibility change and receipt-handle refresh.
     /// </seealso>
     Task ChangeInvisibleDurationAsync(GrpcMessageView message, TimeSpan invisibleDuration, CancellationToken cancellationToken = default);

--- a/src/EventHorizon.RocketMQ.Grpc/Protocol/Protos/apache/rocketmq/v2/definition.proto
+++ b/src/EventHorizon.RocketMQ.Grpc/Protocol/Protos/apache/rocketmq/v2/definition.proto
@@ -301,7 +301,7 @@ message Message {
   // If user_properties contain the reserved keys by RocketMQ,
   // the send message request will be aborted with status `INVALID_ARGUMENT`.
   // See below links for the reserved keys
-  // https://github.com/apache/rocketmq/blob/master/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java#L58
+  // https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/common/src/main/java/org/apache/rocketmq/common/message/MessageConst.java#L58
   map<string, string> user_properties = 2;
 
   SystemProperties system_properties = 3;

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/ConsumeResult.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/ConsumeResult.cs
@@ -19,14 +19,15 @@ namespace EventHorizon.RocketMQ.Remoting.Consumer;
 /// Specifies the outcome of processing a consumed message.
 /// </summary>
 /// <remarks>
-/// Dead-lettering is a terminal retry-policy decision rather than a separate result. A concurrent non-FIFO Push
-/// handler can request direct dead-lettering by returning <see cref="Retry"/> after setting
-/// <see cref="Push.RemotingPushConsumeContext.DelayLevelWhenNextConsume"/> to a negative value.
+/// Dead-lettering is a terminal retry-policy decision rather than a separate result. For a concurrent non-FIFO Push
+/// delivery received through PULL, a handler can request direct dead-lettering by returning <see cref="Retry"/> after
+/// setting <see cref="Push.RemotingPushConsumeContext.DelayLevelWhenNextConsume"/> to a negative value. POP normalizes
+/// a negative value to its default retry level instead.
 /// </remarks>
 /// <seealso href="https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyStatus.java">
 /// Apache RocketMQ Java concurrent consume results.
 /// </seealso>
-/// <seealso href="https://github.com/apache/rocketmq-client-go/blob/99c433634e09f72fa2778ca04411de29d4fc9cff/consumer/consumer.go#L197-L205">
+/// <seealso href="https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/consumer.go#L197-L205">
 /// Apache RocketMQ Go classic consume results.
 /// </seealso>
 public enum ConsumeResult

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Assignment/PushReceiverFactory.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Assignment/PushReceiverFactory.cs
@@ -16,7 +16,6 @@
 using EventHorizon.RocketMQ.Remoting.Consumer.Push.Pop;
 using EventHorizon.RocketMQ.Remoting.Consumer.Push.Processing;
 using EventHorizon.RocketMQ.Remoting.Consumer.Push.Pull.Receive;
-using EventHorizon.RocketMQ.Remoting.Consumer.Settlement;
 using Microsoft.Extensions.Logging;
 
 namespace EventHorizon.RocketMQ.Remoting.Consumer.Push.Assignment;
@@ -25,26 +24,22 @@ internal sealed class PushReceiverFactory
 {
     private readonly RemotingPushConsumerOptions _options;
     private readonly PopWireClient _popClient;
-    private readonly IRemotingSettlementClient _settlementClient;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
 
     public PushReceiverFactory(
         RemotingPushConsumerOptions options,
         PopWireClient popClient,
-        IRemotingSettlementClient settlementClient,
         TimeProvider timeProvider,
         ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(popClient);
-        ArgumentNullException.ThrowIfNull(settlementClient);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(logger);
 
         _options = options;
         _popClient = popClient;
-        _settlementClient = settlementClient;
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -65,7 +60,6 @@ internal sealed class PushReceiverFactory
                 new PopDeliveryProcessor(
                     _options,
                     _popClient,
-                    _settlementClient,
                     _timeProvider,
                     _logger,
                     (messages, canInvoke, token) => HandlePopMessagesAsync(run, messages, canInvoke, token)),

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pop/PopDeliveryProcessor.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pop/PopDeliveryProcessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 using EventHorizon.RocketMQ.Remoting.Consumer.Push.Processing;
-using EventHorizon.RocketMQ.Remoting.Consumer.Settlement;
 using Microsoft.Extensions.Logging;
 
 namespace EventHorizon.RocketMQ.Remoting.Consumer.Push.Pop;
@@ -34,7 +33,6 @@ internal sealed class PopDeliveryProcessor
 
     private readonly RemotingPushConsumerOptions _options;
     private readonly PopWireClient _popClient;
-    private readonly IRemotingSettlementClient _settlementClient;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
     private readonly Func<
@@ -46,7 +44,6 @@ internal sealed class PopDeliveryProcessor
     public PopDeliveryProcessor(
         RemotingPushConsumerOptions options,
         PopWireClient popClient,
-        IRemotingSettlementClient settlementClient,
         TimeProvider timeProvider,
         ILogger logger,
         Func<
@@ -57,14 +54,12 @@ internal sealed class PopDeliveryProcessor
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(popClient);
-        ArgumentNullException.ThrowIfNull(settlementClient);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(messageHandler);
 
         _options = options;
         _popClient = popClient;
-        _settlementClient = settlementClient;
         _timeProvider = timeProvider;
         _logger = logger;
         _messageHandler = messageHandler;
@@ -131,9 +126,6 @@ internal sealed class PopDeliveryProcessor
             case ConsumeResult.Success:
                 await AcknowledgeAsync(state, cancellationToken).ConfigureAwait(false);
                 break;
-            case ConsumeResult.Retry when handlerOutcome.DelayLevelWhenNextConsume < 0:
-                await SendToDeadLetterQueueAsync(state, cancellationToken).ConfigureAwait(false);
-                break;
             case ConsumeResult.Retry:
                 await SettleRetryAsync(state, handlerOutcome.DelayLevelWhenNextConsume, cancellationToken)
                     .ConfigureAwait(false);
@@ -162,8 +154,11 @@ internal sealed class PopDeliveryProcessor
         }
         else
         {
+            // Java 5.5.0 POP has no PULL-style negative-delay dead-letter branch. Normalize that PULL-only sentinel to
+            // POP's default retry level so an internal receive-mode choice cannot turn it into an invalid table index.
+            var popDelayLevel = Math.Max(delayLevelWhenNextConsume, 0);
             invisibleDuration = PopRetryDelaySchedule.Resolve(
-                delayLevelWhenNextConsume,
+                popDelayLevel,
                 message.DeliveryAttempt);
         }
 
@@ -209,39 +204,6 @@ internal sealed class PopDeliveryProcessor
                 state.Receipt.QueueId,
                 state.Receipt.QueueOffset);
         }
-    }
-
-    private async Task SendToDeadLetterQueueAsync(
-        PopDeliveryState state,
-        CancellationToken cancellationToken)
-    {
-        var receipt = state.Receipt;
-        var physicalQueue = new RemotingConsumerQueue(
-            receipt.Topic,
-            receipt.BrokerName,
-            receipt.QueueId);
-        if (!await RetrySettlementAsync(
-                state,
-                "send to the dead-letter queue",
-                token => _settlementClient.SendBackAsync(
-                    physicalQueue,
-                    state.Message.Message,
-                    delayLevel: -1,
-                    _options.MaxDeliveryAttempts,
-                    token),
-                cancellationToken).ConfigureAwait(false))
-        {
-            return;
-        }
-
-        await RetrySettlementAsync(
-            state,
-            "acknowledge after dead-letter forwarding",
-            token => _popClient.AcknowledgeAsync(
-                state.Receipt,
-                state.Message.Message,
-                token),
-            cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<bool> RetrySettlementAsync(

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumeContext.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumeContext.cs
@@ -20,10 +20,10 @@ namespace EventHorizon.RocketMQ.Remoting.Consumer.Push;
 /// </summary>
 /// <remarks>
 /// For a concurrent non-FIFO batch, <see cref="AckIndex"/> selects the acknowledged prefix when the handler returns
-/// <see cref="ConsumeResult.Success"/>, while <see cref="DelayLevelWhenNextConsume"/> selects retry timing or direct
-/// dead-lettering when it returns <see cref="ConsumeResult.Retry"/>. This mirrors RocketMQ's concurrent-consumer
-/// acknowledgement model. FIFO <c>MessageGroup</c> and orderly deliveries are singleton paths and ignore these
-/// settings.
+/// <see cref="ConsumeResult.Success"/>, while <see cref="DelayLevelWhenNextConsume"/> selects retry timing when it
+/// returns <see cref="ConsumeResult.Retry"/>. A negative value requests direct dead-lettering only when the internal
+/// receiver uses PULL; POP normalizes it to the default retry level. FIFO <c>MessageGroup</c> and orderly deliveries are
+/// singleton paths and ignore these settings.
 /// </remarks>
 public sealed class RemotingPushConsumeContext
 {
@@ -53,20 +53,21 @@ public sealed class RemotingPushConsumeContext
     }
 
     /// <summary>
-    /// Gets or sets the RocketMQ delay level used when the consumer sends unacknowledged messages back.
+    /// Gets or sets the RocketMQ delay level used after an unsuccessful concurrent delivery.
     /// </summary>
     /// <remarks>
-    /// The default value is <c>0</c>, which lets the Broker choose the retry interval. Set it to a positive RocketMQ
-    /// delay level to select a Broker-defined interval, or to a negative value to explicitly request direct
-    /// dead-letter delivery. For POP retries at <see cref="RemotingPushConsumerOptions.MaxDeliveryAttempts"/>, the
-    /// official age-based terminal policy takes precedence over this value. If
+    /// The default value is <c>0</c>, which selects the receiver's default retry interval. A positive value selects a
+    /// receiver-specific RocketMQ retry interval. A negative value requests direct dead-letter delivery for PULL; POP
+    /// normalizes it to <c>0</c> and follows its normal invisibility retry schedule. For POP retries at
+    /// <see cref="RemotingPushConsumerOptions.MaxDeliveryAttempts"/>, the official age-based terminal policy takes
+    /// precedence over this value. If
     /// <see cref="RemotingPushConsumerOptions.ConsumeTimeout"/> elapses first, the consumer ignores this value and
     /// retries the complete batch using the Broker-selected interval.
     /// </remarks>
     /// <seealso href="https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyContext.java">
     /// Apache RocketMQ Java concurrent consume context.
     /// </seealso>
-    /// <seealso href="https://github.com/apache/rocketmq-client-go/blob/99c433634e09f72fa2778ca04411de29d4fc9cff/primitive/ctx.go#L133-L152">
+    /// <seealso href="https://github.com/apache/rocketmq-client-go/blob/v2.1.2/primitive/ctx.go#L133-L152">
     /// Apache RocketMQ Go classic concurrent consume context.
     /// </seealso>
     public int DelayLevelWhenNextConsume { get; set; }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumer.cs
@@ -87,7 +87,6 @@ internal sealed class RemotingPushConsumer : IRemotingPushConsumer
         var receiverFactory = new PushReceiverFactory(
             _options,
             popClient,
-            consumerEngine,
             timeProvider,
             logger);
         _assignmentCoordinator = new PushAssignmentCoordinator(

--- a/src/EventHorizon.RocketMQ.Remoting/README.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.md
@@ -304,11 +304,13 @@ records the source-level Java and Broker references.
 
 `ConsumeMessageBatchSize` controls the largest list passed to one handler call. Return `Success` or `Retry`. For a
 concurrent non-FIFO batch, set `RemotingPushConsumeContext.AckIndex` before returning `Success` to acknowledge only a
-contiguous prefix. `DelayLevelWhenNextConsume` controls the next retry delay; set it to a negative value before
-returning `Retry` to request direct dead-lettering. Its default value is `0`, which delegates retry timing to the Broker. At
-`MaxDeliveryAttempts`, PULL retry uses classic dead-letter send-back. POP retry follows the official Java age policy:
-it continues with age-selected invisibility changes and ACKs only after the message is older than twice the final POP
-retry delay, without implicit dead-letter forwarding.
+contiguous prefix. `DelayLevelWhenNextConsume` controls the next retry delay. For PULL reception, set it to a negative
+value before returning `Retry` to request direct dead-letter send-back. For POP reception, the .NET adapter normalizes a
+negative value to level `0` and follows the normal Java-compatible invisibility retry schedule. Its default value is `0`;
+PULL uses Broker retry timing for that value, while POP applies the Java schedule. At `MaxDeliveryAttempts`, PULL retry
+uses classic dead-letter send-back. POP retry follows the official Java age policy: it continues with age-selected
+invisibility changes and ACKs only after the message is older than twice the final POP retry delay, without implicit
+dead-letter forwarding.
 
 `ServiceLifetime.Scoped` or `Transient` creates a fresh async scope for each handling attempt. A singleton handler
 must be thread-safe. Handlers must honor cancellation and remain idempotent because delivery is at least once.

--- a/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
@@ -292,8 +292,9 @@ PULL。Broker 分配查询失败时，Consumer 会等待下一轮协调，不会
 
 `ConsumeMessageBatchSize` 控制一次处理器调用接收的消息列表上限。处理器返回 `Success` 或 `Retry`。对于并发的非 FIFO
 批次，返回 `Success` 前设置 `RemotingPushConsumeContext.AckIndex`，只确认连续前缀内的消息。
-`DelayLevelWhenNextConsume` 控制下一次重试的延迟；需要直接进入死信队列时，先把它设为负值，再返回 `Retry`。
-默认值为 `0`，由 Broker 决定重试时间。
+`DelayLevelWhenNextConsume` 控制下一次重试的延迟。PULL 接收时，可在返回 `Retry` 前将其设为负值，请求直接执行死信
+send-back。POP 接收时，.NET 适配器会先将负值归一化为 `0`，再按 Java 兼容的不可见时间重试表处理。默认值为 `0`；
+PULL 由 Broker 决定重试时间，POP 则按 Java 重试表处理。
 达到 `MaxDeliveryAttempts` 后，PULL 重试按 classic send-back 进入死信；POP 重试则遵循官方 Java 的消息年龄策略，继续按
 年龄修改不可见时间，只有消息年龄超过 POP 最后一级重试延迟的两倍时才 ACK，不会隐式转入死信。
 

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQDeadLetterIntegrationTests.cs
@@ -13,9 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using EventHorizon.RocketMQ.Grpc.Consumer;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
 using EventHorizon.RocketMQ.Grpc.Producer;
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
@@ -26,7 +29,6 @@ namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 
 public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
-
     [Fact]
     [Trait("Category", "Integration")]
     public async Task GrpcPushConsumer_FifoFailureExhaustsRetries_ForwardsToDeadLetterQueue()
@@ -40,8 +42,9 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
             cancellationToken);
         var handled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var expected = $"grpc-dlq-{Guid.NewGuid():N}";
+        var observation = new DeadLetterObservation(expected, handled);
         var services = new ServiceCollection();
-        services.AddSingleton(new DeadLetterObservation(expected, handled));
+        services.AddSingleton(observation);
         services
             .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
             .AddGrpcProducer()
@@ -50,6 +53,7 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
                 options.GroupName = consumerGroup;
                 options.MaxDeliveryAttempts = 2;
                 options.RetryDelay = TimeSpan.FromMilliseconds(100);
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
                 options.Subscribe(scope.Topic, new FilterExpression("grpc-dlq"));
             });
 
@@ -67,27 +71,169 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
                 Tag = "grpc-dlq",
                 MessageGroup = $"grpc-dlq-{Guid.NewGuid():N}"
             }, cancellationToken);
-            await handled.Task.WaitAsync(TimeSpan.FromSeconds(20), cancellationToken);
-
-            var deadLetterTopic = $"%DLQ%{consumerGroup}";
-            var status = string.Empty;
-            for (var attempt = 0; attempt < 20; attempt++)
-            {
-                status = await fixture.GetTopicStatusAsync(deadLetterTopic, cancellationToken);
-                if (HasMessage(status))
-                {
-                    return;
-                }
-
-                await Task.Delay(TimeSpan.FromMilliseconds(500), cancellationToken);
-            }
-
-            Assert.Fail($"Dead-letter topic did not receive the message. Topic status: {status}");
+            await handled.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await AssertDeadLetterMessageAsync(fixture, consumerGroup, cancellationToken);
+            AssertSingleRetry(observation, requireAttemptIncrement: true);
         }
         finally
         {
             await consumer.StopAsync(CancellationToken.None);
             await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GrpcPushConsumer_NonFifoFailureExhaustsRetries_MovesToDeadLetterQueue()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
+        var consumerGroup = await scope.CreateConsumerGroupAsync(
+            "grpc-push-non-fifo-dlq-consumer",
+            retryMaxTimes: 1,
+            cancellationToken);
+        var handled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expected = $"grpc-non-fifo-dlq-{Guid.NewGuid():N}";
+        var observation = new DeadLetterObservation(expected, handled);
+        var services = new ServiceCollection();
+        services.AddSingleton(observation);
+        services
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
+            .AddGrpcProducer()
+            .AddGrpcPushConsumer<DeadLetterMessageHandler>(ServiceLifetime.Singleton, options =>
+            {
+                options.GroupName = consumerGroup;
+                options.MaxDeliveryAttempts = 2;
+                options.RetryDelay = TimeSpan.FromMilliseconds(100);
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+                options.Subscribe(scope.Topic, new FilterExpression("grpc-non-fifo-dlq"));
+            });
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IGrpcProducer>();
+        var consumer = provider.GetRequiredService<IGrpcPushConsumer>();
+        await producer.StartAsync(cancellationToken);
+        await consumer.StartAsync(cancellationToken);
+        try
+        {
+            await producer.SendAsync(new Message(
+                scope.Topic,
+                Encoding.UTF8.GetBytes(expected))
+            {
+                Tag = "grpc-non-fifo-dlq"
+            }, cancellationToken);
+            await handled.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await AssertDeadLetterMessageAsync(fixture, consumerGroup, cancellationToken);
+            AssertSingleRetry(observation, requireAttemptIncrement: true);
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GrpcLitePushConsumer_FailureExhaustsRetries_MovesToDeadLetterQueue()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Lite, cancellationToken);
+        // Released Proxy 5.5.0 yields one Lite redelivery with this setting. The assertions below pin the resulting
+        // two handler calls by requiring both the configured retry interval and a new receipt handle.
+        var consumerGroup = await scope.CreateLiteConsumerGroupAsync(
+            "grpc-lite-push-dlq-consumer",
+            retryMaxTimes: 0,
+            cancellationToken);
+        var liteTopic = $"grpc-lite-dlq-{Guid.NewGuid():N}";
+        var handled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expected = $"grpc-lite-dlq-{Guid.NewGuid():N}";
+        var observation = new DeadLetterObservation(expected, handled);
+        var services = new ServiceCollection();
+        services.AddSingleton(observation);
+        services
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
+            .AddGrpcProducer(options => options.Topics.Add(scope.Topic))
+            .AddGrpcLitePushConsumer<DeadLetterMessageHandler>(ServiceLifetime.Singleton, options =>
+            {
+                options.GroupName = consumerGroup;
+                options.BindTopic = scope.Topic;
+                options.LiteTopics.Add(liteTopic);
+                options.MaxDeliveryAttempts = 2;
+                options.RetryDelay = TimeSpan.FromMilliseconds(100);
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+            });
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IGrpcProducer>();
+        var consumer = provider.GetRequiredService<IGrpcLitePushConsumer>();
+        await producer.StartAsync(cancellationToken);
+        await consumer.StartAsync(cancellationToken);
+        try
+        {
+            await producer.SendAsync(new Message(
+                scope.Topic,
+                Encoding.UTF8.GetBytes(expected))
+            {
+                LiteTopic = liteTopic
+            }, cancellationToken);
+            await handled.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
+            await AssertDeadLetterMessageAsync(fixture, consumerGroup, cancellationToken);
+            AssertSingleRetry(observation, requireAttemptIncrement: false);
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private static async Task AssertDeadLetterMessageAsync(
+        RocketMQSingleBrokerContainerFixture fixture,
+        string consumerGroup,
+        CancellationToken cancellationToken)
+    {
+        var deadLetterTopic = $"%DLQ%{consumerGroup}";
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(10);
+        var status = string.Empty;
+        do
+        {
+            status = await fixture.GetTopicStatusAsync(deadLetterTopic, cancellationToken);
+            if (HasMessage(status))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+        }
+        while (DateTimeOffset.UtcNow < deadline);
+
+        Assert.Fail($"Dead-letter topic did not receive the message. Topic status: {status}");
+    }
+
+    private static void AssertSingleRetry(
+        DeadLetterObservation observation,
+        bool requireAttemptIncrement)
+    {
+        Assert.Equal(2, observation.DeliveryCount);
+        var deliveries = observation.Deliveries;
+        Assert.Equal(2, deliveries.Count);
+        Assert.True(
+            Stopwatch.GetElapsedTime(deliveries[0].Timestamp, deliveries[1].Timestamp) >=
+            TimeSpan.FromMilliseconds(500),
+            "The second handler call arrived before the configured retry interval.");
+        if (requireAttemptIncrement)
+        {
+            Assert.True(
+                deliveries[1].DeliveryAttempt > deliveries[0].DeliveryAttempt,
+                $"Expected one redelivery with an increased attempt, but observed " +
+                $"[{deliveries[0].DeliveryAttempt}, {deliveries[1].DeliveryAttempt}].");
+        }
+        else
+        {
+            Assert.NotEqual(deliveries[0].ReceiptHandle, deliveries[1].ReceiptHandle);
         }
     }
 
@@ -108,9 +254,34 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
         return false;
     }
 
-    private sealed record DeadLetterObservation(
-        string ExpectedBody,
-        TaskCompletionSource Handled);
+    private sealed class DeadLetterObservation(string expectedBody, TaskCompletionSource handled)
+    {
+        private readonly ConcurrentQueue<ObservedDelivery> _deliveries = [];
+        private int _deliveryCount;
+
+        public string ExpectedBody { get; } = expectedBody;
+
+        public TaskCompletionSource Handled { get; } = handled;
+
+        public int DeliveryCount => Volatile.Read(ref _deliveryCount);
+
+        public IReadOnlyList<ObservedDelivery> Deliveries => _deliveries.ToArray();
+
+        public void RecordDelivery(GrpcMessageView message)
+        {
+            _deliveries.Enqueue(new ObservedDelivery(
+                message.DeliveryAttempt,
+                message.ReceiptHandle,
+                Stopwatch.GetTimestamp()));
+            Interlocked.Increment(ref _deliveryCount);
+            Handled.TrySetResult();
+        }
+    }
+
+    private sealed record ObservedDelivery(
+        int DeliveryAttempt,
+        string ReceiptHandle,
+        long Timestamp);
 
     private sealed class DeadLetterMessageHandler(DeadLetterObservation observation) : IGrpcPushMessageHandler
     {
@@ -120,7 +291,7 @@ public sealed class RocketMQDeadLetterIntegrationTests(RocketMQSingleBrokerConta
         {
             if (Encoding.UTF8.GetString(message.Body) == observation.ExpectedBody)
             {
-                observation.Handled.TrySetResult();
+                observation.RecordDelivery(message);
                 return ValueTask.FromResult(ConsumeResult.Failure);
             }
 

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixture.cs
@@ -329,6 +329,9 @@ public sealed class RocketMQSingleBrokerContainerFixture : IAsyncLifetime
             {
                 createGroupCommand.Add("--retryMaxTimes");
                 createGroupCommand.Add(retryMaxTimes.Value.ToString(CultureInfo.InvariantCulture));
+                createGroupCommand.Add("--groupRetryPolicy");
+                createGroupCommand.Add(
+                    "{\"type\":\"CUSTOMIZED\",\"customizedRetryPolicy\":{\"next\":[1000]}}");
             }
 
             var createGroup = await _broker.ExecAsync(createGroupCommand, cancellationToken).ConfigureAwait(false);

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQTestScope.cs
@@ -63,7 +63,10 @@ public sealed class RocketMQTestScope
     /// Creates an isolated consumer group with a configured maximum retry count.
     /// </summary>
     /// <param name="role">The role label included in the group name.</param>
-    /// <param name="retryMaxTimes">The non-negative maximum number of consumption retries.</param>
+    /// <param name="retryMaxTimes">
+    /// The non-negative maximum number of consumption retries. The integration group uses a one-second customized
+    /// backoff so retry workflows remain bounded.
+    /// </param>
     /// <param name="cancellationToken">The token used to cancel the Broker administration request.</param>
     /// <returns>The created consumer group name.</returns>
     public async Task<string> CreateConsumerGroupAsync(
@@ -87,6 +90,27 @@ public sealed class RocketMQTestScope
     {
         var group = CreateGroupName(role);
         await _fixture.CreateConsumerGroupAsync(group, Topic, null, cancellationToken).ConfigureAwait(false);
+        return group;
+    }
+
+    /// <summary>
+    /// Creates and configures an isolated LitePush consumer group with a maximum retry count.
+    /// </summary>
+    /// <param name="role">The role label included in the group name.</param>
+    /// <param name="retryMaxTimes">
+    /// The non-negative maximum number of consumption retries. The integration group uses a one-second customized
+    /// backoff so retry workflows remain bounded.
+    /// </param>
+    /// <param name="cancellationToken">The token used to cancel the Broker administration request.</param>
+    /// <returns>A LitePush consumer group name unique to this test scope.</returns>
+    public async Task<string> CreateLiteConsumerGroupAsync(
+        string role,
+        int retryMaxTimes,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(retryMaxTimes);
+        var group = CreateGroupName(role);
+        await _fixture.CreateConsumerGroupAsync(group, Topic, retryMaxTimes, cancellationToken).ConfigureAwait(false);
         return group;
     }
 

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/Consumer/Push/Pop/RocketMQBrokerAssignedPopNegativeDelayIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/Consumer/Push/Pop/RocketMQBrokerAssignedPopNegativeDelayIntegrationTests.cs
@@ -16,7 +16,6 @@
 using System.Text;
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 using EventHorizon.RocketMQ.Remoting.Consumer;
-using EventHorizon.RocketMQ.Remoting.Consumer.LitePull;
 using EventHorizon.RocketMQ.Remoting.Consumer.Push;
 using EventHorizon.RocketMQ.Remoting.IntegrationTests.Consumer.Push.Pop.Support;
 using EventHorizon.RocketMQ.Remoting.Producer;
@@ -25,33 +24,38 @@ using Xunit;
 
 namespace EventHorizon.RocketMQ.Remoting.IntegrationTests.Consumer.Push.Pop;
 
-public sealed class RocketMQBrokerAssignedPopDeadLetterIntegrationTests(
+public sealed class RocketMQBrokerAssignedPopNegativeDelayIntegrationTests(
     RocketMQSingleBrokerContainerFixtureRegistry registry)
 {
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task BrokerAssignedPop_HandlerRequestsDeadLetter_ForwardsBeforeAcknowledgingReceipt()
+    public async Task BrokerAssignedPop_HandlerRequestsNegativeDelay_RedeliversWithoutDeadLetterAndAcknowledgesReceipt()
     {
         using var settlements = new RemotingSettlementObserver();
         var cancellationToken = TestContext.Current.CancellationToken;
         var fixture = await registry.GetFixtureAsync(cancellationToken);
         var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Normal, cancellationToken);
-        var consumerGroup = scope.CreateConsumerGroupName("remoting-broker-pop-dead-letter");
+        var consumerGroup = scope.CreateConsumerGroupName("remoting-broker-pop-negative-delay");
         var deadLetterTopic = $"%DLQ%{consumerGroup}";
-        var tag = $"remoting-broker-pop-dead-letter-{Guid.NewGuid():N}";
-        var body = $"remoting-broker-pop-dead-letter-{Guid.NewGuid():N}";
-        var deadLetterRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tag = $"remoting-broker-pop-negative-delay-{Guid.NewGuid():N}";
+        var body = $"remoting-broker-pop-negative-delay-{Guid.NewGuid():N}";
+        var firstAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var redelivered = new TaskCompletionSource<RemotingMessageView>(TaskCreationOptions.RunContinuationsAsynchronously);
         var deliveryCount = 0;
         var services = new ServiceCollection();
         var rocketMQ = BrokerAssignedPopIntegrationTestSupport.AddRemotingClient(
             services,
             fixture,
-            $"remoting-broker-pop-dead-letter-{Guid.NewGuid():N}");
+            $"remoting-broker-pop-negative-delay-{Guid.NewGuid():N}");
         rocketMQ.AddRemotingProducer(options =>
-            options.GroupName = scope.CreateProducerGroupName("remoting-broker-pop-dead-letter-producer"));
-        rocketMQ.AddRemotingPushConsumerWithTestHandler<DeadLetterConsumerMarker>(options =>
+            options.GroupName = scope.CreateProducerGroupName("remoting-broker-pop-negative-delay-producer"));
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<NegativeDelayConsumerMarker>(options =>
         {
-            BrokerAssignedPopIntegrationTestSupport.ConfigureBrokerAssignedPop(options, consumerGroup, scope.Topic, tag);
+            BrokerAssignedPopIntegrationTestSupport.ConfigureBrokerAssignedPop(
+                options,
+                consumerGroup,
+                scope.Topic,
+                tag);
             options.PopBatchSize = 1;
             options.ConsumeMessageBatchSize = 1;
         }, (messages, context, _) =>
@@ -62,10 +66,16 @@ public sealed class RocketMQBrokerAssignedPopDeadLetterIntegrationTests(
                     return ValueTask.FromResult(ConsumeResult.Success);
                 }
 
-                Interlocked.Increment(ref deliveryCount);
-                deadLetterRequested.TrySetResult();
-                context.DelayLevelWhenNextConsume = -1;
-                return ValueTask.FromResult(ConsumeResult.Retry);
+                var attempt = Interlocked.Increment(ref deliveryCount);
+                if (attempt == 1)
+                {
+                    firstAttempt.TrySetResult();
+                    context.DelayLevelWhenNextConsume = -1;
+                    return ValueTask.FromResult(ConsumeResult.Retry);
+                }
+
+                redelivered.TrySetResult(message);
+                return ValueTask.FromResult(ConsumeResult.Success);
             });
 
         await using var provider = services.BuildServiceProvider(
@@ -89,26 +99,21 @@ public sealed class RocketMQBrokerAssignedPopDeadLetterIntegrationTests(
             var sent = await producer.SendAsync(
                 new Message(scope.Topic, Encoding.UTF8.GetBytes(body)) { Tag = tag },
                 cancellationToken);
-            await deadLetterRequested.Task.WaitAsync(
+            await firstAttempt.Task.WaitAsync(
                 BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
                 cancellationToken);
-            await BrokerAssignedPopIntegrationTestSupport.WaitUntilAsync(
-                async () => (await fixture.GetTopicListAsync(cancellationToken)).Contains(
-                    deadLetterTopic,
-                    StringComparison.Ordinal),
+            var redeliveredMessage = await redelivered.Task.WaitAsync(
                 BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
                 cancellationToken);
 
-            var deadLetter = await ConsumeDeadLetterAsync(
-                fixture,
-                scope,
-                deadLetterTopic,
-                body,
-                cancellationToken);
-            Assert.Equal(scope.Topic, deadLetter.Topic);
-            Assert.Equal(body, Encoding.UTF8.GetString(deadLetter.Body));
+            Assert.Equal(sent.MessageId, redeliveredMessage.MessageId);
+            Assert.Equal(scope.Topic, redeliveredMessage.Topic);
+            Assert.Equal(body, Encoding.UTF8.GetString(redeliveredMessage.Body));
+            Assert.Equal("broker-a", redeliveredMessage.BrokerName);
+            Assert.True(redeliveredMessage.QueueId >= 0);
+            Assert.True(redeliveredMessage.DeliveryAttempt >= 2);
             await settlements.WaitForAsync(
-                "reject",
+                "nack",
                 scope.Topic,
                 consumerGroup,
                 1,
@@ -123,7 +128,12 @@ public sealed class RocketMQBrokerAssignedPopDeadLetterIntegrationTests(
                 BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
                 cancellationToken,
                 sent.MessageId);
-            Assert.Equal(1, Volatile.Read(ref deliveryCount));
+            Assert.Equal(0, settlements.Count("reject", scope.Topic, consumerGroup, sent.MessageId));
+            Assert.Equal(2, Volatile.Read(ref deliveryCount));
+            Assert.DoesNotContain(
+                deadLetterTopic,
+                await fixture.GetTopicListAsync(cancellationToken),
+                StringComparison.Ordinal);
         }
         finally
         {
@@ -132,53 +142,5 @@ public sealed class RocketMQBrokerAssignedPopDeadLetterIntegrationTests(
         }
     }
 
-    private static async Task<RemotingMessageView> ConsumeDeadLetterAsync(
-        RocketMQSingleBrokerContainerFixture fixture,
-        RocketMQTestScope scope,
-        string deadLetterTopic,
-        string expectedBody,
-        CancellationToken cancellationToken)
-    {
-        var services = new ServiceCollection();
-        services
-            .AddRocketMQRemoting(options => options.NamesrvAddr = fixture.NameServerAddress)
-            .AddRemotingLitePullConsumer(options =>
-            {
-                options.GroupName = scope.CreateConsumerGroupName("remoting-dead-letter-observer");
-                options.InitialPosition = ConsumeFromPosition.Beginning;
-                options.EnableAutoCommit = false;
-                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
-                options.PollTimeout = TimeSpan.FromSeconds(2);
-                options.Subscribe(deadLetterTopic);
-            });
-
-        await using var provider = services.BuildServiceProvider(
-            new ServiceProviderOptions { ValidateOnBuild = true });
-        var observer = provider.GetRequiredService<IRemotingLitePullConsumer>();
-        await observer.StartAsync(cancellationToken);
-        try
-        {
-            var deadline = DateTimeOffset.UtcNow + BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout;
-            do
-            {
-                var messages = await observer.PollAsync(cancellationToken: cancellationToken);
-                var matching = messages.SingleOrDefault(message =>
-                    Encoding.UTF8.GetString(message.Body) == expectedBody);
-                if (matching is not null)
-                {
-                    await observer.CommitAsync(cancellationToken);
-                    return matching;
-                }
-            }
-            while (DateTimeOffset.UtcNow < deadline);
-
-            throw new TimeoutException($"No matching message was consumed from dead-letter topic '{deadLetterTopic}'.");
-        }
-        finally
-        {
-            await observer.StopAsync(CancellationToken.None);
-        }
-    }
-
-    private sealed record DeadLetterConsumerMarker;
+    private sealed record NegativeDelayConsumerMarker;
 }

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/Consumer/Push/Pull/RocketMQPushPullDeadLetterIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/Consumer/Push/Pull/RocketMQPushPullDeadLetterIntegrationTests.cs
@@ -1,0 +1,271 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
+using EventHorizon.RocketMQ.Remoting.Consumer;
+using EventHorizon.RocketMQ.Remoting.Consumer.LitePull;
+using EventHorizon.RocketMQ.Remoting.Consumer.Push;
+using EventHorizon.RocketMQ.Remoting.Consumer.Push.Assignment;
+using EventHorizon.RocketMQ.Remoting.IntegrationTests.Consumer.Push.Pop.Support;
+using EventHorizon.RocketMQ.Remoting.Producer;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EventHorizon.RocketMQ.Remoting.IntegrationTests.Consumer.Push.Pull;
+
+public sealed class RocketMQPushPullDeadLetterIntegrationTests(
+    RocketMQSingleBrokerContainerFixtureRegistry registry)
+{
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task PushPullConsumer_HandlerRequestsNegativeDelay_ForwardsToDeadLetterQueue()
+    {
+        await RunDeadLetterWorkflowAsync(
+            DeadLetterScenario.Explicit,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task PushPullConsumer_ConcurrentRetryFailsAgain_ForwardsToDeadLetterQueue()
+    {
+        await RunDeadLetterWorkflowAsync(
+            DeadLetterScenario.ConcurrentRetryExhausted,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task PushPullConsumer_MessageGroupRetryFailsAgain_ForwardsToDeadLetterQueue()
+    {
+        await RunDeadLetterWorkflowAsync(
+            DeadLetterScenario.MessageGroupRetryExhausted,
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task PushPullConsumer_OrderlyRetryFailsAgain_ForwardsToDeadLetterQueue()
+    {
+        await RunDeadLetterWorkflowAsync(
+            DeadLetterScenario.OrderlyRetryExhausted,
+            TestContext.Current.CancellationToken);
+    }
+
+    private async Task RunDeadLetterWorkflowAsync(
+        DeadLetterScenario scenario,
+        CancellationToken cancellationToken)
+    {
+        using var settlements = new RemotingSettlementObserver();
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var role = scenario switch
+        {
+            DeadLetterScenario.Explicit => "direct",
+            DeadLetterScenario.ConcurrentRetryExhausted => "concurrent",
+            DeadLetterScenario.MessageGroupRetryExhausted => "message-group",
+            DeadLetterScenario.OrderlyRetryExhausted => "orderly",
+            _ => throw new ArgumentOutOfRangeException(nameof(scenario))
+        };
+        var topicType = scenario == DeadLetterScenario.MessageGroupRetryExhausted
+            ? RocketMQTestTopicType.Fifo
+            : RocketMQTestTopicType.Normal;
+        var scope = await fixture.CreateTestScopeAsync(topicType, cancellationToken);
+        var consumerGroup = scope.CreateConsumerGroupName($"remoting-push-pull-dlq-{role}");
+        var deadLetterTopic = $"%DLQ%{consumerGroup}";
+        var tag = $"remoting-push-pull-dlq-{role}-{Guid.NewGuid():N}";
+        var body = $"remoting-push-pull-dlq-{role}-{Guid.NewGuid():N}";
+        var expectedDeliveryCount = scenario == DeadLetterScenario.Explicit ? 1 : 2;
+        var terminalAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var deliveryCount = 0;
+        var services = new ServiceCollection();
+        var rocketMQ = services.AddRocketMQRemoting(options =>
+        {
+            options.NamesrvAddr = fixture.NameServerAddress;
+            options.InstanceName = $"remoting-push-pull-dlq-{role}-{Guid.NewGuid():N}";
+        });
+        rocketMQ.AddRemotingProducer(options =>
+            options.GroupName = scope.CreateProducerGroupName($"remoting-push-pull-dlq-{role}-producer"));
+        rocketMQ.AddRemotingPushConsumerWithTestHandler<DeadLetterConsumerMarker>(options =>
+        {
+            options.GroupName = consumerGroup;
+            options.InitialPosition = ConsumeFromPosition.Beginning;
+            options.PullBatchSize = 1;
+            options.ConsumeMessageBatchSize = 1;
+            options.MaxConcurrency = 1;
+            options.MaxDeliveryAttempts = expectedDeliveryCount;
+            options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+            options.RetryDelay = TimeSpan.FromMilliseconds(100);
+            options.ConsumeOrderly = scenario == DeadLetterScenario.OrderlyRetryExhausted;
+            options.Subscribe(scope.Topic, new FilterExpression(tag));
+        }, (messages, context, _) =>
+            {
+                var message = Assert.Single(messages);
+                if (Encoding.UTF8.GetString(message.Body) != body)
+                {
+                    return ValueTask.FromResult(ConsumeResult.Success);
+                }
+
+                if (Interlocked.Increment(ref deliveryCount) == expectedDeliveryCount)
+                {
+                    terminalAttempt.TrySetResult();
+                }
+
+                context.DelayLevelWhenNextConsume = scenario switch
+                {
+                    DeadLetterScenario.Explicit => -1,
+                    DeadLetterScenario.ConcurrentRetryExhausted => 1,
+                    _ => 0
+                };
+                return ValueTask.FromResult(ConsumeResult.Retry);
+            });
+
+        await using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IRemotingProducer>();
+        var consumer = provider.GetRequiredService<IRemotingPushConsumer>();
+        await producer.StartAsync(cancellationToken);
+        await consumer.StartAsync(cancellationToken);
+        try
+        {
+            var pushConsumer = Assert.IsType<RemotingPushConsumer>(consumer);
+            await BrokerAssignedPopIntegrationTestSupport.WaitUntilAsync(
+                () => Task.FromResult(pushConsumer.ReceiveAssignments.Any(assignment =>
+                    string.Equals(assignment.Topic, scope.Topic, StringComparison.Ordinal) &&
+                    assignment.Mode == RemotingPushReceiveMode.Pull)),
+                BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
+                cancellationToken);
+
+            var sent = await producer.SendAsync(new Message(scope.Topic, Encoding.UTF8.GetBytes(body))
+            {
+                Tag = tag,
+                MessageGroup = scenario == DeadLetterScenario.MessageGroupRetryExhausted
+                    ? $"remoting-push-pull-dlq-{Guid.NewGuid():N}"
+                    : null
+            }, cancellationToken);
+            await terminalAttempt.Task.WaitAsync(
+                BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
+                cancellationToken);
+            if (scenario == DeadLetterScenario.ConcurrentRetryExhausted)
+            {
+                await settlements.WaitForAsync(
+                    "nack",
+                    scope.Topic,
+                    consumerGroup,
+                    1,
+                    BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
+                    cancellationToken,
+                    sent.MessageId);
+            }
+
+            await settlements.WaitForAsync(
+                "reject",
+                scope.Topic,
+                consumerGroup,
+                1,
+                BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
+                cancellationToken,
+                sent.MessageId);
+            await BrokerAssignedPopIntegrationTestSupport.WaitUntilAsync(
+                async () => (await fixture.GetTopicListAsync(cancellationToken)).Contains(
+                    deadLetterTopic,
+                    StringComparison.Ordinal),
+                BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
+                cancellationToken);
+
+            var deadLetter = await ConsumeDeadLetterAsync(
+                fixture,
+                scope,
+                deadLetterTopic,
+                body,
+                cancellationToken);
+            Assert.Equal(scope.Topic, deadLetter.Topic);
+            Assert.Equal(body, Encoding.UTF8.GetString(deadLetter.Body));
+            var commit = await fixture.WaitForConsumerCommitAsync(
+                consumerGroup,
+                scope.Topic,
+                sent.MessageQueue.BrokerName,
+                sent.MessageQueue.QueueId,
+                BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout,
+                cancellationToken);
+            Assert.True(commit.Committed, $"PULL dead-letter source offset was not committed. {commit.Progress}");
+            Assert.Equal(1, settlements.Count("reject", scope.Topic, consumerGroup, sent.MessageId));
+            Assert.Equal(expectedDeliveryCount, Volatile.Read(ref deliveryCount));
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private static async Task<RemotingMessageView> ConsumeDeadLetterAsync(
+        RocketMQSingleBrokerContainerFixture fixture,
+        RocketMQTestScope scope,
+        string deadLetterTopic,
+        string expectedBody,
+        CancellationToken cancellationToken)
+    {
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQRemoting(options => options.NamesrvAddr = fixture.NameServerAddress)
+            .AddRemotingLitePullConsumer(options =>
+            {
+                options.GroupName = scope.CreateConsumerGroupName("remoting-push-pull-dead-letter-observer");
+                options.InitialPosition = ConsumeFromPosition.Beginning;
+                options.EnableAutoCommit = false;
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+                options.PollTimeout = TimeSpan.FromSeconds(2);
+                options.Subscribe(deadLetterTopic);
+            });
+
+        await using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true });
+        var observer = provider.GetRequiredService<IRemotingLitePullConsumer>();
+        await observer.StartAsync(cancellationToken);
+        try
+        {
+            var deadline = DateTimeOffset.UtcNow + BrokerAssignedPopIntegrationTestSupport.DeliveryTimeout;
+            do
+            {
+                var messages = await observer.PollAsync(cancellationToken: cancellationToken);
+                var matching = messages.SingleOrDefault(message =>
+                    Encoding.UTF8.GetString(message.Body) == expectedBody);
+                if (matching is not null)
+                {
+                    await observer.CommitAsync(cancellationToken);
+                    return matching;
+                }
+            }
+            while (DateTimeOffset.UtcNow < deadline);
+
+            throw new TimeoutException($"No matching message was consumed from dead-letter topic '{deadLetterTopic}'.");
+        }
+        finally
+        {
+            await observer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private sealed record DeadLetterConsumerMarker;
+
+    private enum DeadLetterScenario
+    {
+        Explicit,
+        ConcurrentRetryExhausted,
+        MessageGroupRetryExhausted,
+        OrderlyRetryExhausted
+    }
+}

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/Assignment/RemotingPushConsumerBrokerAssignmentTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/Assignment/RemotingPushConsumerBrokerAssignmentTests.cs
@@ -585,9 +585,10 @@ public sealed class RemotingPushConsumerBrokerAssignmentTests : RemotingPushCons
     }
 
     [Fact]
-    public async Task BrokerAssignedPop_HandlerSelectsNegativeRetryDelay_ForwardsToDeadLetterWithoutChangingInvisibleTime()
+    public async Task BrokerAssignedPop_HandlerSelectsNegativeRetryDelay_UsesDefaultPopRetrySchedule()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
+        var settlementAttempted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var remoting = new FakeRemotingClient(BrokerAssignmentClientId)
         {
             QueryAssignmentHandler = static (request, _) => Task.FromResult(
@@ -595,7 +596,20 @@ public sealed class RemotingPushConsumerBrokerAssignmentTests : RemotingPushCons
                     ? AssignmentResponse("orders", -1, "POP")
                     : EmptyAssignmentResponse()),
             PopHandler = ReceiveOnePopThenWait(CreatePopSuccessResponse(invisibleTimeMilliseconds: 5_000)),
-            SendBackHandler = static (_, _) => Task.FromResult(BrokerSuccess()),
+            ChangeInvisibleHandler = (_, _) =>
+            {
+                settlementAttempted.TrySetResult();
+                return Task.FromResult(
+                    ChangeInvisibleTimeResponse(
+                        PopTimeMilliseconds + 1_000,
+                        invisibleTimeMilliseconds: 10_000,
+                        reviveQueueId: 4));
+            },
+            SendBackHandler = (_, _) =>
+            {
+                settlementAttempted.TrySetResult();
+                return Task.FromResult(BrokerSuccess());
+            },
             AckHandler = static (_, _) => Task.FromResult(BrokerSuccess())
         };
         var options = CreateBrokerAssignmentOptions(static (_, context, _) =>
@@ -606,18 +620,15 @@ public sealed class RemotingPushConsumerBrokerAssignmentTests : RemotingPushCons
         await using var consumer = CreateBrokerAssignmentConsumer(options, remoting);
 
         await consumer.StartAsync(cancellationToken);
-        await WaitForBrokerRequestAsync(remoting, RequestCode.AckMessage, cancellationToken);
+        await settlementAttempted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
 
-        Assert.Equal(
-            [RequestCode.ConsumerSendMsgBack, RequestCode.AckMessage],
-            remoting.Requests
-                .Where(static request =>
-                    request.Code is RequestCode.ConsumerSendMsgBack or RequestCode.AckMessage)
-                .Select(static request => request.Code)
-                .ToArray());
-        Assert.DoesNotContain(
+        var change = Assert.Single(
             remoting.Requests,
             static request => request.Code == RequestCode.ChangeMessageInvisibleTime);
+        Assert.Equal(false, change.ExtFields["suspend"]);
+        Assert.Equal(10_000L, Convert.ToInt64(change.ExtFields["invisibleTime"]));
+        Assert.DoesNotContain(remoting.Requests, static request =>
+            request.Code is RequestCode.ConsumerSendMsgBack or RequestCode.AckMessage);
     }
 
     [Fact]
@@ -739,8 +750,11 @@ public sealed class RemotingPushConsumerBrokerAssignmentTests : RemotingPushCons
         }
     }
 
-    [Fact]
-    public async Task BrokerAssignedPop_RetryChangeInvisibleResponseIsUncertain_DoesNotRetryOldReceipt()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task BrokerAssignedPop_RetryChangeInvisibleResponseIsUncertain_DoesNotRetryOldReceipt(
+        int delayLevelWhenNextConsume)
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var firstChangeAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -767,8 +781,11 @@ public sealed class RemotingPushConsumerBrokerAssignmentTests : RemotingPushCons
                     ChangeInvisibleTimeResponse(PopTimeMilliseconds + 1_000, invisibleTimeMilliseconds: 5_000, reviveQueueId: 4));
             }
         };
-        var options = CreateBrokerAssignmentOptions(
-            static (_, _, _) => ValueTask.FromResult(ConsumeResult.Retry));
+        var options = CreateBrokerAssignmentOptions((_, context, _) =>
+        {
+            context.DelayLevelWhenNextConsume = delayLevelWhenNextConsume;
+            return ValueTask.FromResult(ConsumeResult.Retry);
+        });
         await using var consumer = CreateBrokerAssignmentConsumer(options, remoting);
 
         await consumer.StartAsync(cancellationToken);
@@ -777,6 +794,8 @@ public sealed class RemotingPushConsumerBrokerAssignmentTests : RemotingPushCons
         await Assert.ThrowsAsync<TimeoutException>(() =>
             secondChangeAttempt.Task.WaitAsync(TimeSpan.FromMilliseconds(500), cancellationToken));
         Assert.Equal(1, Volatile.Read(ref changeAttempts));
+        Assert.DoesNotContain(remoting.Requests, static request =>
+            request.Code is RequestCode.ConsumerSendMsgBack or RequestCode.AckMessage);
     }
 
     [Fact]
@@ -858,51 +877,6 @@ public sealed class RemotingPushConsumerBrokerAssignmentTests : RemotingPushCons
             TimeSpan.FromSeconds(1),
             cancellationToken);
         Assert.Equal(43L, Convert.ToInt64(acknowledgement.ExtFields["offset"]));
-    }
-
-    [Fact]
-    public async Task BrokerAssignedPop_DeadLetterAckFails_RetriesAckWithoutForwardingAgain()
-    {
-        var cancellationToken = TestContext.Current.CancellationToken;
-        var acknowledgementAttempts = 0;
-        var acknowledgementRetried = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var remoting = new FakeRemotingClient(BrokerAssignmentClientId)
-        {
-            QueryAssignmentHandler = static (request, _) => Task.FromResult(
-                AssignmentQueryTopic(request) == "orders"
-                    ? AssignmentResponse("orders", -1, "POP")
-                    : EmptyAssignmentResponse()),
-            PopHandler = ReceiveOnePopThenWait(CreatePopSuccessResponse(invisibleTimeMilliseconds: 2_000)),
-            SendBackHandler = static (_, _) => Task.FromResult(BrokerSuccess()),
-            AckHandler = (_, _) =>
-            {
-                if (Interlocked.Increment(ref acknowledgementAttempts) == 1)
-                {
-                    return Task.FromException<RemotingCommand>(
-                        new InvalidOperationException("dead-letter acknowledgement failed"));
-                }
-
-                acknowledgementRetried.TrySetResult();
-                return Task.FromResult(BrokerSuccess());
-            }
-        };
-        var options = CreateBrokerAssignmentOptions(static (_, context, _) =>
-        {
-            context.DelayLevelWhenNextConsume = -1;
-            return ValueTask.FromResult(ConsumeResult.Retry);
-        });
-        await using var consumer = CreateBrokerAssignmentConsumer(options, remoting);
-
-        await consumer.StartAsync(cancellationToken);
-        await acknowledgementRetried.Task.WaitAsync(TimeSpan.FromSeconds(1), cancellationToken);
-
-        Assert.Equal(
-            [RequestCode.ConsumerSendMsgBack, RequestCode.AckMessage, RequestCode.AckMessage],
-            remoting.Requests
-                .Where(static request =>
-                    request.Code is RequestCode.ConsumerSendMsgBack or RequestCode.AckMessage)
-                .Select(static request => request.Code)
-                .ToArray());
     }
 
     private static RemotingPushConsumerOptions CreateBrokerAssignmentOptions(


### PR DESCRIPTION
## Summary

- align classic Remoting POP retry settlement with the officially released Java client: a negative `DelayLevelWhenNextConsume` no longer performs classic send-back plus receipt ACK
- normalize the PULL-only negative sentinel to POP level `0`, then issue one `CHANGE_MESSAGE_INVISIBLETIME` request through the normal POP retry schedule
- add live dead-letter coverage for Remoting PULL concurrent, MessageGroup, and orderly exhaustion, plus gRPC FIFO Push, non-FIFO Push, and LitePush
- document the PULL/POP boundary, telemetry outcomes, and repository policy that released Java tags are primary references and released Go tags are secondary references

## Stable upstream baselines

- Java Remoting: `rocketmq-all-5.5.0` (primary)
- Java gRPC: `java-5.2.1` (primary)
- Go classic: `v2.1.2` (secondary)
- Go gRPC: `golang/v5.1.2` (secondary)

Java Remoting 5.5.0 has no PULL-style direct-DLQ branch in `ConsumeMessagePopConcurrentlyService`. It changes POP invisibility for ordinary failure and uses age-based defer-or-ACK handling after the configured maximum attempt. The .NET adapter intentionally normalizes a negative value to `0` instead of reproducing Java's invalid negative retry-table index if the PULL-only sentinel reaches POP.

Java gRPC 5.2.1 retries FIFO handlers locally and forwards to DLQ after attempts are exhausted; non-FIFO retry and DLQ progression remain service-owned. This PR does not change gRPC production behavior.

## Retry and DLQ coverage

| Workflow | Handler calls | Terminal result |
| --- | ---: | --- |
| Remoting PULL explicit `delay = -1` | 1 | immediate explicit DLQ send-back |
| Remoting PULL concurrent exhaustion | 2 | DLQ after one retry |
| Remoting PULL MessageGroup exhaustion | 2 | DLQ after one retry |
| Remoting PULL orderly exhaustion | 2 | DLQ after one retry |
| Remoting POP negative delay | 2 | redelivery then ACK; no DLQ |
| gRPC FIFO Push exhaustion | 2 | client forwards to DLQ |
| gRPC non-FIFO Push exhaustion | 2 | service moves to DLQ |
| gRPC LitePush exhaustion | 2 | service moves to DLQ |

Test consumer groups use a one-second customized Broker backoff, and client-owned local retry tests use 100 ms. The POP negative-delay regression retains Java's real first POP delay (10 seconds) because shortening it would test different semantics.

## Breaking change

Broker-assigned POP deliveries no longer interpret `DelayLevelWhenNextConsume < 0` as a direct dead-letter request. They normalize it to `0` and follow POP retry policy. Internal PULL behavior is unchanged.

## Verification

- `dotnet format EventHorizon.RocketMQ.slnx --no-restore`
- `dotnet restore EventHorizon.RocketMQ.slnx`
- `dotnet build EventHorizon.RocketMQ.slnx --no-restore` (0 warnings, 0 errors)
- gRPC unit tests: 206 passed
- Remoting unit tests: 601 passed
- compatibility tests: 27 passed
- gRPC integration tests: 15 passed
- Remoting integration tests: 41 passed
- focused LitePush DLQ integration test rerun: passed against RocketMQ 5.5.0

Tracks #25; the remaining SUSPEND differences stay open for separate design work.
