### PR TITLE
fix: align consumer retry lifecycle with stable Java

### DIFF
--- a/docs/en-US/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/en-US/architecture/dependency-injection-and-lifetimes.md
@@ -194,8 +194,8 @@ invoke their `IGrpcPushMessageHandler` for each message. Remoting Push invokes i
 `ConsumeMessageBatchSize` defaults to `1`, so existing settings retain singleton delivery unless configured
 otherwise. For a concurrent non-FIFO batch, a handler can return `Success` with `AckIndex` set to confirm a
 contiguous prefix and retry its tail; `Retry` remains a whole-batch outcome. A negative
-`DelayLevelWhenNextConsume` requests direct dead-lettering only on the internal PULL path; POP normalizes it to the
-default retry level.
+`DelayLevelWhenNextConsume` requests direct dead-lettering only on the concurrent internal PULL path; orderly PULL
+publishes to its retry topic and POP normalizes it to the default retry level.
 
 For non-FIFO gRPC Push and LitePush messages, `ConsumeTimeout` cancels the handler token and requests retry when the
 configured limit elapses. Receipt renewal while the handler is active belongs to the Proxy requested by `AutoRenew`,

--- a/docs/en-US/architecture/opentelemetry-instrumentation.md
+++ b/docs/en-US/architecture/opentelemetry-instrumentation.md
@@ -85,7 +85,7 @@ are preserved.
 | Producer send | All `IGrpcProducer` send paths, including transactional sends. | Standard, reply, batch, and one-way send paths. |
 | Consumer receive | Simple, Push, and LitePush receive engine. | LitePull receives and Push PULL/POP receivers. |
 | Automatic handler processing | Push and LitePush handlers. | Push handlers. |
-| Consumer settlement | Acknowledge, negative acknowledgement, and dead-letter forwarding. | LitePull and Push PULL offset commits, retry/dead-letter send-back, and internal Push POP acknowledgement and invisibility changes. |
+| Consumer settlement | Acknowledge, negative acknowledgement, and dead-letter forwarding. | LitePull and Push PULL offset commits, concurrent retry/dead-letter send-back, orderly `%RETRY%group` publication, and internal Push POP acknowledgement and invisibility changes. |
 
 For gRPC, Proxy-managed renewal requested by `ReceiveMessageRequest.AutoRenew` is not a separate client wire operation
 and must not create a client settlement span. A client-issued `ChangeInvisibleDuration` must be classified by intent:
@@ -96,9 +96,16 @@ shared receive engine keeps these intent-specific internal operations separate e
 Proxy-managed handler renewal creates no duplicate client timer, span, or metric. Result tags use fixed outcome names;
 the caller-selected duration is not a metric dimension.
 
+Each actual gRPC completion RPC attempt owns one settlement Activity and one metric completion. A failed attempt
+completes with an error before the fixed one-second retry wait; the later wire attempt creates a new operation. Waiting
+between attempts creates no telemetry because no RPC occurs. The logical retry sequence ends on success, caller or
+Consumer-run cancellation, or a terminal receipt error. ACK and invisibility-change `INVALID_RECEIPT_HANDLE` is terminal,
+whereas dead-letter forwarding retries it. This keeps an extended Proxy outage observable without one multi-minute span
+hiding the number and outcome of wire attempts.
+
 Classic Remoting instrumentation follows the wire-operation owner. `PullWireClient` owns receive completion for
 non-empty, empty, canceled, and failed PULL operations. `RemotingConsumerOffsetClient` owns commit settlement, while
-`RemotingSettlementClient` owns PULL retry and dead-letter send-back. `PopWireClient` continues to own POP receive,
+`RemotingSettlementClient` owns concurrent PULL retry/dead-letter send-back and orderly `%RETRY%group` publication. `PopWireClient` continues to own POP receive,
 acknowledgement, and invisibility-change telemetry. The role-level consumer engine only composes these clients; moving
 a responsibility between internal types must not duplicate or drop its Activity or metric completion.
 
@@ -113,8 +120,11 @@ valid.
 
 Classic orderly suspension is a local scheduler decision. Each handler invocation still owns one process Activity,
 but the delay between attempts creates no settlement Activity or metric because no wire operation occurs. At the
-terminal limit, clustering and broadcasting each record a `reject` settlement attempt. If it fails, the next local
-suspension creates no additional settlement signal; the later send-back attempt records a new `reject` operation.
+terminal limit, clustering and broadcasting each record a `reject` operation for publication to `%RETRY%group` through
+the internal producer path. That logical settlement performs up to three immediate wire send attempts; a successful
+retry-topic publication lets the Broker redirect the message to DLQ when its reconsume count exceeds the supplied
+maximum. If publication fails, the next local suspension creates no additional settlement signal and the message is
+retried locally.
 
 Activities use OpenTelemetry messaging semantic-convention attributes such as `messaging.system`,
 `messaging.destination.name`, `messaging.consumer.group.name`, message ID, partition ID, body size, and batch size.

--- a/docs/en-US/architecture/protocol-boundaries.md
+++ b/docs/en-US/architecture/protocol-boundaries.md
@@ -61,14 +61,16 @@ The small foundational models are declared separately in each protocol namespace
 gRPC Push and LitePush follow the released Apache Java gRPC listener contract and expose `Success`, `Failure`, and a
 duration-bearing `Suspend`. Regular Push normalizes Suspend to Failure. Non-FIFO LitePush sends Failure and Suspend
 through service-owned retry/DLQ progression and ignores the Suspend duration. FIFO LitePush uses the protocol's
-caller-duration suspend operation; FIFO failures retry locally and attempt internal dead-letter forwarding. If that
-forwarding completion fails, the message remains unsettled and may be redelivered.
+caller-duration suspend operation; FIFO failures retry locally and use client-owned dead-letter forwarding. Completion
+RPCs retry at a fixed one-second interval; ACK and invisibility-change `INVALID_RECEIPT_HANDLE` is terminal, while DLQ
+forwarding retries it. FIFO successors wait during completion retry and are released after a terminal completion failure.
 Classic Remoting follows the concurrent callback model shared by the
 [Java client](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyStatus.java)
 and the
 [Go client](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/consumer.go#L197-L205):
 it exposes `Success` and `Retry`. A negative `RemotingPushConsumeContext.DelayLevelWhenNextConsume` requests direct
-dead-lettering only on the internal PULL path; POP normalizes it to the default retry level. Compatibility tests lock
+dead-lettering only on the concurrent internal PULL path; orderly PULL publishes to its retry topic and POP normalizes
+the value to the default retry level. Compatibility tests lock
 each protocol's independently owned result shape. The gRPC result is an immutable value object because one outcome
 carries a duration; the Remoting result remains its independently owned two-member enum.
 

--- a/docs/en-US/grpc/consumer-model.md
+++ b/docs/en-US/grpc/consumer-model.md
@@ -131,13 +131,22 @@ message fields:
 | Client mode | `Failure` | `Suspend(duration)` |
 | --- | --- | --- |
 | Regular non-FIFO Push | Change invisibility using the effective retry policy; the service owns retry and dead-letter progression. | Convert to `Failure`; ignore the requested duration. |
-| Regular FIFO Push | Retry the handler locally, then the client attempts DLQ forwarding after exhaustion. A failed forwarding completion leaves the message unsettled for possible redelivery. | Convert to `Failure`; ignore the requested duration. |
+| Regular FIFO Push | Retry the handler locally, then the client forwards to DLQ after exhaustion. Completion retries continue at one-second intervals; a terminal completion failure leaves the message unsettled for possible redelivery. | Convert to `Failure`; ignore the requested duration. |
 | Non-FIFO LitePush | Change invisibility using the effective retry policy; the service owns retry and dead-letter progression. | Follow the same retry-policy NACK path as `Failure`; ignore the requested duration. |
-| FIFO LitePush | Retry the handler locally, then the client attempts DLQ forwarding after exhaustion. A failed forwarding completion leaves the message unsettled for possible redelivery. The FIFO key is `LiteTopic`. | Suspend the current message and every unprocessed same-`LiteTopic` message from the same receive batch without invoking those sibling handlers; other LiteTopics continue. |
+| FIFO LitePush | Retry the handler locally, then the client forwards to DLQ after exhaustion. Completion retries continue at one-second intervals; a terminal completion failure leaves the message unsettled for possible redelivery. The FIFO key is `LiteTopic`. | Suspend the current message and every unprocessed same-`LiteTopic` message from the same receive batch without invoking those sibling handlers; other LiteTopics continue. |
 
 The server's FIFO setting remains authoritative when the optional `MessageGroup` or `LiteTopic` field is absent. Such
 messages use a physical-queue fallback key, matching Java's null FIFO group, rather than falling back to non-FIFO
 settlement. For FIFO LitePush, unkeyed siblings in the same receive batch therefore share the suspend decision.
+
+Client-issued acknowledgement, retry-policy NACK, FIFO LitePush suspension, and FIFO dead-letter forwarding remain
+pending across completion failures while their retry is in progress. The receive engine retries every failed completion
+RPC at a fixed one-second interval until it succeeds or the caller/Consumer lifecycle cancels it. `INVALID_RECEIPT_HANDLE`
+is terminal for acknowledgement and invisibility changes because retrying the same stale receipt cannot settle the
+message; dead-letter forwarding retries that status as well. Each FIFO successor waits while its predecessor's completion
+is retrying. When a completion ends with a terminal failure, the current message remains unsettled but its order key is
+released so the successor can run, matching the released Java client; retry-in-progress is the only FIFO blocking phase.
+Stopping the Consumer cancels pending completion retries and does not synthesize successful settlement.
 
 This matches the released Java `java-5.2.1` split between
 [`StandardConsumeService`](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/StandardConsumeService.java),

--- a/docs/en-US/remoting/consumer-model.md
+++ b/docs/en-US/remoting/consumer-model.md
@@ -144,7 +144,7 @@ organized by ownership rather than by a generic Consumer base class:
 | `Coordination/Rebalance` | Shared client-rebalance scheduling, registration, wakeup, and the deterministic average queue allocator. |
 | `Pull` | Stateless internal PULL request/response contracts and wire execution used by LitePull and Push PULL receivers; each pull receives its filter from the current receive target. |
 | `Offset` | Internal queue-position queries and consumer-group offset persistence. |
-| `Settlement` | Classic `CONSUMER_SEND_MSG_BACK` execution used by Push PULL retry and retry-topic offset initialization. |
+| `Settlement` | Classic `CONSUMER_SEND_MSG_BACK` execution for concurrent Push PULL retry and retry-topic offset initialization, plus orderly `%RETRY%group` publication. |
 | `LitePull` and `Push` | The two public role facades and their role-specific assignment, receive, dispatch, and run state. |
 
 The protocol composition root still creates one `IRemotingConsumerEngine` per registered role. The engine owns only
@@ -375,8 +375,8 @@ DI.
 | `Pull/Dispatch/PullProcessQueue` | One physical PULL queue's cached messages, pull/commit positions, contiguous completion watermark, settlement retry state, and FIFO barriers under one synchronization boundary. | Consumer-wide scheduling or wire I/O. |
 | `Pull/Receive/ConcurrentPullReceiveLoop` | One concurrent PULL assignment's long polling with its target filter, cache admission, and serialized offset-persistence loop. | Application-handler results or send-back. |
 | `Pull/Dispatch/PullConsumeRequestProcessor` | Concurrent handler-result mapping, queue-local completion, and activation of stored local settlement retries. | Receive polling, retry-topic preparation, send-back execution, or orderly Broker-lock handling. |
-| `Pull/Settlement/PullSendBackSettlement` | Retry-topic preparation, send-back execution, and retry-queue offset initialization. | Local settlement retry state or scheduling, receive polling, handler-result mapping, or queue-local completion. |
-| `Pull/Receive/OrderlyPullReceiveLoop` | Broker-lock validation, target-filtered long polling, serial handler retry, send-back, and inline offset persistence for orderly consumption. | Concurrent `PullProcessQueue` dispatch. |
+| `Pull/Settlement/PullSendBackSettlement` | Retry-topic preparation, concurrent send-back execution, orderly `%RETRY%group` publication, and retry-queue offset initialization. | Local settlement retry state or scheduling, receive polling, handler-result mapping, or queue-local completion. |
+| `Pull/Receive/OrderlyPullReceiveLoop` | Broker-lock validation, target-filtered long polling, serial handler retry, `%RETRY%group` publication, and inline offset persistence for orderly consumption. | Concurrent `PullProcessQueue` dispatch. |
 | `Pull/Offset/PullOffsetManager` | PULL initial and committed offsets, broadcasting storage, reset boundaries, and retry-topic initialization boundaries. | POP progress. |
 | `Pull/Receive/PullAssignmentReceiver` | One PULL assignment's identity, cancellation, observed Broker-lock lease, and completion boundary for its receive loop plus active consume requests. | POP wire operations or handler-result policy. |
 | `Pop/PopAssignmentReceiver` | One POP assignment's target-filtered long polling, receive batching, cancellation, and receive-failure isolation. | Handler invocation, receipt lifetime, or settlement. |
@@ -468,10 +468,16 @@ consumer result model:
   clamped to Java's 10-millisecond through 30-second scheduling range. A fresh context is created for every attempt,
   so an override applies only to the next local retry. Concurrent PULL, POP, and `MessageGroup` paths cannot consume
   the value.
-- A clustered PULL `Retry` and an orderly broadcasting `Retry` that reach `MaxDeliveryAttempts` make the client attempt
-  classic send-back into the dead-letter queue. An orderly send-back failure retains the current message, waits for that
-  attempt's suspension duration, and invokes the handler again without advancing the offset. Concurrent broadcasting
-  still has no Broker retry or dead-letter ownership and drops an unsuccessful tail. A POP `Retry` at the same limit
+- A clustered concurrent PULL `Retry` that reaches `MaxDeliveryAttempts` makes the client attempt classic send-back
+  into the dead-letter queue. Orderly PULL uses the separate zero-based `OrderlyMaxReconsumeTimes`: `-1` is the default
+  effectively unbounded Java behavior, `0` publishes after the first failure, and a positive value permits that many
+  local reconsumes before publication. This applies to both clustering and orderly broadcasting. At exhaustion the
+  client constructs a `%RETRY%<group>` message through internal producer semantics with reconsume, maximum, and delay
+  metadata, then performs up to three immediate wire send attempts for each logical terminal settlement. A successful
+  publication lets the Broker redirect the retry-topic message to DLQ when its reconsume count exceeds the maximum.
+  If publication fails, the current message remains local, increments its reconsume count, waits for that attempt's
+  suspension duration, and invokes the handler again without advancing the offset. Concurrent broadcasting still has no Broker
+  retry or dead-letter ownership and drops an unsuccessful tail. A POP `Retry` at `MaxDeliveryAttempts`
   follows the Java client's `checkNeedAckOrDelay` path instead: it never performs implicit dead-letter send-back. While
   the message age is at most twice the final POP
   delay, the client makes one
@@ -488,27 +494,31 @@ and the classic Go client's
 PULL passes the level to classic send-back. For POP, the adapter normalizes a negative value to level `0`, then maps the
 resulting level through Java's POP-specific retry schedule; `0` selects that schedule by the zero-based reconsume count
 (`DeliveryAttempt - 1`). This schedule starts at 10 seconds and is distinct from the normal delayed-message level table.
-Direct dead-lettering remains a classic PULL-only send-back behavior; the client attempts the send-back and leaves the
-offset unresolved if completion fails, so the message may be redelivered. POP retry never interprets a negative value as a
-direct dead-letter request.
+Direct dead-lettering remains a concurrent classic PULL-only send-back behavior; orderly PULL uses its internal retry-topic
+publication instead, and POP retry never interprets a negative value as a direct dead-letter request. A failed concurrent
+PULL send-back leaves the offset unresolved, so the message may be redelivered.
 
-The orderly duration contract follows released Java `rocketmq-all-5.5.0`
+The orderly retry and duration contract follows released Java `rocketmq-all-5.5.0`
 [`ConsumeOrderlyContext`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeOrderlyContext.java)
-and its 1-second consumer default. Both clustering and broadcasting orderly consumers perform local suspension and
-attempt DLQ send-back after this client's configured delivery limit. If terminal send-back fails, the current message
-remains local and uses the current attempt's suspension duration before the handler runs again. If a handler throws after setting
+and [`ConsumeMessageOrderlyService`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java).
+Both clustering and broadcasting orderly consumers perform local suspension and publish to `%RETRY%<group>` after a finite
+`OrderlyMaxReconsumeTimes` is exhausted. The publication carries reconsume, maximum, and delay metadata and uses up to
+three immediate wire send attempts for each logical terminal settlement; the Broker redirects a successfully published
+message to DLQ when its reconsume count exceeds the maximum. If publication fails, the current message remains local and uses the
+current attempt's suspension duration before the handler runs again. If a handler throws after setting
 `SuspendCurrentQueueDuration`, the current attempt retains that override, matching released Java 5.5.0 behavior; an
 unset value uses the configured orderly default. Cancellation ends the local wait without settlement. Queue-lock loss is observed after the current
 timer completes and before another handler attempt; matching Java's scheduled retry, it does not wake an
 already-running timer. The wait itself is client scheduling and therefore creates no ACK, NACK, reject, or commit
-settlement operation. A failed dead-letter send-back records its own failed settlement operation; the following local
+settlement operation. A failed retry-topic publication records its own failed settlement operation; the following local
 wait does not.
 
-Java orderly consumption defaults to effectively unbounded retries when `maxReconsumeTimes` is `-1` and increments its
-mutable message retry count before another handler call. This client retains its explicit one-based
-`MaxDeliveryAttempts` default of 16 and leaves `RemotingMessageView.DeliveryAttempt` as the immutable Broker-reported
-value while tracking local attempts internally. These are intentional .NET API differences; suspension timing,
-physical-queue isolation, terminal send-back, and send-back failure recovery follow the released Java design.
+`RemotingMessageView.ReconsumeTimes` exposes the same zero-based count as Java's mutable
+`MessageExt.reconsumeTimes`. It starts from the Broker header and increments before every orderly local reconsume,
+including a retry after failed retry-topic publication, so the next handler invocation observes the updated value.
+`RemotingMessageView.DeliveryAttempt` remains the immutable one-based Broker delivery (`ReconsumeTimes + 1` at decode
+time) and is not rewritten by local orderly scheduling. Concurrent PULL, POP, and `MessageGroup` continue to use
+`MaxDeliveryAttempts`; the orderly `-1` sentinel never changes their retry or terminal policy.
 
 POP does not renew a receipt while its handler is active. The client checks the fixed invisible deadline before handler
 processing and again before settlement. If the deadline has passed, the late handler result is ignored and the Broker

--- a/docs/en-US/remoting/transport-and-client-roles.md
+++ b/docs/en-US/remoting/transport-and-client-roles.md
@@ -108,10 +108,13 @@ same Broker physical queue can be grouped and those batches can run in parallel 
 `Success` normally confirms the complete batch. A concurrent non-FIFO handler can set `AckIndex` to the zero-based
 index of the final accepted message before returning `Success`; the client confirms that contiguous prefix and retries
 only its tail. `Retry` applies to every message regardless of `AckIndex`. The context also exposes
-`DelayLevelWhenNextConsume` for the failed batch or unacknowledged tail: for PULL reception, `0` delegates retry timing
+`DelayLevelWhenNextConsume` for the failed batch or unacknowledged tail: for concurrent PULL reception, `0` delegates retry timing
 to the Broker, a positive value selects a RocketMQ delay level, and a negative value requests that the client attempt
 direct dead-lettering through PULL send-back. If that completion fails, the offset remains unresolved and the message may be
-redelivered. When a Push assignment uses POP, the .NET adapter normalizes a negative value to level `0` and follows the normal
+redelivered. Orderly PULL does not use this direct-DLQ option; after `OrderlyMaxReconsumeTimes` is exhausted it publishes a
+`%RETRY%group` message through internal producer semantics with reconsume, maximum, and delay metadata, making up to three immediate
+wire send attempts per logical terminal settlement. The Broker redirects a successfully published message to DLQ when its
+reconsume count exceeds the maximum. When a Push assignment uses POP, the .NET adapter normalizes a negative value to level `0` and follows the normal
 Java-compatible invisibility retry schedule, including for level `0`; POP never interprets a negative value as direct
 dead-lettering. This two-result contract matches the classic Java and Go concurrent consumers; dead-lettering is a
 retry-policy terminal choice rather than a separate handler result. Concurrent broadcasting does not have a Broker
@@ -169,8 +172,10 @@ readiness handshake. Integration tests must not use the default end position to 
 
 For orderly Push, a denied initial lock or a failed lock renewal leaves reconciliation incomplete so the participant
 retries it. The consumer never dispatches a queue until the Broker has granted its lock.
-Both clustering and broadcasting orderly delivery retry the current physical queue locally and attempt terminal DLQ
-send-back. A failed send-back keeps the current message and offset unresolved, then uses that attempt's suspension
+Both clustering and broadcasting orderly delivery retry the current physical queue locally and publish an exhausted message
+to `%RETRY%group` through internal producer semantics. The publication carries reconsume, maximum, and delay metadata and
+makes up to three immediate wire send attempts; the Broker redirects a successful publication to DLQ when its reconsume count
+exceeds the maximum. If publication fails, the current message and offset remain unresolved, then use that attempt's suspension
 duration before invoking the handler again.
 
 Members of one Push group must use identical topic/filter subscriptions, clustering or broadcasting mode, orderly

--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -59,12 +59,16 @@ Focused consumer-result unit coverage includes:
   caller duration with `suspend=true`, suspends unprocessed same-`LiteTopic` siblings in one receive batch, keeps other
   LiteTopics independent, and preserves FIFO behavior through the physical-queue fallback when `MessageGroup` or
   `LiteTopic` is absent;
-- gRPC local retry cancellation stops retry delays promptly, while completion failures leave the message unresolved,
-  preserve FIFO blocking, and cancel cleanly during shutdown;
-- Remoting orderly PULL clamps caller and configured suspension to 10 milliseconds through 30 seconds, resets the
-  per-invocation context, retains the current attempt's override when a handler throws, isolates one suspended physical
-  queue from its siblings, cancels waits on stop, attempts terminal send-back for clustering and broadcasting, and
-  retains the current message and suspension duration when send-back fails.
+- gRPC local retry cancellation stops retry delays promptly; each completion wire attempt retries at a fixed one-second
+  interval until success, caller cancellation, or Consumer stop and emits its own telemetry. Invalid receipt handles remain
+  terminal for ACK and invisibility changes, while DLQ forwarding retries them; FIFO successors wait only while completion
+  retry is in progress and are released after a terminal completion failure;
+- Remoting orderly PULL clamps caller and configured suspension to 10 milliseconds through 30 seconds, tracks the
+  zero-based `ReconsumeTimes` count against `OrderlyMaxReconsumeTimes` (`-1` means unlimited), resets the per-invocation
+  context, retains the current attempt's override when a handler throws, isolates one suspended physical queue from its
+  siblings, cancels waits on stop, publishes exhausted orderly messages to `%RETRY%group` through internal producer
+  semantics with up to three immediate wire attempts for each logical terminal settlement, and retains the current
+  message and suspension duration when publication fails.
 
 Test methods follow the
 [`MemberOrBehavior_Scenario_ExpectedOutcome` convention recommended by Microsoft](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices#naming-your-tests).
@@ -158,16 +162,19 @@ The gRPC DLQ integration suite has four workflows: regular FIFO Push, regular no
 FIFO LitePush. Each configures one retry at its owning boundary: FIFO uses `MaxDeliveryAttempts=2`, while non-FIFO
 groups use Broker `retryMaxTimes=1`; test retry intervals are 100 milliseconds. The suite verifies the DLQ message and
 the ownership split: regular and Lite non-FIFO progression is service-owned, while FIFO Push and FIFO LitePush use
-client attempts to forward to DLQ. A forwarding/completion failure is treated as unresolved rather than as an ACK.
+client attempts to forward to DLQ. Completion retries use the fixed one-second interval; a terminal completion failure is
+treated as unresolved rather than as an ACK, and releases the FIFO successor.
 The FIFO Lite suspend workflow separately requests exactly 250 milliseconds, verifies that redelivery is not early
 and that the receipt is replaced, and deliberately makes no numeric `DeliveryAttempt` assertion because that value is
 service-owned.
 
 The Remoting PULL DLQ integration suite covers direct negative-delay send-back plus concurrent, `MessageGroup` FIFO,
-clustered orderly, and broadcasting orderly retry exhaustion. Retry-exhaustion cases use one retry
-(`MaxDeliveryAttempts=2`) with a 100-millisecond retry delay; orderly delivery additionally exercises its short local
-queue suspension. Each workflow observes one reject and the DLQ message, then verifies the Broker-committed clustering
-offset or the persisted broadcasting offset while preserving the unresolved-on-failure contract.
+clustered orderly, and broadcasting orderly retry exhaustion. Concurrent and `MessageGroup` retry-exhaustion cases use
+one retry (`MaxDeliveryAttempts=2`) with a 100-millisecond retry delay. Orderly cases use
+`OrderlyMaxReconsumeTimes=1` (zero-based, one local retry after the initial failure) and set 50 milliseconds of local
+queue suspension. Each orderly workflow verifies the three-attempt `%RETRY%group` publication and the Broker's subsequent
+DLQ redirect, then verifies the Broker-committed clustering offset or the persisted broadcasting offset. Direct negative-delay
+DLQ remains concurrent PULL-only.
 
 Single-Broker runtime is treated as a measured test-design constraint. On commit `9ef119f`, the local Remoting filter
 `Topology!=MultiBroker` passed 29 tests in 167.7 seconds; approximately 44.6 seconds were shared fixture startup. Test

--- a/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
+++ b/docs/zh-CN/architecture/dependency-injection-and-lifetimes.md
@@ -201,8 +201,8 @@ gRPC Push 和 LitePush 会为每条消息调用 handler。Remoting Push 则通�
 `IRemotingPushMessageHandler` API，在每次批量回调中传入 `IReadOnlyList<RemotingMessageView>` 和
 `RemotingPushConsumeContext`；其 `ConsumeMessageBatchSize` 默认值为 `1`，因此除非显式配置，否则仍是
 单消息投递。对于并发、非 FIFO 批次，handler 可以返回 `Success` 并设置 `AckIndex`，以确认连续前缀并重试
-尾部；`Retry` 仍是整批结果。只有内部 PULL 路径会把负数 `DelayLevelWhenNextConsume` 解释为直接死信；POP 会将其
-归一化为默认重试级别。
+尾部；`Retry` 仍是整批结果。只有并发内部 PULL 路径会把负数 `DelayLevelWhenNextConsume` 解释为直接死信；orderly PULL
+会发布到 retry topic，POP 会将其归一化为默认重试级别。
 
 对于非 FIFO 的 gRPC Push 和 LitePush 消息，`ConsumeTimeout` 到期后会取消 handler token 并请求重新投递。handler
 执行期间的 receipt 续期由 `AutoRenew` 请求的 Proxy 负责，不属于 handler scope，也不由客户端定时器承担。

--- a/docs/zh-CN/architecture/opentelemetry-instrumentation.md
+++ b/docs/zh-CN/architecture/opentelemetry-instrumentation.md
@@ -78,7 +78,7 @@ listener 时才会注入上下文，并且不会覆盖消息中已有的传播�
 | Producer 发送 | 所有 `IGrpcProducer` 发送路径，包括事务消息发送。 | 普通、reply、batch 与 one-way 发送路径。 |
 | Consumer 接收 | Simple、Push 与 LitePush 的 receive engine。 | LitePull receive 与 Push 的 PULL/POP receiver。 |
 | 自动 handler 处理 | Push 与 LitePush handler。 | Push handler。 |
-| Consumer 完结操作 | 确认、负确认和转发死信。 | LitePull 与 Push PULL 位点提交、重试/死信 send-back，以及 Push 内部 POP 确认和不可见时间变更。 |
+| Consumer 完结操作 | 确认、负确认和转发死信。 | LitePull 与 Push PULL 位点提交、并发重试/死信 send-back、orderly `%RETRY%group` 发布，以及 Push 内部 POP 确认和不可见时间变更。 |
 
 对于 gRPC，`ReceiveMessageRequest.AutoRenew` 请求的 Proxy 托管续约不是独立的客户端 wire operation，不能创建客户端
 settlement span。客户端主动发送 `ChangeInvisibleDuration` 时，必须根据意图区分：SimpleConsumer 显式延长租期使用
@@ -87,9 +87,15 @@ settlement span。客户端主动发送 `ChangeInvisibleDuration` 时，必须�
 handler 续期不会在客户端重复创建定时器、span 或 metric。结果 tag 使用固定名称，调用方指定的时长不能进入
 metric 维度。
 
+每次实际执行的 gRPC completion RPC 都独立拥有一个 settlement Activity 和一次 metric completion。失败 attempt 会先以
+error 完成，再等待固定 1 秒后重试；后续 wire attempt 会创建新的 operation。两次尝试之间没有 RPC，因此等待期间不
+生成 telemetry。整个逻辑重试序列会在成功、调用方或 Consumer run 取消、以及终态 receipt 错误时结束。ACK 和不可见时间
+变更的 `INVALID_RECEIPT_HANDLE` 属于终态错误，死信转发则会重试该状态。这样 Proxy 长时间故障时仍能看到真实 wire
+尝试次数和结果，而不是由一个持续数分钟的 span 掩盖。
+
 classic Remoting 的埋点归属应跟随实际 wire operation。`PullWireClient` 负责记录并完成非空、空结果、取消与失败 PULL 的
 receive 埋点；`RemotingConsumerOffsetClient` 负责 commit settlement；`RemotingSettlementClient` 负责 PULL 重试与
-死信 send-back。POP receive、ACK 和不可见时间变更仍由 `PopWireClient` 负责。角色级 consumer engine 只负责组合这些
+死信 send-back 与 orderly `%RETRY%group` 发布。POP receive、ACK 和不可见时间变更仍由 `PopWireClient` 负责。角色级 consumer engine 只负责组合这些
 client；内部职责迁移不能让同一个 Activity 或 metric 被重复完成，也不能遗漏完成。
 
 POP 结算 telemetry 按每次实际的 wire operation 独立记录：确认使用 `ack`，一次性重试/延期
@@ -98,10 +104,11 @@ POP 结算 telemetry 按每次实际的 wire operation 独立记录：确认使�
 POP 重试继续使用这条普通的不可见时间变更路径。handler 结果在固定不可见 deadline 之后到达时，不创建任何结算
 operation。不确定的 `nack` 失败不会使用旧 receipt 重试；确认只在原始 deadline 内重试。
 
-classic orderly suspend 只是本地调度决策。每次 handler 调用仍分别拥有一个 process Activity，但两次尝试之间的
-等待不会创建 settlement Activity 或 metric，因为期间没有 wire operation。达到终态上限时，集群和广播模式都会记录
-一次 `reject` settlement；若该操作失败，随后的本地暂停不会额外记录 settlement，之后再次 send-back 时才创建新的
-`reject` operation。
+classic orderly suspend 只是本地调度决策。每次 handler 调用仍分别拥有一个 process Activity，但两次尝试之间的等待
+不会创建 settlement Activity 或 metric，因为期间没有 wire operation。达到终态上限时，集群和广播模式都会为通过内部
+producer 路径发布到 `%RETRY%group` 记录一次 `reject` operation。一次逻辑结算最多会立即尝试三次 wire send；发布成功后，
+Broker 会在重新消费次数超过上限时把 retry topic 消息转入 DLQ。发布最终失败时，后续本地暂停不会额外记录 settlement，
+消息会继续本地重试。
 
 Activity 使用 OpenTelemetry 消息语义约定属性，例如 `messaging.system`、`messaging.destination.name`、
 `messaging.consumer.group.name`、消息 ID、分区 ID、body 大小和 batch 大小。失败时会把 Activity 状态设为 error，

--- a/docs/zh-CN/architecture/protocol-boundaries.md
+++ b/docs/zh-CN/architecture/protocol-boundaries.md
@@ -54,11 +54,13 @@ Package 版本和发布依赖。
 gRPC Push 与 LitePush 遵循 Apache Java 正式版的 gRPC listener 契约，公开 `Success`、`Failure` 和携带时长的
 `Suspend`。普通 Push 会把 Suspend 转换为 Failure；非 FIFO LitePush 的 Failure 和 Suspend 都由服务端推进重试与死信，
 并忽略 Suspend 指定的时长。FIFO LitePush 才使用协议中由调用方指定时长的 suspend 操作；FIFO Failure 在客户端本地
-重试，并尝试通过内部 RPC 转发死信。转发结算失败时消息保持未结算状态，仍可能再次投递。classic Remoting 遵循
+重试，并由客户端负责转发死信。completion RPC 按固定 1 秒间隔重试；ACK 和不可见时间变更的
+`INVALID_RECEIPT_HANDLE` 属于终态错误，DLQ 转发则会重试该状态。FIFO completion 重试期间后继消息等待，终态结算
+失败后释放后继消息。classic Remoting 遵循
 [Java 客户端](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyStatus.java)
 与[Go 客户端](https://github.com/apache/rocketmq-client-go/blob/v2.1.2/consumer/consumer.go#L197-L205)
-共同采用的并发消费回调模型，只公开 `Success` 和 `Retry`。只有内部 PULL 路径会把负数
-`RemotingPushConsumeContext.DelayLevelWhenNextConsume` 解释为直接死信；POP 会将其归一化为默认重试级别。
+共同采用的并发消费回调模型，只公开 `Success` 和 `Retry`。只有并发内部 PULL 路径会把负数
+`RemotingPushConsumeContext.DelayLevelWhenNextConsume` 解释为直接死信；orderly PULL 会发布到 retry topic，POP 会将其归一化为默认重试级别。
 兼容性测试分别锁定两边独立拥有的结果形态。gRPC 结果因为需要携带时长而使用不可变值对象；Remoting 结果仍是
 独立拥有的两成员枚举。
 

--- a/docs/zh-CN/grpc/consumer-model.md
+++ b/docs/zh-CN/grpc/consumer-model.md
@@ -92,13 +92,20 @@ handler 可以返回 `ConsumeResult.Success`、`ConsumeResult.Failure` 或
 | Consumer 模式 | `Failure` | `Suspend(duration)` |
 | --- | --- | --- |
 | 普通非 FIFO Push | 按生效的重试策略修改不可见时间，由服务端推进重试与死信。 | 转换为 `Failure`，忽略指定时长。 |
-| 普通 FIFO Push | 在客户端本地重试 handler，耗尽后尝试转发 DLQ；转发结算失败时消息保持未结算，仍可能再次投递。 | 转换为 `Failure`，忽略指定时长。 |
+| 普通 FIFO Push | 在客户端本地重试 handler，耗尽后由客户端转发 DLQ。结算失败时按固定 1 秒间隔重试；终态结算失败时消息保持未结算，仍可能再次投递。 | 转换为 `Failure`，忽略指定时长。 |
 | 非 FIFO LitePush | 按生效的重试策略修改不可见时间，由服务端推进重试与死信。 | 与 `Failure` 一样走重试策略 NACK，忽略指定时长。 |
-| FIFO LitePush | 在客户端本地重试 handler，耗尽后尝试转发 DLQ；转发结算失败时消息保持未结算，仍可能再次投递；FIFO key 为 `LiteTopic`。 | 暂停当前消息，并跳过同一 receive batch 中尚未处理的同 `LiteTopic` 消息；其他 LiteTopic 继续处理。 |
+| FIFO LitePush | 在客户端本地重试 handler，耗尽后由客户端转发 DLQ。结算失败时按固定 1 秒间隔重试；终态结算失败时消息保持未结算，仍可能再次投递；FIFO key 为 `LiteTopic`。 | 暂停当前消息，并跳过同一 receive batch 中尚未处理的同 `LiteTopic` 消息；其他 LiteTopic 继续处理。 |
 
 可选的 `MessageGroup` 或 `LiteTopic` 缺失时，服务端下发的 FIFO 设置仍是最终依据。这类消息会使用物理 queue fallback
 key，对应 Java 的空 FIFO group，不会降级到非 FIFO 结算。对于 FIFO LitePush，同一 receive batch 中没有 key 的兄弟消息
 因此会共享 suspend 决策。
+
+客户端主动发起的 ACK、按重试策略执行的 NACK、FIFO LitePush suspend 和 FIFO 死信转发，在重试进行期间会继续保持
+pending。接收引擎对每次失败的 completion RPC 都按固定 1 秒间隔重试，直到成功或调用方/Consumer 生命周期取消。
+ACK 和不可见时间变更遇到 `INVALID_RECEIPT_HANDLE` 时立即终止，因为继续使用同一个过期 receipt 无法完成结算；死信
+转发也会重试该状态。FIFO 前驱的 completion 正在重试时，后续消息会等待；如果 completion 以终态失败结束，当前消息
+仍保持未结算，但会释放顺序 key，让后续消息继续执行，这与正式版 Java 客户端一致。只有重试进行期间会阻塞 FIFO。
+停止 Consumer 会取消等待中的 completion 重试，并且不会伪造成功结算。
 
 这与正式版 `java-5.2.1` 中
 [`StandardConsumeService`](https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/StandardConsumeService.java)、

--- a/docs/zh-CN/remoting/consumer-model.md
+++ b/docs/zh-CN/remoting/consumer-model.md
@@ -132,7 +132,7 @@ Broker endpoint 与建议 Broker ID 由内部路由解析器保存。topic 快�
 | `Coordination/Rebalance` | 共享的客户端 rebalance 调度、注册、唤醒以及确定性的平均队列分配策略。 |
 | `Pull` | 供 LitePull 与 Push PULL receiver 共用、且不保存订阅状态的内部 PULL request/response 契约和 wire 操作；每次 Pull 都从当前 receive target 获取 filter。 |
 | `Offset` | 内部 queue position 查询与 consumer-group offset 持久化。 |
-| `Settlement` | 供 Push PULL 重试和 retry topic 位点初始化使用的 classic `CONSUMER_SEND_MSG_BACK`。 |
+| `Settlement` | 供并发 Push PULL 重试和 retry topic 位点初始化使用的 classic `CONSUMER_SEND_MSG_BACK`，以及 orderly `%RETRY%group` 发布。 |
 | `LitePull` 与 `Push` | 两个公开角色的门面，以及各自的 assignment、receive、dispatch 和运行态。 |
 
 Remoting 组合根仍会为每个已注册角色创建一个 `IRemotingConsumerEngine`。Engine 只管理角色生命周期，并将
@@ -341,8 +341,8 @@ receipt 的 retry marker 还决定 ACK 与不可见时间请求使用的真实 w
 | `Pull/Dispatch/PullProcessQueue` | 一个物理 PULL queue 的缓存消息、拉取/提交位点、连续完成水位、settlement retry 状态和 FIFO barrier，并由同一个同步边界保护。 | Consumer 范围调度或 wire I/O。 |
 | `Pull/Receive/ConcurrentPullReceiveLoop` | 单个并发 PULL assignment 使用自身 target filter 的长轮询、缓存准入和串行 offset 持久化循环。 | 应用 handler 结果或 send-back。 |
 | `Pull/Dispatch/PullConsumeRequestProcessor` | 并发 handler 结果映射、队列内完成状态，以及激活已保存的本地 settlement retry。 | 接收轮询、retry topic 准备、send-back 执行或顺序消费的 Broker lock 处理。 |
-| `Pull/Settlement/PullSendBackSettlement` | retry topic 准备、send-back 执行与 retry queue offset 初始化。 | 本地 settlement retry 状态或调度、接收轮询、handler 结果映射或队列内完成状态。 |
-| `Pull/Receive/OrderlyPullReceiveLoop` | 顺序消费的 Broker lock 校验、使用 target filter 的长轮询、串行 handler 重试、send-back 和内联 offset 持久化。 | 并发 `PullProcessQueue` 调度。 |
+| `Pull/Settlement/PullSendBackSettlement` | retry topic 准备、并发 send-back 执行、orderly `%RETRY%group` 发布与 retry queue offset 初始化。 | 本地 settlement retry 状态或调度、接收轮询、handler 结果映射或队列内完成状态。 |
+| `Pull/Receive/OrderlyPullReceiveLoop` | 顺序消费的 Broker lock 校验、使用 target filter 的长轮询、串行 handler 重试、发布 `%RETRY%group` 消息和内联 offset 持久化。 | 并发 `PullProcessQueue` 调度。 |
 | `Pull/Offset/PullOffsetManager` | PULL 初始与已提交 offset、广播存储、reset boundary 和 retry-topic 初始化 boundary。 | POP 进度。 |
 | `Pull/Receive/PullAssignmentReceiver` | 单个 PULL assignment 的 identity、取消、观察到的 Broker 队列锁 lease，以及覆盖接收循环和活动消费请求的完成边界。 | POP wire 操作或 handler 结果策略。 |
 | `Pop/PopAssignmentReceiver` | 单个 POP assignment 使用自身 target filter 的长轮询、接收分批、取消和接收故障隔离。 | handler 调用、receipt 生命周期或结算。 |
@@ -428,9 +428,12 @@ Push handler 契约继续供两类 receiver 共用，并遵循 classic Java、Go
   已分配 queue 继续消费；未设置时使用 `OrderlySuspendDuration`，最终时长按 Java 的 10 毫秒至 30 秒范围限制。
   每次尝试都会创建新的 context，因此 override 只影响下一次本地重试。并发 PULL、POP 和 `MessageGroup` 路径在
   结构上都不会读取该值。
-- 集群 PULL 和 orderly 广播的 `Retry` 达到 `MaxDeliveryAttempts` 后都会尝试按 classic send-back 进入死信。orderly
-  send-back 失败时，当前消息会继续留在本地，按本次尝试选择的暂停时长等待后重新调用 handler，且不会推进位点。并发广播
-  仍不拥有 Broker retry 或 DLQ，会丢弃未成功的尾部。POP 的 `Retry` 达到同一上限时，则遵循 Java 客户端的
+- 集群并发 PULL 的 `Retry` 达到 `MaxDeliveryAttempts` 后，会尝试按 classic send-back 进入死信。orderly PULL 使用
+  单独的零基 `OrderlyMaxReconsumeTimes`：默认值 `-1` 对应 Java 近似无限重试，`0` 表示首次失败后发布，正数表示
+  允许对应次数的本地重新消费后再发布；该规则同时适用于集群和 orderly 广播。达到上限后，客户端通过内部 producer
+  语义构造 `%RETRY%<group>` 消息，附带重新消费次数、最大次数和延迟元数据，并为每次逻辑终态结算最多立即执行三次 wire
+  send。发布成功后，Broker 会在重新消费次数超过上限时把 retry topic 消息转入 DLQ。发布最终失败时，当前消息会留在本地并递增重新消费次数，按本次暂停时长等待后再次调用 handler，且不会推进位点。并发广播仍不拥有
+  Broker retry 或 DLQ，会丢弃未成功的尾部。POP 的 `Retry` 达到 `MaxDeliveryAttempts` 时，则遵循 Java 客户端的
   `checkNeedAckOrDelay`，不会隐式执行死信 send-back。消息年龄不超过 POP 最后一级延迟的两倍时，
   客户端按年龄选择下一个 POP 延迟档位，并只发送一次 `CHANGE_MESSAGE_INVISIBLETIME`；只有消息年龄严格超过该阈值才
   ACK receipt。官方最后一级延迟为 7,200 秒，因此阈值为四小时。这个最大投递次数分支会忽略 handler 指定的 delay level。
@@ -443,22 +446,25 @@ handler 结果中不再包含 `DeadLetter`。这与 Java 的
 [`ConsumeConcurrentlyContext`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeConcurrentlyContext.java)
 一致。PULL 把该值传给 classic send-back；POP 会先将负值归一化为 `0`，再按 Java 的 POP 专用重试表处理。归一化后的
 值根据从零开始的重试次数（`DeliveryAttempt - 1`）选择表项。该表从 10 秒开始，并不是普通延迟消息的 level 表。
-直接死信仍然只适用于 PULL 的 classic send-back；客户端会尝试执行 send-back，结算失败时位点保持未解决，消息仍可能再次
-投递。POP 重试不会把负值解释为直接死信请求。
+直接死信仍然只适用于并发 PULL 的 classic send-back；orderly PULL 改为发布内部 retry topic，POP 重试不会把负值解释为
+直接死信请求。并发 PULL send-back 失败时位点保持未解决，消息仍可能再次投递。
 
-orderly 时长契约遵循正式版 `rocketmq-all-5.5.0` 的
+orderly 重试与时长契约遵循正式版 `rocketmq-all-5.5.0` 的
 [`ConsumeOrderlyContext`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/consumer/listener/ConsumeOrderlyContext.java)
-及其一秒默认值。集群和广播 orderly Consumer 都会先执行本地暂停，并在达到本客户端配置的投递上限后尝试 DLQ
-send-back。终态 send-back 失败时，当前消息继续留在本地，并按本次尝试的暂停时长等待后重新调用 handler。handler 在设置 `SuspendCurrentQueueDuration` 后抛出异常时，
+和 [`ConsumeMessageOrderlyService`](https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java)。
+集群和广播 orderly Consumer 都会先执行本地暂停，并在有限的 `OrderlyMaxReconsumeTimes` 耗尽后通过内部 producer 语义
+发布 `%RETRY%<group>`。消息携带重新消费次数、最大次数和延迟元数据，每次逻辑终态结算最多立即执行三次 wire send；发布成功后，
+Broker 会在重新消费次数超过上限时把 retry topic 消息转入 DLQ。发布最终失败时，当前消息继续留在本地，并按本次尝试的暂停时长等待后重新调用 handler。handler 在设置 `SuspendCurrentQueueDuration` 后抛出异常时，
 当前尝试仍保留该 override，这与正式版 Java 5.5.0 一致；未设置时才使用配置的 orderly 默认值。取消会终止本地等待且不执行结算。
 queue lock 丢失不会唤醒正在运行的 timer；客户端会在 timer 结束后、再次调用 handler 前发现
 失锁，这与 Java 的定时重试一致。本地等待只是客户端调度，不会创建 ACK、NACK、reject 或 commit settlement
-operation。失败的死信 send-back 会记录自己的失败 settlement operation，之后的本地等待不会重复记录。
+operation。失败的 retry topic 发布会记录自己的失败 settlement operation，之后的本地等待不会重复记录。
 
-Java orderly 在 `maxReconsumeTimes=-1` 时默认近似无限重试，并在再次调用 handler 前递增可变的消息重试次数。本客户端
-保留显式的一基 `MaxDeliveryAttempts`，默认值为 16；本地尝试次数单独维护，`RemotingMessageView.DeliveryAttempt` 始终是
-Broker 返回的不可变值。这些是有意保留的 .NET API 差异；暂停时长、物理 queue 隔离、终态 send-back 及其失败恢复
-遵循正式版 Java 的设计。
+`RemotingMessageView.ReconsumeTimes` 对外提供与 Java 可变 `MessageExt.reconsumeTimes` 相同的零基计数。它以 Broker
+header 为初值，并在每次 orderly 本地重新消费前递增；retry topic 发布失败后也会递增，因此下一次 handler 调用能看到
+新值。`RemotingMessageView.DeliveryAttempt` 继续表示 Broker 返回的一基投递次数（解码时等于
+`ReconsumeTimes + 1`），不会被本地 orderly 调度改写。并发 PULL、POP 和 `MessageGroup` 仍使用
+`MaxDeliveryAttempts`，orderly 的 `-1` sentinel 不会改变这些路径的重试或终态策略。
 
 POP handler 执行期间不会自动续租 receipt。客户端会在 handler 处理前和结算前检查固定不可见 deadline；如果已
 过期，则忽略迟到的 handler 结果，不创建结算 operation，并允许 Broker 重新投递。`Retry` 结果只发起一次带

--- a/docs/zh-CN/remoting/transport-and-client-roles.md
+++ b/docs/zh-CN/remoting/transport-and-client-roles.md
@@ -94,9 +94,11 @@ Push 唯一的 `IRemotingPushMessageHandler.HandleAsync` API 接收 `IReadOnlyLi
 
 `Success` 默认确认整个批次。并发、非 FIFO handler 可以在返回 `Success` 前把 `AckIndex` 设为最后一条已接受
 消息的从零开始索引；客户端会确认这个连续前缀，并只重试尾部消息。无论 `AckIndex` 为何，`Retry` 都会应用到批次
-中的每条消息。context 还提供 `DelayLevelWhenNextConsume`，用于失败批次或未确认的尾部：PULL 接收时，`0` 交由
+中的每条消息。context 还提供 `DelayLevelWhenNextConsume`，用于失败批次或未确认的尾部：并发 PULL 接收时，`0` 交由
 Broker 决定重试时间，正值选择 RocketMQ 延迟级别，负值请求通过 PULL send-back 尝试直接进入死信队列；结算失败时位点
-保持未解决，消息仍可能再次投递。Push assignment 使用 POP 时，.NET 适配器会先将负值归一化为 `0`，再按 Java 兼容的
+保持未解决，消息仍可能再次投递。orderly PULL 不使用该直接死信选项；`OrderlyMaxReconsumeTimes` 耗尽后，客户端通过内部
+producer 语义发布 `%RETRY%group` 消息，附带重新消费次数、最大次数和延迟元数据，并为每次逻辑终态结算最多立即执行三次
+wire send。Broker 会在重新消费次数超过上限时把成功发布的消息转入 DLQ。Push assignment 使用 POP 时，.NET 适配器会先将负值归一化为 `0`，再按 Java 兼容的
 不可见时间重试表处理（包括 level `0`）；POP 不会把负值解释为直接死信。
 这种双结果契约与 classic Java、Go 的并发消费设计一致；死信是重试策略的终态选择，不是独立的 handler 结果。并发
 广播没有 Broker 重试或死信路径，因此未确认的尾部消息会被跳过。
@@ -145,8 +147,9 @@ typed handler 的故障。需要精确切换边界的应用应选择起始或时
 
 对于顺序 Push，初始 lock 被拒绝或 lock 续期失败都会使本次收敛保持未完成状态，participant 会重试。只有 Broker
 授予队列锁后，Consumer 才会开始分发该队列。
-集群和广播 orderly 投递都会在当前物理 queue 上本地重试，并在终态尝试 DLQ send-back。send-back 失败时，当前消息与
-位点保持未解决，并按本次尝试选择的暂停时长等待后重新调用 handler。
+集群和广播 orderly 投递都会在当前物理 queue 上本地重试；达到上限后通过内部 producer 语义发布 `%RETRY%group`，Broker
+随后按重新消费次数把消息转入 DLQ。每次逻辑终态结算最多立即执行三次 wire send；发布最终失败时，当前消息与位点保持未解决，
+并按本次尝试选择的暂停时长等待后重新调用 handler。
 
 同一 Push group 的成员必须使用完全相同的 topic/filter 订阅、集群或广播模式、顺序消费模式和初始位点；并发度、
 超时与 typed handler 仍属于实例本地配置。这些是 group 范围的规则，但注册层只能对同一进程、同一客户端注册中

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -75,10 +75,13 @@ dotnet run -c Release --project tests/benchmarks/EventHorizon.RocketMQ.Remoting.
   LitePush 的 `Failure` 和 `Suspend` 都走服务端 retry/NACK，FIFO LitePush 才使用调用方的精确时长发送
   `suspend=true`。FIFO receive batch 会暂停尚未处理的同 `LiteTopic` 兄弟消息，其他 LiteTopic 保持独立；
   `MessageGroup` 或 `LiteTopic` 缺失时仍通过物理 queue fallback 保持 FIFO 行为；
-- gRPC 本地重试取消会及时停止等待；结算失败会保持消息未解决、维持 FIFO 阻塞，并在停止期间正确取消；
-- Remoting orderly PULL 会把调用方和配置的暂停时长限制在 10 毫秒至 30 秒，重置每次调用的 context；handler 抛出
-  异常时仍保留当前尝试的 override，仅在未设置时使用配置默认值；它还会隔离单个物理 queue、停止时取消等待，
-  在集群和广播模式下都执行终态 send-back，并在 send-back 失败时保留当前消息及本次暂停时长。
+- gRPC 本地重试取消会及时停止等待；每次 completion wire attempt 都按固定 1 秒间隔重试到成功、调用方取消或 Consumer
+  停止，并独立记录 telemetry；ACK 和修改不可见时间遇到无效 receipt handle 时保持终态，DLQ 转发则重试该状态；FIFO
+  后继消息只在 completion 重试期间等待，终态结算失败后会释放后继消息；
+- Remoting orderly PULL 会把调用方和配置的暂停时长限制在 10 毫秒至 30 秒，按 `OrderlyMaxReconsumeTimes`（`-1` 表示
+  无限）跟踪零基 `ReconsumeTimes`，重置每次调用的 context；handler 抛出异常时仍保留当前尝试的 override，仅在未设置
+  时使用配置默认值；它还会隔离单个物理 queue、停止时取消等待，在集群和广播模式下通过内部 producer 语义向
+  `%RETRY%group` 发布终态消息，并为每次逻辑结算最多立即执行三次 wire send；发布最终失败时保留当前消息及本次暂停时长。
 
 对于客户端能够确定性验证的行为，IT 覆盖不能替代 UT。即使 IT 已覆盖完整工作流，底层状态转换、分配、调度、
 offset、重试和失败不变量仍必须保留聚焦的 UT；IT 只在此基础上补充真实 Broker、NameServer、Proxy、transport、
@@ -145,13 +148,15 @@ Consumer API。普通 LitePull 与默认 Push 工作流不依赖 Broker 侧 POP 
 gRPC DLQ 集成测试包含四条工作流：普通 FIFO Push、普通非 FIFO Push、非 FIFO LitePush 和 FIFO LitePush。每条都在行为
 归属方配置一次重试：FIFO 使用 `MaxDeliveryAttempts=2`，非 FIFO group 使用 Broker `retryMaxTimes=1`；测试重试间隔均为
 100 毫秒。测试随后验证 DLQ 消息和职责划分：普通 Push 与 LitePush 的非 FIFO 推进都由服务端负责，FIFO Push 与 FIFO
-LitePush 则由客户端尝试转发 DLQ。转发或结算失败会保持未解决，不会被当作 ACK。FIFO Lite suspend 工作流另行请求精确
-250 毫秒，验证不会提前重投且 receipt 会被替换；由于 `DeliveryAttempt` 由服务端负责，测试刻意不对其数值作保证。
+LitePush 则由客户端尝试转发 DLQ。completion retry 使用固定 1 秒间隔；终态结算失败会保持未解决，不会被当作 ACK，并
+释放 FIFO 后继消息。FIFO Lite suspend 工作流另行请求精确 250 毫秒，验证不会提前重投且 receipt 会被替换；由于
+`DeliveryAttempt` 由服务端负责，测试刻意不对其数值作保证。
 
 Remoting PULL DLQ 集成测试覆盖负 delay 直接 send-back，以及并发、`MessageGroup` FIFO、集群 orderly 和广播 orderly
-的重试耗尽场景。重试耗尽场景使用一次重试（`MaxDeliveryAttempts=2`）和 100 毫秒重试延迟；orderly 另外覆盖短时的本地
-queue 暂停。每条工作流都会观察一次 reject 和 DLQ 消息，再验证集群 Broker 位点或广播本地持久化位点，并保留结算失败时
-位点未解决的契约。
+的重试耗尽场景。并发和 `MessageGroup` FIFO 场景使用一次重试（`MaxDeliveryAttempts=2`）和 100 毫秒重试延迟；orderly
+场景使用 `OrderlyMaxReconsumeTimes=1`（零基计数，首次失败后本地重试一次），并设置 50 毫秒的本地 queue 暂停。每条
+orderly 工作流验证三次立即 wire send 的 `%RETRY%group` 发布和 Broker 后续的 DLQ 转发，再验证集群 Broker 位点或广播
+本地持久化位点。负 delay 直接死信仍只适用于并发 PULL。
 
 single-Broker 的运行时间也属于需要持续测量的测试设计约束。在 commit `9ef119f` 上，本地使用
 `Topology!=MultiBroker` 筛选条件运行 Remoting 测试，29 个测试全部通过，测试阶段耗时 167.7 秒，其中共享

--- a/samples/grpc/GenericHost/LitePushConsumer/README.md
+++ b/samples/grpc/GenericHost/LitePushConsumer/README.md
@@ -66,17 +66,17 @@ delivery still uses client-initiated long polling.
 
 LitePush uses the same `IGrpcPushMessageHandler` contract and dependency-injection lifetime rules as standard Push.
 `ConsumeResult.Success` acknowledges the message. Non-FIFO `Failure` and `Suspend` use service-owned retry/DLQ
-progression, and Suspend ignores its requested duration. FIFO `Failure` retries the handler locally and attempts to
-forward the message to DLQ after the effective attempt limit; if that completion fails, the message remains unsettled
-and may be redelivered. FIFO `ConsumeResult.Suspend(duration)` changes invisibility with `suspend=true`; the service
+progression, and Suspend ignores its requested duration. FIFO `Failure` retries the handler locally and forwards the
+message to DLQ after the effective attempt limit; completion failures retry at a fixed one-second interval, and a
+terminal failure leaves the message unsettled while releasing the FIFO successor. FIFO `ConsumeResult.Suspend(duration)` changes invisibility with `suspend=true`; the service
 owns the delivery attempt reported by the next receive. The minimum duration is 50 milliseconds. It also covers every
 unprocessed same-LiteTopic message from the current receive batch without invoking those sibling handlers. Handler
 exceptions are treated as failures, and failed completion calls can produce duplicate delivery, so processing must be
 idempotent.
 
-Corrupted messages bypass the application handler. The client retries non-FIFO corrupted messages and attempts to
-forward corrupted FIFO messages to DLQ before releasing the next delivery for that LiteTopic. If that completion fails,
-the message remains unsettled and may be redelivered.
+Corrupted messages bypass the application handler. The client retries non-FIFO corrupted messages and forwards corrupted
+FIFO messages to DLQ before releasing the next delivery for that LiteTopic. The successor waits while completion retry is
+in progress; a terminal completion failure releases it, while the failed message remains unsettled and may be redelivered.
 
 LitePush requests set `AutoRenew=true`, so a compatible Proxy renews the receipt while the handler runs; the .NET
 client does not run a second renewal timer. For non-FIFO work, `ConsumeTimeout` cancels the handler token and requests

--- a/samples/grpc/GenericHost/LitePushConsumer/README.zh-CN.md
+++ b/samples/grpc/GenericHost/LitePushConsumer/README.zh-CN.md
@@ -59,13 +59,14 @@ LiteTopic 订阅时生效。
 
 LitePush 与标准 Push 使用同一个 `IGrpcPushMessageHandler` 契约和依赖注入生命周期规则。
 `ConsumeResult.Success` 会确认消息。非 FIFO `Failure` 与 `Suspend` 由服务端推进重试和死信，并忽略 Suspend 指定的时长。
-FIFO `Failure` 在本地重试 handler，达到有效次数上限后尝试转发 DLQ；转发结算失败时消息保持未结算，仍可能再次投递。
+FIFO `Failure` 在本地重试 handler，达到有效次数上限后转发 DLQ；结算失败按固定 1 秒间隔重试，终态失败时消息保持未
+结算但会释放 FIFO 后继消息。
 FIFO `ConsumeResult.Suspend(duration)` 使用 `suspend=true` 和指定时长修改不可见时间；下一次 receive 返回的投递次数由
 服务端负责，且最短时长为 50 毫秒。它还会覆盖当前 receive batch 中尚未处理的同 LiteTopic 消息，并跳过这些消息的
 handler。handler 异常会被当作失败结果，完成操作失败也可能造成重复投递，因此处理逻辑必须幂等。
 
 损坏的消息不会进入应用 handler。客户端会重试非 FIFO 损坏消息；FIFO 损坏消息会在释放同一 LiteTopic 的下一条消息前
-尝试转发 DLQ。转发结算失败时消息保持未结算，仍可能再次投递。
+转发 DLQ。后继消息会在 completion 重试期间等待；终态结算失败后释放后继消息，失败消息保持未结算，仍可能再次投递。
 
 LitePush 请求会设置 `AutoRenew=true`，由兼容的 Proxy 在 handler 运行期间续期 receipt；.NET 客户端不会再启动
 一套续期定时器。对于非 FIFO 工作，`ConsumeTimeout` 会取消 handler token 并请求再次投递，但无法强制终止忽略取消的

--- a/samples/grpc/GenericHost/PushConsumer/README.md
+++ b/samples/grpc/GenericHost/PushConsumer/README.md
@@ -63,16 +63,18 @@ Each handler result asks the consumer to perform a specific settlement operation
 | Result | SDK action |
 | --- | --- |
 | `ConsumeResult.Success` | Acknowledge the message. Return it only after the business effect is durable. |
-| `ConsumeResult.Failure` | Use service-owned retry progression for non-FIFO delivery; retry locally and then attempt DLQ forwarding for FIFO delivery. A failed forwarding completion leaves the message unsettled for possible redelivery. |
+| `ConsumeResult.Failure` | Use service-owned retry progression for non-FIFO delivery; retry locally and then forward to DLQ for FIFO delivery. Completion failures retry at a fixed one-second interval; a terminal failure leaves the message unsettled and releases the FIFO successor. |
 | `ConsumeResult.Suspend(duration)` | Normalize to `Failure`; regular Push does not apply the requested duration. |
 
-An unhandled handler exception is treated as `Failure`. If acknowledgement, retry scheduling, or DLQ forwarding fails,
-the message may be delivered again. Return `Success` only after durable business processing; handlers must therefore
+An unhandled handler exception is treated as `Failure`. Completion RPCs retry every failure at a fixed one-second interval
+until success or lifecycle cancellation. `INVALID_RECEIPT_HANDLE` is terminal for acknowledgement and invisibility changes,
+while DLQ forwarding retries it. Return `Success` only after durable business processing; handlers must therefore
 remain idempotent even when they return `Success`.
 
 Corrupted messages do not reach `IGrpcPushMessageHandler`. A non-FIFO corrupted message is made eligible for retry;
-for a corrupted FIFO message, the client attempts DLQ forwarding before releasing the next member of its message group.
-If that completion fails, the message remains unsettled and may be redelivered.
+for a corrupted FIFO message, the client forwards to DLQ before releasing the next member of its message group. The
+successor waits while completion retry is in progress; a terminal completion failure releases it, while the failed
+message remains unsettled and may be redelivered.
 
 Push requests set `AutoRenew=true`, so a compatible Proxy renews the receipt while the handler is active; the .NET
 client does not run a second renewal timer. For non-FIFO messages, `ConsumeTimeout` bounds how long the dispatcher

--- a/samples/grpc/GenericHost/PushConsumer/README.zh-CN.md
+++ b/samples/grpc/GenericHost/PushConsumer/README.zh-CN.md
@@ -57,14 +57,16 @@ Generic Host 集成会为已注册角色调用 `StartAsync` 和 `StopAsync`。�
 | 结果 | SDK 行为 |
 | --- | --- |
 | `ConsumeResult.Success` | 确认消息。只有业务副作用已经持久化后才能返回该结果。 |
-| `ConsumeResult.Failure` | 非 FIFO 投递由服务端推进重试；FIFO 投递在本地重试，耗尽后尝试转发 DLQ。转发结算失败时消息保持未结算，仍可能再次投递。 |
+| `ConsumeResult.Failure` | 非 FIFO 投递由服务端推进重试；FIFO 投递在本地重试，耗尽后转发 DLQ。结算失败按固定 1 秒间隔重试；终态失败时消息保持未结算并释放 FIFO 后继消息。 |
 | `ConsumeResult.Suspend(duration)` | 归一化为 `Failure`；普通 Push 不使用指定时长。 |
 
-未处理的 handler 异常会被当作 `Failure`。如果确认、重试调度或 DLQ 转发失败，消息可能再次投递。只有业务处理已经
-持久化后才能返回 `Success`，因此即使 handler 返回 `Success`，处理逻辑仍必须保持幂等。
+未处理的 handler 异常会被当作 `Failure`。completion RPC 会对每次失败按固定 1 秒间隔重试，直到成功或生命周期取消。
+`INVALID_RECEIPT_HANDLE` 对确认和修改不可见时间是终态错误，DLQ 转发则会重试该状态。只有业务处理已经持久化后才能
+返回 `Success`，因此即使 handler 返回 `Success`，处理逻辑仍必须保持幂等。
 
 损坏的消息不会进入 `IGrpcPushMessageHandler`。非 FIFO 损坏消息会重新变为可投递状态；对于 FIFO 损坏消息，客户端会在
-释放同一 message group 的下一条消息前尝试转发 DLQ。转发结算失败时消息保持未结算，仍可能再次投递。
+释放同一 message group 的下一条消息前转发 DLQ。后继消息会在 completion 重试期间等待；终态结算失败后释放后继消息，
+失败消息保持未结算，仍可能再次投递。
 
 Push 请求会设置 `AutoRenew=true`，由兼容的 Proxy 在 handler 运行期间续期 receipt；.NET 客户端不会再启动一套续期
 定时器。对于非 FIFO 消息，`ConsumeTimeout` 限制 dispatcher 等待 handler 的时长：超时后会取消 handler token、

--- a/samples/grpc/NonHost/LitePushConsumer/README.md
+++ b/samples/grpc/NonHost/LitePushConsumer/README.md
@@ -22,7 +22,8 @@ in this non-Host process.
 a list of ordinary topics or filters. The sample's scoped `IGrpcPushMessageHandler` logs a message and returns
 `ConsumeResult.Success`, which makes the SDK acknowledge it. Non-FIFO `Failure` and `Suspend` use service-owned
 retry/DLQ progression, and Suspend ignores its requested duration. FIFO `Failure` retries locally before the client
-attempts DLQ forwarding; a failed forwarding completion leaves the message unsettled for possible redelivery. FIFO
+forwards to DLQ; completion failures retry at a fixed one-second interval, and a terminal failure leaves the message
+unsettled while releasing the FIFO successor. FIFO
 `ConsumeResult.Suspend(duration)` delays Lite redelivery while the service owns the next delivery attempt and also
 covers unprocessed same-LiteTopic messages from the current receive batch. Handler exceptions are retried, so
 processing must be idempotent.

--- a/samples/grpc/NonHost/LitePushConsumer/README.zh-CN.md
+++ b/samples/grpc/NonHost/LitePushConsumer/README.zh-CN.md
@@ -18,8 +18,8 @@ LiteTopic 集合，持续运行 handler 直到 Ctrl+C，显式停止角色，并
 
 `BindTopic` 指定 LITE parent topic。`LiteTopics` 是完整的初始逻辑订阅集合，不是普通 topic 或 filter 的列表。示例的 scoped
 `IGrpcPushMessageHandler` 记录消息并返回 `ConsumeResult.Success`，SDK 随后会确认消息。非 FIFO `Failure` 与 `Suspend`
-由服务端推进重试和死信，并忽略 Suspend 指定的时长。FIFO `Failure` 在本地重试，耗尽后由客户端尝试转发 DLQ；转发
-结算失败时消息保持未结算，仍可能再次投递。FIFO `ConsumeResult.Suspend(duration)` 会延迟 Lite 消息重新投递，下一次
+由服务端推进重试和死信，并忽略 Suspend 指定的时长。FIFO `Failure` 在本地重试，耗尽后由客户端转发 DLQ；结算失败按
+固定 1 秒间隔重试，终态失败时消息保持未结算但会释放 FIFO 后继消息，仍可能再次投递。FIFO `ConsumeResult.Suspend(duration)` 会延迟 Lite 消息重新投递，下一次
 投递次数由服务端负责，同时覆盖当前 receive batch 中尚未处理的同 LiteTopic 消息。handler 异常会触发重试，因此处理
 必须是幂等的。
 

--- a/samples/opentelemetry/GenericHost/ConsumerWebApi/README.md
+++ b/samples/opentelemetry/GenericHost/ConsumerWebApi/README.md
@@ -113,13 +113,17 @@ that ignored cancellation. Handlers must honor cancellation and remain idempoten
 `RemotingPushConsumeContext`. Returning `Success` confirms the complete batch by default. For concurrent non-FIFO
 batches, set `AckIndex` to the zero-based last accepted index before returning `Success` to confirm a contiguous
 prefix and retry only the tail; `-1` confirms none. `Retry` ignores `AckIndex` and applies to the whole batch.
-`DelayLevelWhenNextConsume` controls retry timing; a negative value requests direct dead-lettering.
+`DelayLevelWhenNextConsume` controls retry timing for the failed batch; a negative value requests direct dead-lettering
+only for concurrent PULL. Orderly PULL publishes an exhausted message to `%RETRY%group` through internal producer
+semantics, with up to three immediate wire send attempts before the Broker redirects it to DLQ when its reconsume count exceeds
+the supplied maximum.
 
 Remoting FIFO and orderly paths deliver singleton lists and do not support partial batch confirmation. Broadcasting
 has no Broker retry or dead-letter flow. A concurrent clustered non-FIFO batch that exceeds `ConsumeTimeout` is
 requested for redelivery; code that ignores cancellation can overlap that redelivery. Failed Remoting
 retry/dead-letter settlement is retried locally without invoking the handler again, and the per-queue contiguous
-offset watermark does not advance across the unresolved gap.
+offset watermark does not advance across the unresolved gap. If orderly retry-topic publication fails,
+the orderly message remains local and is retried after its suspension interval.
 
 See the [gRPC Consumer model](../../../../docs/en-US/grpc/consumer-model.md) and
 [Remoting transport and roles](../../../../docs/en-US/remoting/transport-and-client-roles.md) for the complete delivery,

--- a/samples/opentelemetry/GenericHost/ConsumerWebApi/README.zh-CN.md
+++ b/samples/opentelemetry/GenericHost/ConsumerWebApi/README.zh-CN.md
@@ -103,11 +103,14 @@ Consumer Group、成功状态和错误属性。直方图 view、采样、基数�
 `IRemotingPushMessageHandler.HandleAsync` 接收 `IReadOnlyList<RemotingMessageView>` 和
 `RemotingPushConsumeContext`。默认返回 `Success` 会确认完整批次。并发非 FIFO 批次可先把 `AckIndex` 设为最后一条
 已接受消息的从零开始索引，再返回 `Success`，从而确认连续前缀并只重试尾部；`-1` 表示一条也不确认。`Retry` 会忽略
-`AckIndex` 并作用于整个批次。`DelayLevelWhenNextConsume` 控制重试时间；负值请求直接进入死信队列。
+`AckIndex` 并作用于整个批次。`DelayLevelWhenNextConsume` 控制失败 batch 的重试时间；只有并发 PULL 会把负值解释为直接进入死信。
+orderly PULL 会通过内部 producer 语义把耗尽上限的消息发布到 `%RETRY%group`，每次逻辑终态结算最多立即执行三次 wire send，Broker
+会在重新消费次数超过上限时把成功发布的消息转入 DLQ。
 
 Remoting FIFO 与 orderly 路径只投递单消息列表，不支持批量部分确认。广播模式没有 Broker 重试或死信流程。并发
 集群非 FIFO 批次超过 `ConsumeTimeout` 后会请求重新投递；忽略取消的代码可能与重新投递重叠。Remoting
-重试/死信结算失败时会在本地重试，不会再次调用 handler；对应物理队列的连续位点水位不会跨过该未决缺口。
+重试/死信结算失败时会在本地重试，不会再次调用 handler；对应物理队列的连续位点水位不会跨过该未决缺口。orderly retry topic
+发布最终失败时，消息会在本地保留，并按暂停时长再次调用 handler。
 
 完整投递、并发和位点规则请参阅 [gRPC Consumer 模型](../../../../docs/zh-CN/grpc/consumer-model.md)与
 [Remoting 传输和角色](../../../../docs/zh-CN/remoting/transport-and-client-roles.md)。span 属性、link 与 metric tag 由

--- a/samples/remoting/GenericHost/PushConsumer/README.md
+++ b/samples/remoting/GenericHost/PushConsumer/README.md
@@ -140,13 +140,14 @@ The handler returns one `ConsumeResult` for its batch:
 
 For a clustered concurrent non-FIFO batch, `context.DelayLevelWhenNextConsume` defaults to `0`, allowing the Broker to
 select the retry interval. Set it to a positive RocketMQ delay level to request that level, or to a negative value to
-request direct dead-letter delivery. PULL retries use classic send-back; POP retries map the selected level through the
+request direct dead-letter delivery on concurrent PULL. PULL retries use classic send-back; POP retries map the selected level through the
 classic POP retry schedule and change the receipt's invisibility. POP dead-letter handling forwards before
 acknowledging the receipt.
 `MessageGroup` FIFO, `ConsumeOrderly`, and broadcasting paths ignore this context setting. In clustering mode,
-`MaxDeliveryAttempts` starts terminal retry handling. PULL sends the retried message to the dead-letter queue. POP
-follows the official Java age policy: it keeps changing invisibility using age-selected POP delays, then ACKs after the
-message age is strictly greater than twice the final POP delay without implicitly forwarding to the dead-letter queue.
+`MaxDeliveryAttempts` remains the limit for clustered concurrent PULL, `MessageGroup` FIFO, and POP. Clustered PULL and
+`MessageGroup` send the retried message to the dead-letter queue at that limit. POP follows the official Java age policy:
+it keeps changing invisibility using age-selected POP delays, then ACKs after the message age is strictly greater than twice
+the final POP delay without implicitly forwarding to the dead-letter queue.
 
 Every PULL `PullProcessQueue` maintains an independent contiguous completion watermark. A later batch, or a batch from another
 queue or Broker, cannot skip an earlier unresolved queue offset. Pulling may run ahead of handler completion. In
@@ -180,9 +181,15 @@ be idempotent.
 
 `Broadcasting` assigns every readable queue to every Consumer instance and stores offsets locally. Concurrent delivery
 has no group-owned Broker retry or dead-letter flow: `Retry` and an unacknowledged batch tail are dropped while the
-local offset advances. Orderly broadcasting instead retries the current message locally and attempts DLQ send-back at
-`MaxDeliveryAttempts`; send-back failure retains the message and offset and uses the current suspension duration before
-calling the handler again. Use a stable, instance-specific `LocalOffsetStorePath` when client identity is not stable.
+local offset advances. Orderly delivery, including orderly broadcasting, retries the current message locally and attempts
+`%RETRY%group` publication after `OrderlyMaxReconsumeTimes` is exhausted. This setting is zero-based and defaults to `-1` (effectively unlimited); `1`
+allows one local retry after the initial failure. `RemotingMessageView.ReconsumeTimes` starts at the Broker's zero-based
+value and increments before each local reconsume, while `DeliveryAttempt` remains the immutable Broker-reported value. The
+publication uses internal producer semantics with reconsume, maximum, and delay metadata and makes up to three immediate wire
+send attempts per logical terminal settlement; the Broker redirects the retry-topic message to DLQ when its reconsume count
+exceeds the maximum. If publication fails, the message and offset remain local and use the current suspension duration
+before calling the handler again.
+Use a stable, instance-specific `LocalOffsetStorePath` when client identity is not stable.
 
 For a normal PULL queue, `InitialPosition` supplies a starting offset only when the active offset store has no
 value: the Broker group offset in clustering mode, or the instance's local offset file in broadcasting mode. It does

--- a/samples/remoting/GenericHost/PushConsumer/README.zh-CN.md
+++ b/samples/remoting/GenericHost/PushConsumer/README.zh-CN.md
@@ -126,11 +126,12 @@ handler 为一个 batch 返回一个 `ConsumeResult`：
 - `Retry` 会忽略 `AckIndex`，并应用到整个 batch。
 
 对于集群并发、非 FIFO batch，`context.DelayLevelWhenNextConsume` 默认为 `0`，由 Broker 选择重试间隔；设为正的
-RocketMQ 延迟级别时请求该级别，设为负值时请求直接进入死信队列。PULL 重试使用经典 send-back；POP 重试按
+RocketMQ 延迟级别时请求该级别，设为负值时仅请求并发 PULL 直接进入死信队列。PULL 重试使用经典 send-back；POP 重试按
 classic POP 重试表将级别换算为不可见时间，并修改 receipt 不可见期。POP 死信处理则先转发、再确认 receipt。
 `MessageGroup` FIFO、`ConsumeOrderly` 和广播路径会忽略此 context 设置。在集群模式下，
-`MaxDeliveryAttempts` 会启动终态重试处理：PULL 把重试消息送入死信；POP 则遵循官方 Java 的消息年龄策略，继续按年龄
-选择 POP 延迟并修改不可见时间，只有消息年龄严格超过最后一级 POP 延迟的两倍时才 ACK，不会隐式转入死信。
+`MaxDeliveryAttempts` 仍是集群并发 PULL、`MessageGroup` FIFO 和 POP 使用的上限。集群 PULL 和 `MessageGroup` 达到该
+上限后会把重试消息送入死信；POP 则遵循官方 Java 的消息年龄策略，继续按年龄选择 POP 延迟并修改不可见时间，只有
+消息年龄严格超过最后一级 POP 延迟的两倍时才 ACK，不会隐式转入死信。
 
 每个 PULL `PullProcessQueue` 都独立维护连续完成水位。后面的 batch，或者来自其他队列、其他 Broker 的 batch，即使先
 完成，也不能跳过前面尚未解决的队列位点。拉取可以先于 handler 完成继续前进。在集群模式下，Broker 已提交位点不能
@@ -155,8 +156,11 @@ Broker 重新投递。assignment 被移除或切换模式时，旧 generation �
 阻塞当前队列，使后面的消息不能超越它。队列锁保持顺序，但不会改变至少一次投递，因此顺序 handler 也必须幂等。
 
 `Broadcasting` 会把每个可读队列分配给每个 Consumer 实例，并在本地存储位点。并发投递没有 group 所属的 Broker
-重试或死信流程：`Retry` 和未确认的 batch 尾部都会被丢弃，同时推进本地位点。orderly 广播则在本地重试当前消息，
-达到 `MaxDeliveryAttempts` 后尝试 DLQ send-back；send-back 失败时保留当前消息与位点，并按本次暂停时长等待后重新调用
+重试或死信流程：`Retry` 和未确认的 batch 尾部都会被丢弃，同时推进本地位点。orderly 投递（包括 orderly 广播）则在本地重试当前消息，
+耗尽 `OrderlyMaxReconsumeTimes` 后发布 `%RETRY%group` 消息。该设置采用零基计数，默认值 `-1`（近似无限），`1` 表示首次
+失败后再本地重试一次。`RemotingMessageView.ReconsumeTimes` 从 Broker 返回的零基值开始，并在每次本地重新消费前递增；
+`DeliveryAttempt` 仍是 Broker 返回的不可变值。发布使用内部 producer 语义，附带重新消费次数、最大次数和延迟元数据；每次逻辑终态结算最多立即执行三次
+wire send，Broker 会在重新消费次数超过上限时把 retry topic 消息转入 DLQ。发布最终失败时保留当前消息与位点，并按本次暂停时长等待后重新调用
 handler。当客户端标识不稳定时，应配置稳定且每实例独立的 `LocalOffsetStorePath`。
 
 对于普通 PULL 队列，`InitialPosition` 只在当前模式使用的位点存储没有值时提供起点：集群模式读取 Broker group

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/ConsumeResult.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/ConsumeResult.cs
@@ -22,7 +22,10 @@ namespace EventHorizon.RocketMQ.Grpc.Consumer;
 /// Regular Push normalizes <see cref="Suspend(TimeSpan)"/> to <see cref="Failure"/>. Non-FIFO LitePush sends Suspend
 /// through its retry-policy NACK path; FIFO LitePush preserves the caller duration and protocol suspend flag.
 /// Non-FIFO Push and LitePush use service-owned retry progression, while their FIFO modes retry locally before
-/// client-owned dead-letter forwarding.
+/// client-owned dead-letter forwarding. Completion RPC failures retry at a fixed one-second interval until success or
+/// lifecycle cancellation. <c>INVALID_RECEIPT_HANDLE</c> is terminal for acknowledgement and invisibility changes,
+/// while dead-letter forwarding retries it; a terminal FIFO completion failure releases the successor after the retry
+/// phase, even though the failed message remains unsettled.
 /// </remarks>
 /// <seealso href="https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client-apis/src/main/java/org/apache/rocketmq/client/apis/consumer/ConsumeResultSuspend.java">
 /// Apache RocketMQ Java duration-carrying suspend result.

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/GrpcReceiveConsumerEngine.cs
@@ -21,7 +21,6 @@ using EventHorizon.RocketMQ.Grpc.Protocol;
 using EventHorizon.RocketMQ.Grpc.Protocol.Route;
 using EventHorizon.RocketMQ.Grpc.Protocol.Telemetry;
 using Google.Protobuf.WellKnownTypes;
-using Grpc.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Proto = Apache.Rocketmq.V2;
@@ -30,9 +29,7 @@ namespace EventHorizon.RocketMQ.Grpc.Consumer;
 
 internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
 {
-    private const int CompletionMaxAttempts = 3;
-    private static readonly TimeSpan CompletionInitialRetryDelay = TimeSpan.FromMilliseconds(200);
-    private static readonly TimeSpan CompletionMaximumRetryDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan CompletionRetryDelay = TimeSpan.FromSeconds(1);
     private readonly IRocketMQGrpcClient _client;
     private readonly IGrpcRouteService _routes;
     private readonly GrpcClientOptions _clientOptions;
@@ -46,7 +43,10 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
     private readonly ConcurrentDictionary<string, FilterExpression> _subscriptions;
     private readonly SemaphoreSlim _subscriptionGate = new(1, 1);
     private readonly object _messageOwner = new();
+    private readonly object _completionOwner = new();
     private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
+    private CancellationToken _completionCancellationToken;
+    private CancellationTokenSource? _completionCts;
     private GrpcSessionManager? _sessions;
     private int _started;
 
@@ -90,16 +90,32 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
                 return;
             }
 
-            var sessions = new GrpcSessionManager(
-                _client,
-                Options.Create(_clientOptions),
-                _clientType,
-                _groupName,
-                _sessionLogger,
-                _telemetryHandler);
-            sessions.Start();
-            Volatile.Write(ref _sessions, sessions);
-            Volatile.Write(ref _started, 1);
+            var completionCts = new CancellationTokenSource();
+            try
+            {
+                var sessions = new GrpcSessionManager(
+                    _client,
+                    Options.Create(_clientOptions),
+                    _clientType,
+                    _groupName,
+                    _sessionLogger,
+                    _telemetryHandler);
+                sessions.Start();
+                lock (_completionOwner)
+                {
+                    _completionCts = completionCts;
+                    _completionCancellationToken = completionCts.Token;
+                }
+
+                Volatile.Write(ref _sessions, sessions);
+                Volatile.Write(ref _started, 1);
+            }
+            catch
+            {
+                completionCts.Cancel();
+                completionCts.Dispose();
+                throw;
+            }
         }
         finally
         {
@@ -118,10 +134,25 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
             }
 
             Volatile.Write(ref _started, 0);
-            var sessions = Interlocked.Exchange(ref _sessions, null);
-            if (sessions is not null)
+            CancellationTokenSource? completionCts;
+            lock (_completionOwner)
             {
-                await sessions.DisposeAsync().ConfigureAwait(false);
+                completionCts = _completionCts;
+                _completionCts = null;
+            }
+
+            completionCts?.Cancel();
+            var sessions = Interlocked.Exchange(ref _sessions, null);
+            try
+            {
+                if (sessions is not null)
+                {
+                    await sessions.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                completionCts?.Dispose();
             }
         }
         finally
@@ -448,7 +479,7 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
                 request,
                 token).ConfigureAwait(false);
             GrpcStatus.EnsureSuccess(response.Status);
-        }, cancellationToken);
+        }, cancellationToken, retryInvalidReceiptHandle: true);
     }
 
     public int GetMaxDeliveryAttempts(GrpcMessageView message, int fallback)
@@ -549,48 +580,60 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
         string telemetryOperation,
         GrpcMessageView message,
         Func<CancellationToken, Task> action,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool retryInvalidReceiptHandle = false)
     {
-        using var telemetry = _telemetry.StartSettle(
-            telemetryOperation,
-            message.Topic,
-            _groupName,
-            message.MessageId,
-            message.QueueId,
-            message.Properties);
-        try
+        var lifetimeToken = GetCompletionCancellationToken();
+        using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            lifetimeToken);
+        var completionToken = linkedCancellation.Token;
+        for (var attempt = 1L; ; attempt++)
         {
-            for (var attempt = 1; ; attempt++)
+            completionToken.ThrowIfCancellationRequested();
+            using var telemetry = _telemetry.StartSettle(
+                telemetryOperation,
+                message.Topic,
+                _groupName,
+                message.MessageId,
+                message.QueueId,
+                message.Properties);
+            try
             {
-                try
-                {
-                    await action(cancellationToken).ConfigureAwait(false);
-                    telemetry.Complete();
-                    return;
-                }
-                catch (Exception exception) when (
-                    attempt < CompletionMaxAttempts &&
-                    IsTransientCompletionFailure(exception, cancellationToken))
-                {
-                    var delay = TimeSpan.FromMilliseconds(Math.Min(
-                        CompletionInitialRetryDelay.TotalMilliseconds * Math.Pow(2, attempt - 1),
-                        CompletionMaximumRetryDelay.TotalMilliseconds));
-                    _logger.LogWarning(
-                        exception,
-                        "Transient failure while attempting to {Operation} message {MessageId}; retrying attempt {NextAttempt} of {MaxAttempts} in {Delay}",
-                        operation,
-                        message.MessageId,
-                        attempt + 1,
-                        CompletionMaxAttempts,
-                        delay);
-                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                }
+                await action(completionToken).ConfigureAwait(false);
+                telemetry.Complete();
+                return;
             }
+            catch (Exception exception)
+            {
+                telemetry.Complete(exception);
+                completionToken.ThrowIfCancellationRequested();
+                if (!IsRetryableCompletionFailure(
+                        exception,
+                        completionToken,
+                        retryInvalidReceiptHandle))
+                {
+                    throw;
+                }
+
+                _logger.LogWarning(
+                    exception,
+                    "Failure while attempting to {Operation} message {MessageId}; retrying attempt {NextAttempt} in {Delay}",
+                    operation,
+                    message.MessageId,
+                    attempt + 1,
+                    CompletionRetryDelay);
+            }
+
+            await Task.Delay(CompletionRetryDelay, completionToken).ConfigureAwait(false);
         }
-        catch (Exception exception)
+    }
+
+    private CancellationToken GetCompletionCancellationToken()
+    {
+        lock (_completionOwner)
         {
-            telemetry.Complete(exception);
-            throw;
+            return _completionCancellationToken;
         }
     }
 
@@ -655,28 +698,14 @@ internal sealed class GrpcReceiveConsumerEngine : IGrpcReceiveConsumerEngine
         }
     }
 
-    private static bool IsTransientCompletionFailure(Exception exception, CancellationToken cancellationToken) =>
-        exception switch
-        {
-            OperationCanceledException => !cancellationToken.IsCancellationRequested,
-            RpcException rpc => rpc.StatusCode is
-                StatusCode.Unavailable or
-                StatusCode.DeadlineExceeded or
-                StatusCode.ResourceExhausted or
-                StatusCode.Aborted or
-                StatusCode.Internal,
-            GrpcServiceException service => service.ResponseCode is
-                (int)Proto.Code.RequestTimeout or
-                (int)Proto.Code.TooManyRequests or
-                (int)Proto.Code.InternalError or
-                (int)Proto.Code.InternalServerError or
-                (int)Proto.Code.HaNotAvailable or
-                (int)Proto.Code.ProxyTimeout or
-                (int)Proto.Code.MasterPersistenceTimeout or
-                (int)Proto.Code.SlavePersistenceTimeout,
-            IOException or HttpRequestException or TimeoutException => true,
-            _ => false
-        };
+    private static bool IsRetryableCompletionFailure(
+        Exception exception,
+        CancellationToken cancellationToken,
+        bool retryInvalidReceiptHandle) =>
+        !cancellationToken.IsCancellationRequested &&
+        (exception is not GrpcServiceException service ||
+         retryInvalidReceiptHandle ||
+         service.ResponseCode != (int)Proto.Code.InvalidReceiptHandle);
 
     private bool IsPushConsumer() => _clientType is Proto.ClientType.PushConsumer or Proto.ClientType.LitePushConsumer;
 

--- a/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
+++ b/src/EventHorizon.RocketMQ.Grpc/Consumer/Push/GrpcPushConsumer.cs
@@ -45,6 +45,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
     private CancellationTokenSource? _receivingCts;
     private CancellationTokenSource? _processingCts;
     private CancellationTokenSource? _localRetryCts;
+    private CancellationTokenSource? _completionCts;
     private Task[] _receivers = Array.Empty<Task>();
     private Task[] _consumeLoopTasks = Array.Empty<Task>();
     private int _started;
@@ -96,6 +97,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             _receivingCts = new CancellationTokenSource();
             _processingCts = new CancellationTokenSource();
             _localRetryCts = new CancellationTokenSource();
+            _completionCts = new CancellationTokenSource();
             try
             {
                 await _engine.StartAsync(cancellationToken).ConfigureAwait(false);
@@ -110,12 +112,16 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 _messages.Writer.TryComplete();
                 _receivingCts.Cancel();
                 _processingCts.Cancel();
+                _localRetryCts.Cancel();
+                _completionCts.Cancel();
                 _receivingCts.Dispose();
                 _processingCts.Dispose();
                 _localRetryCts.Dispose();
+                _completionCts.Dispose();
                 _receivingCts = null;
                 _processingCts = null;
                 _localRetryCts = null;
+                _completionCts = null;
                 await _engine.StopAsync().ConfigureAwait(false);
                 throw;
             }
@@ -217,9 +223,11 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         var receivingCts = _receivingCts!;
         var processingCts = _processingCts!;
         var localRetryCts = _localRetryCts!;
+        var completionCts = _completionCts!;
         var consumeLoopsDetached = false;
         receivingCts.Cancel();
         localRetryCts.Cancel();
+        completionCts.Cancel();
         try
         {
             try
@@ -249,7 +257,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 processingCts.Cancel();
-                ObserveConsumeLoops(consumeLoops, processingCts, localRetryCts);
+                ObserveConsumeLoops(consumeLoops, processingCts, localRetryCts, completionCts);
                 consumeLoopsDetached = true;
                 throw;
             }
@@ -292,11 +300,13 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                     {
                         processingCts.Dispose();
                         localRetryCts.Dispose();
+                        completionCts.Dispose();
                     }
 
                     _receivingCts = null;
                     _processingCts = null;
                     _localRetryCts = null;
+                    _completionCts = null;
                     _receivers = Array.Empty<Task>();
                     _consumeLoopTasks = Array.Empty<Task>();
                     DrainMessageChannel();
@@ -674,12 +684,14 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         CancellationToken cancellationToken)
     {
         var maxDeliveryAttempts = _engine.GetMaxDeliveryAttempts(message, _options.MaxDeliveryAttempts);
+        var completionCancellationToken = Volatile.Read(ref _completionCts)?.Token ?? CancellationToken.None;
         if (message.IsCorrupted)
         {
             return await DiscardCorruptedMessageAsync(
                 message,
                 fifo,
                 maxDeliveryAttempts,
+                completionCancellationToken,
                 cancellationToken).ConfigureAwait(false);
         }
 
@@ -713,9 +725,13 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
 
         try
         {
+            using var completionCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                completionCancellationToken);
+            var completionToken = completionCancellation.Token;
             if (completion.Result == ConsumeResult.Success)
             {
-                await _engine.AckAsync(message, cancellationToken).ConfigureAwait(false);
+                await _engine.AckAsync(message, completionToken).ConfigureAwait(false);
             }
             else if (fifo && completion.Result.SuspendDuration is { } suspendDuration)
             {
@@ -724,23 +740,27 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                     batch,
                     fifo,
                     suspendDuration,
-                    cancellationToken).ConfigureAwait(false);
+                    completionToken).ConfigureAwait(false);
             }
             else if (completion.ForwardToDeadLetterQueue)
             {
-                await _engine.ForwardToDeadLetterQueueAsync(message, maxDeliveryAttempts, cancellationToken).ConfigureAwait(false);
+                await _engine.ForwardToDeadLetterQueueAsync(message, maxDeliveryAttempts, completionToken).ConfigureAwait(false);
             }
             else
             {
                 // Processing has finished with failure. This NACK schedules service-owned redelivery; it is not a
                 // handler-active lease extension, which the Proxy owns through AutoRenew.
                 var retryDelay = _engine.GetRetryDelay(message, _options.RetryDelay);
-                await _engine.ScheduleRetryAsync(message, retryDelay, cancellationToken).ConfigureAwait(false);
+                await _engine.ScheduleRetryAsync(message, retryDelay, completionToken).ConfigureAwait(false);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
+        }
+        catch (OperationCanceledException) when (completionCancellationToken.IsCancellationRequested)
+        {
+            return false;
         }
         catch (Exception exception)
         {
@@ -749,7 +769,11 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 "Failed to complete {ConsumeResult} processing for message {MessageId}; the message may be redelivered",
                 completion.Result,
                 message.MessageId);
-            return false;
+            // Released Java advances the FIFO iterator after the completion future finishes exceptionally. Retryable
+            // failures never reach this branch because the engine keeps retrying; a terminal receipt failure therefore
+            // releases only the local order chain and does not synthesize acknowledgement.
+            // https://github.com/apache/rocketmq-clients/blob/java-5.2.1/java/client/src/main/java/org/apache/rocketmq/client/java/impl/consumer/FifoConsumeService.java#L79-L87
+            return true;
         }
 
         return true;
@@ -759,6 +783,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         GrpcMessageView message,
         bool fifo,
         int maxDeliveryAttempts,
+        CancellationToken completionCancellationToken,
         CancellationToken cancellationToken)
     {
         _logger.LogError(
@@ -768,12 +793,16 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
             message.CorruptionReason);
         try
         {
+            using var completionCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                completionCancellationToken);
+            var completionToken = completionCancellation.Token;
             if (fifo)
             {
                 await _engine.ForwardToDeadLetterQueueAsync(
                     message,
                     maxDeliveryAttempts,
-                    cancellationToken).ConfigureAwait(false);
+                    completionToken).ConfigureAwait(false);
             }
             else
             {
@@ -782,7 +811,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
                 await _engine.ScheduleRetryAsync(
                     message,
                     _engine.GetRetryDelay(message, _options.RetryDelay),
-                    cancellationToken).ConfigureAwait(false);
+                    completionToken).ConfigureAwait(false);
             }
 
             return true;
@@ -790,6 +819,10 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
+        }
+        catch (OperationCanceledException) when (completionCancellationToken.IsCancellationRequested)
+        {
+            return false;
         }
         catch (Exception exception)
         {
@@ -1082,13 +1115,15 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
     private void ObserveConsumeLoops(
         Task consumeLoops,
         CancellationTokenSource processingCts,
-        CancellationTokenSource localRetryCts) =>
-        _ = ObserveConsumeLoopsAsync(consumeLoops, processingCts, localRetryCts);
+        CancellationTokenSource localRetryCts,
+        CancellationTokenSource completionCts) =>
+        _ = ObserveConsumeLoopsAsync(consumeLoops, processingCts, localRetryCts, completionCts);
 
     private async Task ObserveConsumeLoopsAsync(
         Task consumeLoops,
         CancellationTokenSource processingCts,
-        CancellationTokenSource localRetryCts)
+        CancellationTokenSource localRetryCts,
+        CancellationTokenSource completionCts)
     {
         try
         {
@@ -1107,6 +1142,7 @@ internal sealed class GrpcPushConsumer : IGrpcPushConsumer
         {
             processingCts.Dispose();
             localRetryCts.Dispose();
+            completionCts.Dispose();
         }
     }
 

--- a/src/EventHorizon.RocketMQ.Grpc/README.md
+++ b/src/EventHorizon.RocketMQ.Grpc/README.md
@@ -193,6 +193,13 @@ messages and does not enable automatic renewal; acknowledge only after durable p
 long-running work. An unsettled message becomes visible again after its current invisible duration. RocketMQ 5.5.0
 Proxy requires a five-second minimum receive long-poll interval.
 
+Every gRPC completion RPC (acknowledgement, retry/NACK, invisibility change, suspension, or dead-letter forwarding)
+retries every failed wire operation at a fixed one-second interval until it succeeds, the caller cancels, or the owning
+Consumer stops. Each attempt creates its own settlement Activity and metric. `INVALID_RECEIPT_HANDLE` is terminal for
+acknowledgement and invisibility changes; dead-letter forwarding retries that status as well, in line with the official
+Java client. FIFO successors wait while completion retry is in progress, then are released after a terminal completion
+failure even though the failed message remains unsettled.
+
 ## PushConsumer
 
 Use `IGrpcPushConsumer` for automatic receive, handler dispatch, and settlement. Register a typed
@@ -227,9 +234,9 @@ public sealed class OrderHandler : IGrpcPushMessageHandler
 ```
 
 Return `ConsumeResult.Success` to acknowledge or `Failure` to follow the effective retry policy. Regular non-FIFO
-Push lets the service advance retry and dead-letter state. FIFO Push retries locally, then the client attempts to
-forward the message to DLQ after exhaustion; if that completion fails, the message remains unsettled and may be
-redelivered. Regular Push treats `ConsumeResult.Suspend(duration)` as `Failure` and ignores its duration. Return
+Push lets the service advance retry and dead-letter state. FIFO Push retries locally, then the client forwards the
+message to DLQ after exhaustion; completion failures retry at one-second intervals, and a terminal failure leaves the
+message unsettled and releases the FIFO successor. Regular Push treats `ConsumeResult.Suspend(duration)` as `Failure` and ignores its duration. Return
 `Success` only after durable business processing; retries, failed completion, and duplicate delivery mean handlers
 must remain idempotent.
 `SubscribeAsync` and `UnsubscribeAsync` update ordinary Push subscriptions at runtime.
@@ -254,8 +261,9 @@ rocketMQ.AddGrpcLitePushConsumer<OrderHandler>(ServiceLifetime.Scoped, options =
 
 Do not call `Subscribe` for LitePush. Use `LiteTopics` at startup or `SubscribeLiteAsync` and
 `UnsubscribeLiteAsync` after startup. Non-FIFO LitePush sends `Failure` and `Suspend` through service-owned retry/DLQ
-progression and ignores the Suspend duration. FIFO LitePush retries `Failure` locally and attempts DLQ forwarding
-after the effective attempt limit; if that completion fails, the message remains unsettled and may be redelivered.
+progression and ignores the Suspend duration. FIFO LitePush retries `Failure` locally and forwards to DLQ after the
+effective attempt limit; completion failures retry at one-second intervals, and a terminal failure leaves the message
+unsettled while releasing the FIFO successor.
 FIFO `ConsumeResult.Suspend(duration)` changes invisibility with the caller-selected duration and `suspend=true`;
 the service owns the delivery attempt reported by the next receive. The same suspension also covers unprocessed
 messages with the same LiteTopic from the current receive batch. Durations shorter than 50 milliseconds are rejected. See the

--- a/src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md
+++ b/src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md
@@ -181,6 +181,11 @@ public sealed class OrderReceiver(IGrpcSimpleConsumer consumer)
 只有在消息完成持久化处理后才确认。对于长时间运行的处理，需要显式延长不可见时间。消息未结算时，会在当前
 不可见时间结束后重新可见。RocketMQ 5.5.0 Proxy 要求接收长轮询间隔至少为五秒。
 
+所有 gRPC completion RPC（确认、重试/NACK、修改不可见时间、暂停和死信转发）都会在每次 wire failure 后按固定 1 秒
+间隔继续发起实际 RPC，直到成功、调用方取消或所属 Consumer 停止。每次 attempt 都会创建独立的 settlement Activity 和
+metric。`INVALID_RECEIPT_HANDLE` 对确认和修改不可见时间是终态错误；死信转发也会重试该状态，与正式版 Java 客户端一致。
+FIFO 后继消息会在 completion 重试期间等待；终态结算失败后，即使失败消息仍未结算，也会释放 FIFO 后继消息。
+
 ## PushConsumer
 
 需要自动接收、分发和结算时，请使用 `IGrpcPushConsumer`。注册 typed
@@ -214,7 +219,8 @@ public sealed class OrderHandler : IGrpcPushMessageHandler
 ```
 
 返回 `ConsumeResult.Success` 表示确认消息，返回 `Failure` 则按生效的重试策略处理。普通非 FIFO Push 由服务端推进
-重试与死信；FIFO Push 在本地重试，耗尽后由客户端尝试转发 DLQ。若该结算失败，消息会保持未结算状态，仍可能再次投递。
+重试与死信；FIFO Push 在本地重试，耗尽后由客户端转发 DLQ。结算失败会按 1 秒间隔重试；终态失败时消息保持未结算，
+但会释放 FIFO 后继消息，仍可能再次投递。
 普通 Push 会把 `ConsumeResult.Suspend(duration)` 当作 `Failure`，并忽略指定时长。只有业务处理已经持久化后才能返回
 `Success`；重试、结算失败和重复投递都可能发生，因此 handler 必须保持幂等。`SubscribeAsync` 和
 `UnsubscribeAsync` 可在运行时更新普通 Push 订阅。
@@ -239,8 +245,8 @@ rocketMQ.AddGrpcLitePushConsumer<OrderHandler>(ServiceLifetime.Scoped, options =
 
 LitePush 不要调用 `Subscribe`。启动时使用 `LiteTopics`，启动后使用 `SubscribeLiteAsync` 和
 `UnsubscribeLiteAsync`。非 FIFO LitePush 的 `Failure` 与 `Suspend` 都由服务端推进重试和死信，并忽略 Suspend 指定的
-时长。FIFO LitePush 会在本地重试 `Failure`，达到有效次数上限后尝试转发 DLQ；如果该结算失败，消息会保持未结算状态，
-仍可能再次投递。FIFO `ConsumeResult.Suspend(duration)` 使用调用方指定的时长和 `suspend=true` 修改不可见时间；
+时长。FIFO LitePush 会在本地重试 `Failure`，达到有效次数上限后转发 DLQ；结算失败会按 1 秒间隔重试，终态失败时消息
+保持未结算但会释放 FIFO 后继消息，仍可能再次投递。FIFO `ConsumeResult.Suspend(duration)` 使用调用方指定的时长和 `suspend=true` 修改不可见时间；
 下一次 receive 返回的投递次数由服务端负责，同时还会暂停当前 receive batch 中尚未处理的同 LiteTopic 消息。时长不能
 短于 50 毫秒。完整结果矩阵参见
 [Consumer 模型](../../docs/zh-CN/grpc/consumer-model.md)。

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pull/Receive/OrderlyPullReceiveLoop.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pull/Receive/OrderlyPullReceiveLoop.cs
@@ -172,7 +172,9 @@ internal sealed class OrderlyPullReceiveLoop
         RemotingMessageView message,
         CancellationToken cancellationToken)
     {
-        var attempt = message.DeliveryAttempt;
+        var maxReconsumeTimes = _options.OrderlyMaxReconsumeTimes < 0
+            ? int.MaxValue
+            : _options.OrderlyMaxReconsumeTimes;
         while (true)
         {
             if (!HasValidBrokerQueueLock(receiver))
@@ -221,14 +223,12 @@ internal sealed class OrderlyPullReceiveLoop
             {
                 case ConsumeResult.Success:
                     return OrderlyDeliveryOutcome.Success;
-                case ConsumeResult.Retry when attempt >= _options.MaxDeliveryAttempts:
+                case ConsumeResult.Retry when message.ReconsumeTimes >= maxReconsumeTimes:
                     try
                     {
-                        await _sendBackSettlement.SendAsync(
-                            receiver.Queue,
+                        await _sendBackSettlement.SendOrderlyRetryAsync(
                             message,
-                            deadLetter: true,
-                            delayLevel: -1,
+                            maxReconsumeTimes,
                             cancellationToken).ConfigureAwait(false);
                         return OrderlyDeliveryOutcome.Success;
                     }
@@ -240,8 +240,9 @@ internal sealed class OrderlyPullReceiveLoop
                     {
                         _logger.LogWarning(
                             exception,
-                            "Unable to send orderly message {MessageId} to the dead-letter queue; retaining the current message for another local attempt",
+                            "Unable to publish exhausted orderly message {MessageId} to the retry topic; retaining the current message for another local attempt",
                             message.MessageId);
+                        IncrementReconsumeTimes(message);
                         var terminalSuspendDuration = ResolveSuspendDuration(
                             batchResult.SuspendCurrentQueueDuration,
                             _options.OrderlySuspendDuration);
@@ -250,7 +251,7 @@ internal sealed class OrderlyPullReceiveLoop
                         break;
                     }
                 case ConsumeResult.Retry:
-                    attempt++;
+                    IncrementReconsumeTimes(message);
                     var suspendDuration = ResolveSuspendDuration(
                         batchResult.SuspendCurrentQueueDuration,
                         _options.OrderlySuspendDuration);
@@ -259,6 +260,14 @@ internal sealed class OrderlyPullReceiveLoop
                 default:
                     throw new InvalidOperationException($"Unsupported ordered consume result '{batchResult.Result}'.");
             }
+        }
+    }
+
+    private static void IncrementReconsumeTimes(RemotingMessageView message)
+    {
+        if (message.ReconsumeTimes < int.MaxValue)
+        {
+            message.ReconsumeTimes++;
         }
     }
 

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pull/Settlement/PullSendBackSettlement.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/Pull/Settlement/PullSendBackSettlement.cs
@@ -100,6 +100,15 @@ internal sealed class PullSendBackSettlement
         _wakeupRebalance();
     }
 
+    public Task SendOrderlyRetryAsync(
+        RemotingMessageView message,
+        int maxReconsumeTimes,
+        CancellationToken cancellationToken) =>
+        _settlementClient.SendOrderlyRetryAsync(
+            message,
+            maxReconsumeTimes,
+            cancellationToken);
+
     private async Task<RetryQueueOffsetInitialization?> PrepareRetryOffsetAsync(
         RemotingConsumerQueue sourceQueue,
         CancellationToken cancellationToken)

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumeContext.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumeContext.cs
@@ -22,7 +22,7 @@ namespace EventHorizon.RocketMQ.Remoting.Consumer.Push;
 /// For a concurrent non-FIFO batch, <see cref="AckIndex"/> selects the acknowledged prefix when the handler returns
 /// <see cref="ConsumeResult.Success"/>, while <see cref="DelayLevelWhenNextConsume"/> selects retry timing when it
 /// returns <see cref="ConsumeResult.Retry"/>. A negative value requests direct dead-lettering only when the internal
-/// receiver uses PULL; POP normalizes it to the default retry level. FIFO <c>MessageGroup</c> ignores these settings.
+/// receiver uses concurrent PULL; POP normalizes it to the default retry level. FIFO <c>MessageGroup</c> ignores these settings.
 /// An orderly PULL delivery uses only <see cref="SuspendCurrentQueueDuration"/>.
 /// </remarks>
 public sealed class RemotingPushConsumeContext
@@ -57,8 +57,9 @@ public sealed class RemotingPushConsumeContext
     /// </summary>
     /// <remarks>
     /// The default value is <c>0</c>, which selects the receiver's default retry interval. A positive value selects a
-    /// receiver-specific RocketMQ retry interval. A negative value requests direct dead-letter delivery for PULL; POP
-    /// normalizes it to <c>0</c> and follows its normal invisibility retry schedule. For POP retries at
+    /// receiver-specific RocketMQ retry interval. A negative value requests direct dead-letter delivery for concurrent PULL;
+    /// orderly PULL uses retry-topic publication instead. POP normalizes it to <c>0</c> and follows its normal invisibility
+    /// retry schedule. For POP retries at
     /// <see cref="RemotingPushConsumerOptions.MaxDeliveryAttempts"/>, the official age-based terminal policy takes
     /// precedence over this value. If
     /// <see cref="RemotingPushConsumerOptions.ConsumeTimeout"/> elapses first, the consumer ignores this value and

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumerOptions.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Push/RemotingPushConsumerOptions.cs
@@ -107,12 +107,32 @@ public sealed class RemotingPushConsumerOptions : ConsumerOptions
     /// Gets or sets the maximum delivery attempt at which protocol-specific terminal retry handling begins.
     /// </summary>
     /// <remarks>
-    /// Clustered PULL and orderly broadcasting attempt dead-letter send-back at this limit. Concurrent broadcasting
-    /// cannot use Broker retry or dead-letter send-back and drops an unsuccessful tail. Classic POP follows the Apache
-    /// Java client's age-based terminal handling instead: it continues changing invisibility until the message is older
-    /// than twice the final POP retry delay, then acknowledges it without implicit dead-letter forwarding.
+    /// Clustered concurrent PULL attempts dead-letter send-back at this limit. Concurrent broadcasting cannot use
+    /// Broker retry or dead-letter send-back and drops an unsuccessful tail. Classic POP follows the Apache Java
+    /// client's age-based terminal handling instead: it continues changing invisibility until the message is older than
+    /// twice the final POP retry delay, then acknowledges it without implicit dead-letter forwarding. Orderly PULL uses
+    /// <see cref="OrderlyMaxReconsumeTimes"/> instead.
     /// </remarks>
     public int MaxDeliveryAttempts { get; set; } = 16;
+
+    /// <summary>
+    /// Gets or sets the maximum number of local orderly reconsumes before retry-topic publication.
+    /// </summary>
+    /// <remarks>
+    /// The value is zero-based and applies only when <see cref="ConsumeOrderly"/> is enabled. The default value
+    /// <c>-1</c> follows the released Apache RocketMQ Java client and means effectively unlimited local reconsumes.
+    /// A value of <c>0</c> publishes after the first unsuccessful handler invocation. At exhaustion, orderly PULL does
+    /// not call <c>CONSUMER_SEND_MSG_BACK</c> or directly forward to DLQ: it publishes a <c>%RETRY%group</c> message
+    /// through internal producer semantics with reconsume, maximum, and delay metadata. The client makes up to three
+    /// immediate wire send attempts for each logical terminal settlement, and the Broker redirects a successfully
+    /// published message to DLQ when its reconsume count exceeds the supplied maximum. Concurrent PULL, POP, and
+    /// <c>MessageGroup</c> delivery ignore this option. A negative delay-level direct-DLQ request remains concurrent
+    /// PULL-only.
+    /// </remarks>
+    /// <seealso href="https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java">
+    /// Apache RocketMQ Java orderly consumption service.
+    /// </seealso>
+    public int OrderlyMaxReconsumeTimes { get; set; } = -1;
 
     /// <summary>
     /// Gets or sets how long the broker may hold a pull request while waiting for new messages.

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/RemotingConsumerEngine.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/RemotingConsumerEngine.cs
@@ -68,6 +68,7 @@ internal sealed class RemotingConsumerEngine : IRemotingConsumerEngine
             resolvedClientOptions,
             routes,
             remotingClient,
+            timeProvider,
             resolvedTelemetry);
     }
 
@@ -177,6 +178,18 @@ internal sealed class RemotingConsumerEngine : IRemotingConsumerEngine
             queue,
             message,
             delayLevel,
+            maxReconsumeTimes,
+            cancellationToken);
+    }
+
+    public Task SendOrderlyRetryAsync(
+        RemotingMessageView message,
+        int maxReconsumeTimes,
+        CancellationToken cancellationToken)
+    {
+        EnsureStarted();
+        return _settlementClient.SendOrderlyRetryAsync(
+            message,
             maxReconsumeTimes,
             cancellationToken);
     }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/RemotingMessageView.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/RemotingMessageView.cs
@@ -37,7 +37,8 @@ public sealed class RemotingMessageView
         long queueOffset,
         long commitLogOffset,
         DateTimeOffset bornTimestamp,
-        DateTimeOffset storeTimestamp)
+        DateTimeOffset storeTimestamp,
+        int flag = 0)
     {
         Topic = topic;
         Body = body;
@@ -47,6 +48,7 @@ public sealed class RemotingMessageView
         Keys = keys;
         Properties = properties;
         DeliveryAttempt = deliveryAttempt;
+        ReconsumeTimes = Math.Max(0, deliveryAttempt - 1);
         MessageGroup = messageGroup;
         QueueId = queueId;
         BrokerName = brokerName;
@@ -54,6 +56,7 @@ public sealed class RemotingMessageView
         CommitLogOffset = commitLogOffset;
         BornTimestamp = bornTimestamp;
         StoreTimestamp = storeTimestamp;
+        Flag = flag;
     }
 
     /// <summary>
@@ -97,6 +100,17 @@ public sealed class RemotingMessageView
     public int DeliveryAttempt { get; }
 
     /// <summary>
+    /// Gets the zero-based number of times the message has been reconsumed.
+    /// </summary>
+    /// <remarks>
+    /// The initial value comes from the Broker message header. Orderly PULL increments this value before each local
+    /// reconsume so the next handler invocation observes the same mutable count as the released Apache RocketMQ Java
+    /// client, including after a failed publication to the group's <c>%RETRY%</c> topic. Other receive
+    /// paths leave it at the Broker-reported value.
+    /// </remarks>
+    public int ReconsumeTimes { get; internal set; }
+
+    /// <summary>
     /// Gets the optional message group used to preserve FIFO ordering.
     /// </summary>
     public string? MessageGroup { get; }
@@ -133,6 +147,8 @@ public sealed class RemotingMessageView
 
     internal ActivityContext? ReceiveActivityContext { get; set; }
 
+    internal int Flag { get; }
+
     internal RemotingMessageView WithTopic(string topic)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(topic);
@@ -156,9 +172,11 @@ public sealed class RemotingMessageView
             QueueOffset,
             CommitLogOffset,
             BornTimestamp,
-            StoreTimestamp)
+            StoreTimestamp,
+            Flag)
         {
-            ReceiveActivityContext = ReceiveActivityContext
+            ReceiveActivityContext = ReceiveActivityContext,
+            ReconsumeTimes = ReconsumeTimes
         };
     }
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Route/RemotingConsumerRouteResolver.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Route/RemotingConsumerRouteResolver.cs
@@ -64,6 +64,18 @@ internal sealed class RemotingConsumerRouteResolver
         }
     }
 
+    internal Task<TopicRouteData> GetRawRouteAsync(
+        string topic,
+        bool forceRefresh,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(topic);
+        return _routes.GetAsync(
+            LegacyNamespace.Wrap(_clientOptions.Namespace, topic),
+            forceRefresh,
+            cancellationToken);
+    }
+
     public async Task<RemotingBrokerEndpoint> ResolveBrokerAsync(
         RemotingConsumerQueue queue,
         bool useSuggestedBroker,

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Settlement/IRemotingSettlementClient.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Settlement/IRemotingSettlementClient.cs
@@ -23,4 +23,9 @@ internal interface IRemotingSettlementClient
         int delayLevel,
         int maxReconsumeTimes,
         CancellationToken cancellationToken);
+
+    Task SendOrderlyRetryAsync(
+        RemotingMessageView message,
+        int maxReconsumeTimes,
+        CancellationToken cancellationToken);
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Consumer/Settlement/RemotingSettlementClient.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Consumer/Settlement/RemotingSettlementClient.cs
@@ -13,40 +13,273 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Globalization;
 using EventHorizon.RocketMQ.Remoting.Consumer.Route;
 using EventHorizon.RocketMQ.Remoting.Exceptions;
 using EventHorizon.RocketMQ.Remoting.Instrumentation;
+using EventHorizon.RocketMQ.Remoting.Producer;
 using EventHorizon.RocketMQ.Remoting.Protocol;
+using EventHorizon.RocketMQ.Remoting.Protocol.Route;
 
 namespace EventHorizon.RocketMQ.Remoting.Consumer.Settlement;
 
 internal sealed class RemotingSettlementClient : IRemotingSettlementClient
 {
+    private const string InnerProducerGroup = "CLIENT_INNER_PRODUCER";
+    private const int DefaultTopicQueueCount = 4;
+    private const int OrderlyRetrySendMaxAttempts = 3;
     private readonly RemotingConsumerSettings _settings;
     private readonly RemotingClientOptions _clientOptions;
     private readonly RemotingConsumerRouteResolver _routes;
     private readonly IRemotingClient _remotingClient;
     private readonly IRemotingRocketMQTelemetry _telemetry;
+    private readonly TimeProvider _timeProvider;
+    private int _orderlyRetryQueueIndex;
 
     public RemotingSettlementClient(
         RemotingConsumerSettings settings,
         RemotingClientOptions clientOptions,
         RemotingConsumerRouteResolver routes,
         IRemotingClient remotingClient,
+        TimeProvider timeProvider,
         IRemotingRocketMQTelemetry telemetry)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(clientOptions);
         ArgumentNullException.ThrowIfNull(routes);
         ArgumentNullException.ThrowIfNull(remotingClient);
+        ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(telemetry);
 
         _settings = settings;
         _clientOptions = clientOptions;
         _routes = routes;
         _remotingClient = remotingClient;
+        _timeProvider = timeProvider;
         _telemetry = telemetry;
     }
+
+    public async Task SendOrderlyRetryAsync(
+        RemotingMessageView message,
+        int maxReconsumeTimes,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        var effectiveMaxReconsumeTimes = maxReconsumeTimes < 0 ? int.MaxValue : maxReconsumeTimes;
+        var nextReconsumeTimes = message.ReconsumeTimes == int.MaxValue
+            ? int.MaxValue
+            : message.ReconsumeTimes + 1;
+        var delayLevel = message.ReconsumeTimes > int.MaxValue - 3
+            ? int.MaxValue
+            : message.ReconsumeTimes + 3;
+        using var telemetry = _telemetry.StartSettle(
+            "reject",
+            message.Topic,
+            _settings.GroupName,
+            message.MessageId,
+            message.QueueId,
+            message.Properties);
+        try
+        {
+            // Released Java republishes an exhausted orderly message through the client's internal producer. The
+            // Broker then compares the retry counters and redirects the new message to DLQ; this is intentionally not
+            // CONSUMER_SEND_MSG_BACK with a negative delay level.
+            // https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java#L351-L399
+            var retryTopic = $"%RETRY%{_settings.GroupName}";
+            var wireRetryTopic = LegacyNamespace.Wrap(_clientOptions.Namespace, retryTopic);
+            var originMessageId = message.Properties.TryGetValue("ORIGIN_MESSAGE_ID", out var origin) &&
+                                  !string.IsNullOrWhiteSpace(origin)
+                ? origin
+                : message.MessageId;
+            var properties = new Dictionary<string, string>(message.Properties, StringComparer.Ordinal)
+            {
+                ["ORIGIN_MESSAGE_ID"] = originMessageId,
+                ["RETRY_TOPIC"] = message.Topic,
+                ["RECONSUME_TIME"] = nextReconsumeTimes.ToString(CultureInfo.InvariantCulture),
+                ["MAX_RECONSUME_TIMES"] = effectiveMaxReconsumeTimes.ToString(CultureInfo.InvariantCulture),
+                ["DELAY"] = delayLevel.ToString(CultureInfo.InvariantCulture)
+            };
+            properties.Remove("TRAN_MSG");
+
+            // Java's internal DefaultMQProducer uses two retries after the initial send. Each attempt resolves a fresh
+            // writable queue so a failed Broker is not pinned for the whole logical settlement operation.
+            // https://github.com/apache/rocketmq/blob/rocketmq-all-5.5.0/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+            Exception? lastException = null;
+            string? lastBrokerName = null;
+            for (var attempt = 0; attempt < OrderlyRetrySendMaxAttempts; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    var queue = await SelectWritableQueueAsync(
+                        retryTopic,
+                        forceRefresh: attempt > 0,
+                        lastBrokerName,
+                        cancellationToken).ConfigureAwait(false);
+                    lastBrokerName = queue.BrokerName;
+                    var response = await _remotingClient.InvokeAsync(
+                        EndpointParser.Parse(queue.Address),
+                        new RemotingCommand(RequestCode.SendMessage, new SendMessageRequestHeader
+                        {
+                            ProducerGroup = InnerProducerGroup,
+                            Topic = wireRetryTopic,
+                            QueueId = queue.QueueId,
+                            SysFlag = 0,
+                            BornTimestamp = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds(),
+                            Flag = message.Flag,
+                            Properties = MessagePropertyCodec.Serialize(properties),
+                            ReconsumeTimes = nextReconsumeTimes,
+                            UnitMode = _clientOptions.UnitMode,
+                            MaxReconsumeTimes = effectiveMaxReconsumeTimes,
+                            Batch = false,
+                            DefaultTopicQueueNums = DefaultTopicQueueCount,
+                            Bname = queue.BrokerName
+                        })
+                        {
+                            Body = message.Body
+                        },
+                        _clientOptions.RequestTimeout,
+                        cancellationToken).ConfigureAwait(false);
+                    EnsureSendSuccess(response);
+                    telemetry.Complete();
+                    return;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (RemotingCommandException exception) when (
+                    IsRetryableSendResponse(exception.ResponseCode) &&
+                    attempt + 1 < OrderlyRetrySendMaxAttempts)
+                {
+                    lastException = exception;
+                }
+                catch (RemotingCommandException)
+                {
+                    throw;
+                }
+                catch (Exception exception) when (exception is InvalidDataException or ArgumentException)
+                {
+                    throw;
+                }
+                catch (Exception exception) when (attempt + 1 < OrderlyRetrySendMaxAttempts)
+                {
+                    lastException = exception;
+                }
+            }
+
+            throw lastException ?? new InvalidOperationException("The orderly retry message could not be sent.");
+        }
+        catch (Exception exception)
+        {
+            telemetry.Complete(exception);
+            throw;
+        }
+    }
+
+    private async Task<WritableQueue> SelectWritableQueueAsync(
+        string retryTopic,
+        bool forceRefresh,
+        string? lastBrokerName,
+        CancellationToken cancellationToken)
+    {
+        var queues = Array.Empty<WritableQueue>();
+        try
+        {
+            var route = await _routes.GetRawRouteAsync(
+                retryTopic,
+                forceRefresh,
+                cancellationToken).ConfigureAwait(false);
+            queues = GetWritableQueues(route, useDefaultRoute: false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // A missing retry-topic route is handled by the same default-topic fallback below.
+        }
+
+        if (queues.Length == 0)
+        {
+            var defaultRoute = await _routes.GetRawRouteAsync(
+                "TBW102",
+                forceRefresh,
+                cancellationToken).ConfigureAwait(false);
+            queues = GetWritableQueues(defaultRoute, useDefaultRoute: true);
+        }
+
+        if (queues.Length == 0)
+        {
+            throw new InvalidOperationException($"No writable message queue is available for retry topic '{retryTopic}'.");
+        }
+
+        var start = (Interlocked.Increment(ref _orderlyRetryQueueIndex) & int.MaxValue) % queues.Length;
+        for (var offset = 0; offset < queues.Length; offset++)
+        {
+            var candidate = queues[(start + offset) % queues.Length];
+            if (lastBrokerName is null ||
+                candidate.BrokerName != lastBrokerName ||
+                queues.All(queue => queue.BrokerName == lastBrokerName))
+            {
+                return candidate;
+            }
+        }
+
+        return queues[start];
+    }
+
+    private static WritableQueue[] GetWritableQueues(TopicRouteData route, bool useDefaultRoute)
+    {
+        const int writePermission = 1 << 1;
+        return route.QueueDatas
+            .Where(queue => (queue.Perm & writePermission) == writePermission)
+            .SelectMany(
+                queue => Enumerable.Range(
+                    0,
+                    useDefaultRoute
+                        ? Math.Min(queue.WriteQueueNums, DefaultTopicQueueCount)
+                        : queue.WriteQueueNums),
+                (queue, queueId) => new { queue.BrokerName, QueueId = queueId })
+            .Join(
+                route.BrokerDatas,
+                static queue => queue.BrokerName,
+                static broker => broker.BrokerName,
+                static (queue, broker) => new { queue.BrokerName, queue.QueueId, broker.BrokerAddrs })
+            .Where(static value => value.BrokerAddrs.TryGetValue(0, out _))
+            .Select(static value => new WritableQueue(
+                value.BrokerName,
+                value.BrokerAddrs[0],
+                value.QueueId))
+            .OrderBy(static queue => queue.BrokerName, StringComparer.Ordinal)
+            .ThenBy(static queue => queue.QueueId)
+            .ToArray();
+    }
+
+    private static void EnsureSendSuccess(RemotingCommand response)
+    {
+        if (response.Code is not (
+            ResponseCodes.ResSuccess or
+            ResponseCodes.ResFlushDiskTimeout or
+            ResponseCodes.ResFlushSlaveTimeout or
+            ResponseCodes.ResSlaveNotAvailable))
+        {
+            throw new RemotingCommandException(
+                response.Code,
+                response.Remark ?? "Broker rejected the orderly retry message.");
+        }
+    }
+
+    private static bool IsRetryableSendResponse(int responseCode) =>
+        responseCode is ResponseCodes.ResTopicNotExist or
+            ResponseCodes.ResServiceNotAvailable or
+            ResponseCodes.ResError or
+            ResponseCodes.ResSystemBusy or
+            ResponseCodes.ResNoPermission or
+            ResponseCodes.ResNoBuyerId or
+            ResponseCodes.ResNotInCurrentUnit or
+            ResponseCodes.ResGoAway;
 
     public async Task SendBackAsync(
         RemotingConsumerQueue queue,
@@ -110,4 +343,6 @@ internal sealed class RemotingSettlementClient : IRemotingSettlementClient
     private string GetConsumerGroup() => LegacyNamespace.Wrap(_clientOptions.Namespace, _settings.GroupName);
 
     private string GetWireTopic(string topic) => LegacyNamespace.Wrap(_clientOptions.Namespace, topic);
+
+    private sealed record WritableQueue(string BrokerName, string Address, int QueueId);
 }

--- a/src/EventHorizon.RocketMQ.Remoting/Protocol/LegacyMessageDecoder.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Protocol/LegacyMessageDecoder.cs
@@ -76,7 +76,7 @@ internal static class LegacyMessageDecoder
 
         _ = reader.ReadInt32(); // body CRC
         var queueId = reader.ReadInt32();
-        _ = reader.ReadInt32(); // application flag
+        var applicationFlag = reader.ReadInt32();
         var queueOffset = reader.ReadInt64();
         var physicalOffset = reader.ReadInt64();
         var sysFlag = reader.ReadInt32();
@@ -129,7 +129,8 @@ internal static class LegacyMessageDecoder
             queueOffset,
             physicalOffset,
             bornTimestamp,
-            storeTimestamp);
+            storeTimestamp,
+            applicationFlag);
     }
 
     private static string? Get(IReadOnlyDictionary<string, string> properties, string name) =>

--- a/src/EventHorizon.RocketMQ.Remoting/Protocol/ResponseCodes.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/Protocol/ResponseCodes.cs
@@ -31,7 +31,10 @@ internal static class ResponseCodes
     public const int ResPullRetryImmediately = 20;
     public const int ResPullOffsetMoved = 21;
     public const int ResQueryNotFound = 22;
+    public const int ResNoBuyerId = 204;
+    public const int ResNotInCurrentUnit = 205;
     public const int ResNoMessage = 208;
     public const int ResPollingFull = 209;
     public const int ResPollingTimeout = 210;
+    public const int ResGoAway = 1500;
 }

--- a/src/EventHorizon.RocketMQ.Remoting/README.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.md
@@ -261,6 +261,7 @@ rocketMQ.AddRemotingPushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, op
     options.MaxConcurrency = 8;
     options.ConsumeMessageBatchSize = 16;
     options.MaxDeliveryAttempts = 16;
+    options.OrderlyMaxReconsumeTimes = -1;
     options.Subscribe("orders", new FilterExpression("created"));
 });
 
@@ -304,23 +305,31 @@ records the source-level Java and Broker references.
 
 `ConsumeMessageBatchSize` controls the largest list passed to one handler call. Return `Success` or `Retry`. For a
 concurrent non-FIFO batch, set `RemotingPushConsumeContext.AckIndex` before returning `Success` to acknowledge only a
-contiguous prefix. `DelayLevelWhenNextConsume` controls the next retry delay. For PULL reception, set it to a negative
-value before returning `Retry` to request direct dead-letter send-back. If that send-back completion fails, the offset
-remains unresolved and the message may be redelivered. For POP reception, the .NET adapter normalizes a negative value
+contiguous prefix. `DelayLevelWhenNextConsume` controls the next retry delay. For concurrent PULL reception, set it to a
+negative value before returning `Retry` to request direct dead-letter send-back. If that send-back completion fails, the
+offset remains unresolved and the message may be redelivered. Orderly PULL does not use this direct-DLQ option. For POP reception, the .NET adapter normalizes a negative value
 to level `0` and follows the normal Java-compatible invisibility retry schedule. Its default value is `0`; PULL uses
-Broker retry timing for that value, while POP applies the Java schedule. At `MaxDeliveryAttempts`, clustered PULL and
-orderly broadcasting attempt classic dead-letter send-back; a failed completion leaves the offset unresolved and the
-message may be redelivered. Concurrent broadcasting cannot use retry or DLQ send-back. POP retry follows the official Java age policy: it continues
-with age-selected invisibility changes and ACKs only after the message is older than twice the final POP retry delay,
-without implicit dead-letter forwarding.
+Broker retry timing for that value, while POP applies the Java schedule. `MaxDeliveryAttempts` remains the limit for
+clustered concurrent PULL, `MessageGroup` FIFO, and POP. At the clustered PULL and `MessageGroup` limits, the client
+attempts classic dead-letter send-back; POP follows the official Java age policy, continuing age-selected invisibility
+changes and acknowledging only after the message is older than twice the final POP retry delay, without implicit
+dead-letter forwarding. Concurrent broadcasting cannot use retry or DLQ send-back.
 
 For orderly PULL delivery (`ConsumeOrderly = true`), set `RemotingPushConsumeContext.SuspendCurrentQueueDuration` before
 returning `Retry` to pause only that physical queue before its next local attempt. When unset, the consumer uses
 `OrderlySuspendDuration`, which defaults to one second; effective values are clamped to 10 milliseconds through 30
 seconds, and each handler invocation receives a fresh context. Concurrent PULL, POP, and `MessageGroup` FIFO delivery
-ignore this override. In both clustered and broadcasting orderly modes, reaching `MaxDeliveryAttempts` attempts to
-forward the message to the dead-letter queue. If send-back fails, the current message remains local, waits for the
-current attempt's suspension duration, and invokes the handler again without advancing the offset.
+ignore this override. Orderly PULL uses the separate zero-based `OrderlyMaxReconsumeTimes`: the default `-1` means
+effectively unlimited local reconsumes, `0` publishes after the first unsuccessful invocation, and a positive value permits
+that many local reconsumes before publication (`1` therefore allows one retry after the initial failure). This applies to
+clustered and orderly broadcasting delivery; orderly ignores `MaxDeliveryAttempts`. At exhaustion, the client does not
+use `CONSUMER_SEND_MSG_BACK` or direct DLQ. It constructs a `%RETRY%<group>` message through internal producer semantics
+with `RECONSUME_TIME`, `MAX_RECONSUME_TIMES`, and delay metadata, then performs up to three immediate wire send attempts for each
+logical terminal settlement. After successful publication, the Broker redirects the retry-topic message to DLQ when its
+reconsume count exceeds the supplied maximum. Each local reconsume increments `RemotingMessageView.ReconsumeTimes` before
+the next handler invocation. The value starts at the Broker header's zero-based count, while `DeliveryAttempt` remains the
+immutable Broker-reported one-based delivery value. If publication fails, the current message remains local, waits for
+the current attempt's suspension duration, and invokes the handler again without advancing the offset.
 
 `ServiceLifetime.Scoped` or `Transient` creates a fresh async scope for each handling attempt. A singleton handler
 must be thread-safe. Handlers must honor cancellation and remain idempotent because delivery is at least once.

--- a/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
+++ b/src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md
@@ -253,6 +253,7 @@ rocketMQ.AddRemotingPushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, op
     options.MaxConcurrency = 8;
     options.ConsumeMessageBatchSize = 16;
     options.MaxDeliveryAttempts = 16;
+    options.OrderlyMaxReconsumeTimes = -1;
     options.Subscribe("orders", new FilterExpression("created"));
 });
 
@@ -292,19 +293,24 @@ PULL。Broker 分配查询失败时，Consumer 会等待下一轮协调，不会
 
 `ConsumeMessageBatchSize` 控制一次处理器调用接收的消息列表上限。处理器返回 `Success` 或 `Retry`。对于并发的非 FIFO
 批次，返回 `Success` 前设置 `RemotingPushConsumeContext.AckIndex`，只确认连续前缀内的消息。
-`DelayLevelWhenNextConsume` 控制下一次重试的延迟。PULL 接收时，可在返回 `Retry` 前将其设为负值，请求直接执行死信
-send-back；如果 send-back 结算失败，位点会保持未解决，消息仍可能再次投递。POP 接收时，.NET 适配器会先将负值归一化
+`DelayLevelWhenNextConsume` 控制下一次重试的延迟。对于并发 PULL 接收，可在返回 `Retry` 前将其设为负值，请求直接执行死信
+send-back；如果 send-back 结算失败，位点会保持未解决，消息仍可能再次投递。orderly PULL 不使用该直接死信选项。POP 接收时，.NET 适配器会先将负值归一化
 为 `0`，再按 Java 兼容的不可见时间重试表处理。默认值为 `0`；PULL 由 Broker 决定重试时间，POP 则按 Java 重试表处理。
-达到 `MaxDeliveryAttempts` 后，集群 PULL 和 orderly 广播都会尝试 classic send-back 进入死信；结算失败时位点保持未解决，
-消息仍可能再次投递。并发广播不使用 retry 或 DLQ send-back。POP 重试则遵循官方 Java 的消息年龄策略，继续按年龄修改不可见时间，
-只有消息年龄超过 POP 最后一级重试延迟的两倍时才 ACK，不会隐式转入死信。
+`MaxDeliveryAttempts` 仍是集群并发 PULL、`MessageGroup` FIFO 和 POP 使用的上限。集群 PULL 和 `MessageGroup` 达到该
+上限后会尝试 classic send-back 进入死信；POP 则遵循官方 Java 的消息年龄策略，继续按年龄修改不可见时间，只有消息年龄
+超过 POP 最后一级重试延迟的两倍时才 ACK，不会隐式转入死信。并发广播不使用 retry 或 DLQ send-back。
 
 对于 orderly PULL 投递（`ConsumeOrderly = true`），handler 可在返回 `Retry` 前设置
 `RemotingPushConsumeContext.SuspendCurrentQueueDuration`，仅暂停当前物理 queue 的下一次本地尝试。未设置时使用
 `OrderlySuspendDuration`，默认值为 1 秒；有效时长限制在 10 毫秒至 30 秒之间，并且每次 handler 调用都会获得新的
-context。并发 PULL、POP 和 `MessageGroup` FIFO 投递会忽略此 override。集群和广播 orderly 达到
-`MaxDeliveryAttempts` 后都会尝试将消息转发到死信队列。send-back 失败时，当前消息会按本次尝试选择的暂停时长继续留在
-本地，重新调用 handler，且不会推进位点。
+context。并发 PULL、POP 和 `MessageGroup` FIFO 投递会忽略此 override。orderly PULL 使用独立的零基
+`OrderlyMaxReconsumeTimes`：默认值 `-1` 表示近似无限次本地重新消费，`0` 表示首次失败后发布，正数表示
+在发布前允许对应次数的本地重新消费（因此 `1` 表示首次失败后再重试一次）。该规则同时适用于集群和 orderly 广播；orderly 不使用
+`MaxDeliveryAttempts`。达到上限后，客户端不会调用 `CONSUMER_SEND_MSG_BACK` 或直接进入死信，而是通过内部 producer 语义构造并发送
+`%RETRY%<group>` 消息，附带 `RECONSUME_TIME`、`MAX_RECONSUME_TIMES` 和延迟元数据；每次逻辑终态结算最多立即执行三次 wire send。
+发布成功后，Broker 会在重新消费次数超过上限时把 retry topic 消息转入 DLQ。每次本地重新消费前都会递增
+`RemotingMessageView.ReconsumeTimes`。该值从 Broker header 的零基计数开始；`DeliveryAttempt` 仍是 Broker 返回的一基投递次数，不会被本地调度改写。
+发布最终失败时，当前消息会按本次尝试选择的暂停时长继续留在本地，重新调用 handler，且不会推进位点。
 
 `ServiceLifetime.Scoped` 或 `Transient` 会为每次处理尝试创建新的异步作用域。Singleton 处理器必须支持并发访问。
 由于投递语义是至少一次，处理器必须响应取消并保证幂等。

--- a/src/EventHorizon.RocketMQ.Remoting/RemotingRocketMQBuilderExtensions.cs
+++ b/src/EventHorizon.RocketMQ.Remoting/RemotingRocketMQBuilderExtensions.cs
@@ -218,6 +218,9 @@ public static class RemotingRocketMQBuilderExtensions
                 "Maximum cached PULL message bytes must be positive.")
             .Validate(static value => value.MaxMessageBytes > 0, "Maximum pull response size must be positive.")
             .Validate(static value => value.MaxDeliveryAttempts > 0, "Maximum delivery attempts must be positive.")
+            .Validate(
+                static value => value.OrderlyMaxReconsumeTimes >= -1,
+                "Maximum orderly reconsume times cannot be less than -1.")
             .Validate(static value => value.LongPollingTimeout > TimeSpan.Zero, "Long polling timeout must be positive.")
             .Validate(static value => value.RetryDelay > TimeSpan.Zero, "Retry delay must be positive.")
             .Validate(static value => value.ConsumeTimeout > TimeSpan.Zero, "Consume timeout must be positive.")

--- a/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/Consumer/Push/Pull/RocketMQPushPullDeadLetterIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests/Consumer/Push/Pull/RocketMQPushPullDeadLetterIntegrationTests.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Concurrent;
 using System.Text;
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 using EventHorizon.RocketMQ.Remoting.Consumer;
@@ -101,6 +102,10 @@ public sealed class RocketMQPushPullDeadLetterIntegrationTests(
         var expectedDeliveryCount = scenario == DeadLetterScenario.Explicit ? 1 : 2;
         var terminalAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var deliveryCount = 0;
+        var isOrderly = scenario is
+            DeadLetterScenario.OrderlyRetryExhausted or
+            DeadLetterScenario.OrderlyBroadcastRetryExhausted;
+        var orderlyReconsumeTimes = new ConcurrentQueue<int>();
         var isOrderlyBroadcast = scenario == DeadLetterScenario.OrderlyBroadcastRetryExhausted;
         var localOffsetPath = isOrderlyBroadcast
             ? Path.Combine(Path.GetTempPath(), $"rocketmq-remoting-dlq-{Guid.NewGuid():N}.json")
@@ -120,14 +125,20 @@ public sealed class RocketMQPushPullDeadLetterIntegrationTests(
             options.PullBatchSize = 1;
             options.ConsumeMessageBatchSize = 1;
             options.MaxConcurrency = 1;
-            options.MaxDeliveryAttempts = expectedDeliveryCount;
+            if (isOrderly)
+            {
+                options.OrderlyMaxReconsumeTimes = expectedDeliveryCount - 1;
+            }
+            else
+            {
+                options.MaxDeliveryAttempts = expectedDeliveryCount;
+            }
+
             options.LongPollingTimeout = TimeSpan.FromSeconds(1);
             options.RetryDelay = TimeSpan.FromMilliseconds(100);
             options.ConsumerMode = isOrderlyBroadcast ? ConsumerMode.Broadcasting : ConsumerMode.Clustering;
             options.LocalOffsetStorePath = localOffsetPath;
-            options.ConsumeOrderly = scenario is
-                DeadLetterScenario.OrderlyRetryExhausted or
-                DeadLetterScenario.OrderlyBroadcastRetryExhausted;
+            options.ConsumeOrderly = isOrderly;
             options.Subscribe(scope.Topic, new FilterExpression(tag));
         }, (messages, context, _) =>
             {
@@ -142,10 +153,9 @@ public sealed class RocketMQPushPullDeadLetterIntegrationTests(
                     terminalAttempt.TrySetResult();
                 }
 
-                if (scenario is
-                    DeadLetterScenario.OrderlyRetryExhausted or
-                    DeadLetterScenario.OrderlyBroadcastRetryExhausted)
+                if (isOrderly)
                 {
+                    orderlyReconsumeTimes.Enqueue(message.ReconsumeTimes);
                     context.SuspendCurrentQueueDuration = TimeSpan.FromMilliseconds(50);
                 }
 
@@ -245,6 +255,10 @@ public sealed class RocketMQPushPullDeadLetterIntegrationTests(
 
             Assert.Equal(1, settlements.Count("reject", scope.Topic, consumerGroup, sent.MessageId));
             Assert.Equal(expectedDeliveryCount, Volatile.Read(ref deliveryCount));
+            if (isOrderly)
+            {
+                Assert.Equal([0, 1], orderlyReconsumeTimes);
+            }
         }
         finally
         {

--- a/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Grpc.Tests/Consumer/Push/GrpcPushConsumerTests.cs
@@ -314,7 +314,7 @@ public sealed class GrpcPushConsumerTests
     }
 
     [Fact]
-    public async Task LitePushSuspend_FifoSettlementFailure_BlocksSameLiteTopicSuccessor()
+    public async Task LitePushSuspend_FifoSettlementFailure_RetriesAndBlocksSuccessorUntilCancellation()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         using var processingCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -335,10 +335,8 @@ public sealed class GrpcPushConsumerTests
             options => options.MaxConcurrency = 2,
             clientType: Proto.ClientType.LitePushConsumer);
         var channelField = typeof(GrpcPushConsumer).GetField("_messages", BindingFlags.Instance | BindingFlags.NonPublic);
-        var blockedSignalField = typeof(GrpcPushConsumer).GetField("_fifoBlockedSignal", BindingFlags.Instance | BindingFlags.NonPublic);
         var processMethod = typeof(GrpcPushConsumer).GetMethod("RunConsumeLoopAsync", BindingFlags.Instance | BindingFlags.NonPublic);
         var channel = Assert.IsAssignableFrom<Channel<GrpcMessageView>>(channelField?.GetValue(consumer));
-        var blockedSignal = Assert.IsType<TaskCompletionSource>(blockedSignalField?.GetValue(consumer));
         var consumeLoops = Enumerable.Range(0, 2)
             .Select(_ => Assert.IsAssignableFrom<Task>(processMethod?.Invoke(consumer, [processingCancellation.Token])))
             .ToArray();
@@ -349,10 +347,14 @@ public sealed class GrpcPushConsumerTests
 
         await consumer.EnqueueBatchAsync([first, successor], cancellationToken);
         channel.Writer.Complete();
-        await blockedSignal.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(3);
+        while (client.ChangeInvisibleRequests.Count < 4 && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(10, cancellationToken);
+        }
 
         Assert.Equal(new[] { "first" }, handled);
-        Assert.Equal(6, client.ChangeInvisibleRequests.Count);
+        Assert.True(client.ChangeInvisibleRequests.Count >= 4);
         Assert.Empty(client.AckRequests);
         Assert.Empty(client.DeadLetterRequests);
 
@@ -916,7 +918,7 @@ public sealed class GrpcPushConsumerTests
             CreateRouteService(queue));
 
         await consumer.StartAsync(cancellationToken);
-        await finalCompletionAttemptStarted.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await finalCompletionAttemptStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
         var stop = consumer.StopAsync(cancellationToken).AsTask();
         try
         {
@@ -934,6 +936,60 @@ public sealed class GrpcPushConsumerTests
         Assert.Equal(new[] { "first" }, handled);
         Assert.Equal(3, ackCalls);
         Assert.Equal(0, consumer.CachedMessageBytes);
+    }
+
+    [Fact]
+    public async Task FifoCompletionFailure_InvalidReceiptHandle_ReleasesSuccessor()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var handled = new ConcurrentQueue<string>();
+        var client = new FakeGrpcClient
+        {
+            AckHandler = static request => Task.FromResult(new Proto.AckMessageResponse
+            {
+                Status = new Proto.Status { Code = Proto.Code.Ok },
+                Entries =
+                {
+                    new Proto.AckMessageResultEntry
+                    {
+                        MessageId = request.Entries[0].MessageId,
+                        ReceiptHandle = request.Entries[0].ReceiptHandle,
+                        Status = new Proto.Status
+                        {
+                            Code = request.Entries[0].MessageId == "first"
+                                ? Proto.Code.InvalidReceiptHandle
+                                : Proto.Code.Ok
+                        }
+                    }
+                }
+            })
+        };
+        await using var consumer = CreateConsumer(
+            client,
+            (message, _) =>
+            {
+                handled.Enqueue(message.MessageId);
+                return ValueTask.FromResult(ConsumeResult.Success);
+            },
+            out var engine,
+            options => options.MaxConcurrency = 2);
+        var channelField = typeof(GrpcPushConsumer).GetField("_messages", BindingFlags.Instance | BindingFlags.NonPublic);
+        var processMethod = typeof(GrpcPushConsumer).GetMethod("RunConsumeLoopAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        var channel = Assert.IsAssignableFrom<Channel<GrpcMessageView>>(channelField?.GetValue(consumer));
+        var consumeLoops = Enumerable.Range(0, 2)
+            .Select(_ => Assert.IsAssignableFrom<Task>(processMethod?.Invoke(consumer, [cancellationToken])))
+            .ToArray();
+        var first = Message("first", "account-7", fifo: true);
+        var successor = Message("successor", "account-7", fifo: true);
+        engine.BindMessage(first);
+        engine.BindMessage(successor);
+
+        await consumer.EnqueueBatchAsync([first, successor], cancellationToken);
+        channel.Writer.Complete();
+        await Task.WhenAll(consumeLoops).WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+
+        Assert.Equal(["first", "successor"], handled);
+        Assert.Equal(2, client.AckRequests.Count);
     }
 
     [Fact]
@@ -1825,26 +1881,163 @@ public sealed class GrpcPushConsumerTests
     }
 
     [Fact]
-    public async Task CompletionRetries_BoundedAndCancellationAware_AreBoundedAndCancellable()
+    public async Task CompletionRetries_ActionFailuresBeyondFormerLimit_RetriesUntilSuccess()
+    {
+        var calls = 0;
+        var client = new FakeGrpcClient
+        {
+            AckHandler = _ => Interlocked.Increment(ref calls) < 4
+                ? Task.FromException<Proto.AckMessageResponse>(new InvalidOperationException("unavailable"))
+                : Task.FromResult(AckSuccess())
+        };
+        await using var engine = CreateEngine(client);
+        var message = Message("eventual-success");
+        engine.BindMessage(message);
+
+        await engine.AckAsync(message, TestContext.Current.CancellationToken);
+
+        Assert.Equal(4, client.AckRequests.Count);
+    }
+
+    [Fact]
+    public async Task CompletionRetries_RetryableFailure_WaitsOneSecondBeforeNextAttempt()
+    {
+        var attempts = new ConcurrentQueue<long>();
+        var client = new FakeGrpcClient
+        {
+            AckHandler = _ =>
+            {
+                attempts.Enqueue(Stopwatch.GetTimestamp());
+                return attempts.Count == 1
+                    ? Task.FromException<Proto.AckMessageResponse>(new IOException("unavailable"))
+                    : Task.FromResult(AckSuccess());
+            }
+        };
+        await using var engine = CreateEngine(client);
+        var message = Message("fixed-delay");
+        engine.BindMessage(message);
+
+        await engine.AckAsync(message, TestContext.Current.CancellationToken);
+
+        var timestamps = attempts.ToArray();
+        Assert.Equal(2, timestamps.Length);
+        Assert.True(
+            Stopwatch.GetElapsedTime(timestamps[0], timestamps[1]) >= TimeSpan.FromMilliseconds(900),
+            "The completion retry did not use the released Java client's one-second interval.");
+    }
+
+    [Fact]
+    public async Task CompletionRetries_CallerCancels_StopsRetrySequence()
     {
         var client = new FakeGrpcClient
         {
             AckHandler = static _ => Task.FromException<Proto.AckMessageResponse>(new IOException("unavailable"))
         };
         await using var engine = CreateEngine(client);
-        var bounded = Message("bounded");
-        engine.BindMessage(bounded);
-
-        await Assert.ThrowsAsync<IOException>(() =>
-            engine.AckAsync(bounded, TestContext.Current.CancellationToken));
-        Assert.Equal(3, client.AckRequests.Count);
+        var message = Message("cancelled");
+        engine.BindMessage(message);
 
         using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
-        var cancelled = Message("cancelled");
-        engine.BindMessage(cancelled);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            engine.AckAsync(cancelled, cancellation.Token));
-        Assert.Equal(4, client.AckRequests.Count);
+            engine.AckAsync(message, cancellation.Token));
+
+        Assert.Single(client.AckRequests);
+    }
+
+    [Fact]
+    public async Task CompletionRetries_ConsumerStops_CancelsRetrySequence()
+    {
+        var firstAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new FakeGrpcClient
+        {
+            AckHandler = _ =>
+            {
+                firstAttempt.TrySetResult();
+                return Task.FromException<Proto.AckMessageResponse>(new IOException("unavailable"));
+            }
+        };
+        await using var engine = CreateEngine(client);
+        await engine.StartAsync(TestContext.Current.CancellationToken);
+        var message = Message("stopped");
+        engine.BindMessage(message);
+
+        var completion = engine.AckAsync(message, CancellationToken.None);
+        await firstAttempt.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        await engine.StopAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            completion.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CompletionRetries_AfterConsumerStops_DoesNotStartWireAttempt()
+    {
+        var client = new FakeGrpcClient();
+        await using var engine = CreateEngine(client);
+        await engine.StartAsync(TestContext.Current.CancellationToken);
+        var message = Message("after-stop");
+        engine.BindMessage(message);
+        await engine.StopAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            engine.AckAsync(message, CancellationToken.None));
+
+        Assert.Empty(client.AckRequests);
+    }
+
+    [Fact]
+    public async Task CompletionTelemetry_RetryableWireFailures_RecordsEveryAttempt()
+    {
+        var calls = 0;
+        var client = new FakeGrpcClient
+        {
+            AckHandler = _ => Interlocked.Increment(ref calls) < 3
+                ? Task.FromException<Proto.AckMessageResponse>(new IOException("unavailable"))
+                : Task.FromResult(AckSuccess())
+        };
+        var failedOperations = Enumerable.Range(0, 2)
+            .Select(_ =>
+            {
+                var operation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
+                operation.Setup(value => value.Complete(It.IsAny<IOException>()));
+                operation.Setup(value => value.Dispose());
+                return operation;
+            })
+            .ToArray();
+        var successfulOperation = new Mock<IGrpcRocketMQTelemetryOperation>(MockBehavior.Strict);
+        successfulOperation.Setup(value => value.Complete());
+        successfulOperation.Setup(value => value.Dispose());
+        var operations = new Queue<IGrpcRocketMQTelemetryOperation>(
+            failedOperations.Select(static operation => operation.Object).Append(successfulOperation.Object));
+        var telemetry = new Mock<IGrpcRocketMQTelemetry>(MockBehavior.Strict);
+        telemetry
+            .Setup(value => value.StartSettle(
+                "ack",
+                "orders",
+                "tests",
+                "telemetry-retry",
+                0,
+                It.IsAny<IReadOnlyDictionary<string, string>?>()))
+            .Returns(() => operations.Dequeue());
+        await using var engine = CreateEngine(client, telemetry.Object);
+        var message = Message("telemetry-retry");
+        engine.BindMessage(message);
+
+        await engine.AckAsync(message, TestContext.Current.CancellationToken);
+
+        telemetry.Verify(value => value.StartSettle(
+            "ack",
+            "orders",
+            "tests",
+            "telemetry-retry",
+            0,
+            It.IsAny<IReadOnlyDictionary<string, string>?>()), Times.Exactly(3));
+        foreach (var operation in failedOperations)
+        {
+            operation.VerifyAll();
+        }
+
+        successfulOperation.VerifyAll();
     }
 
     [Fact]

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/LitePull/RemotingLitePullConsumerTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/LitePull/RemotingLitePullConsumerTests.cs
@@ -1533,6 +1533,12 @@ public sealed class RemotingLitePullConsumerTests
             CancellationToken cancellationToken) =>
             Task.FromException(new NotSupportedException("LitePull tests do not send messages back."));
 
+        public Task SendOrderlyRetryAsync(
+            RemotingMessageView message,
+            int maxReconsumeTimes,
+            CancellationToken cancellationToken) =>
+            Task.FromException(new NotSupportedException("LitePull tests do not send orderly retry messages."));
+
         public ValueTask DisposeAsync()
         {
             Interlocked.Increment(ref _disposeCount);

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/Pull/Orderly/RemotingPushConsumerOrderlyTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/Pull/Orderly/RemotingPushConsumerOrderlyTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using EventHorizon.RocketMQ.Remoting.Consumer;
 using EventHorizon.RocketMQ.Remoting.Consumer.Push;
@@ -32,6 +33,60 @@ namespace EventHorizon.RocketMQ.Remoting.Tests.Consumer.Push.Pull.Orderly;
 
 public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestSupport
 {
+    [Fact]
+    public async Task OrderlyConsumer_DefaultUnlimitedRetryBudget_IncrementsReconsumeTimesPastConcurrentLimit()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var thirdAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var reconsumeTimes = new List<int>();
+        var delivered = 0;
+        var remoting = new FakeRemotingClient("127.0.0.1@orderly-unlimited")
+        {
+            PullHandler = async (request, token) =>
+            {
+                if (Assert.IsType<string>(request.ExtFields["topic"]) == "orders" &&
+                    Interlocked.Exchange(ref delivered, 1) == 0)
+                {
+                    return PullSuccess(CreateMessageRecord("orders", "unlimited", null, 0, 1_000), 1);
+                }
+
+                return await WaitForCanceledPullAsync(token);
+            }
+        };
+        var options = WithMessageHandler(new RemotingPushConsumerOptions
+        {
+            GroupName = "legacy-group",
+            ConsumeOrderly = true,
+            InitialPosition = ConsumeFromPosition.Beginning,
+            MaxConcurrency = 1,
+            MaxDeliveryAttempts = 2,
+            OrderlySuspendDuration = TimeSpan.FromMilliseconds(10),
+            LongPollingTimeout = TimeSpan.FromSeconds(1)
+        }, (messages, _, _) =>
+        {
+            reconsumeTimes.Add(Assert.Single(messages).ReconsumeTimes);
+            if (reconsumeTimes.Count == 3)
+            {
+                thirdAttempt.TrySetResult();
+            }
+
+            return ValueTask.FromResult(ConsumeResult.Retry);
+        });
+        options.Subscribe("orders");
+        await using var consumer = CreateRemotingPushConsumer(
+            options,
+            CreateRouteServiceMock().Object,
+            remoting,
+            "orderly-unlimited");
+
+        await consumer.StartAsync(cancellationToken);
+        await thirdAttempt.Task.WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
+        await consumer.StopAsync(cancellationToken);
+
+        Assert.Equal([0, 1, 2], reconsumeTimes.Take(3));
+        Assert.DoesNotContain(remoting.Requests, static request => request.Code == RequestCode.ConsumerSendMsgBack);
+    }
+
     [Theory]
     [InlineData(-1, 10)]
     [InlineData(0, 10)]
@@ -106,7 +161,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 1,
-            MaxDeliveryAttempts = 3,
+            OrderlyMaxReconsumeTimes = 2,
             RetryDelay = TimeSpan.FromMilliseconds(10),
             OrderlySuspendDuration = TimeSpan.FromMilliseconds(10),
             LongPollingTimeout = TimeSpan.FromSeconds(1)
@@ -180,7 +235,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 1,
-            MaxDeliveryAttempts = 2,
+            OrderlyMaxReconsumeTimes = 1,
             OrderlySuspendDuration = TimeSpan.FromMilliseconds(10),
             LongPollingTimeout = TimeSpan.FromSeconds(1)
         }, (_, _, _) =>
@@ -216,7 +271,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
     }
 
     [Fact]
-    public async Task OrderlyBroadcastConsumer_RetryAtDeliveryLimit_SendsBackAndAdvances()
+    public async Task OrderlyBroadcastConsumer_RetryAtReconsumeLimit_SendsRetryTopicMessageAndAdvances()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var offsetPath = Path.Combine(
@@ -246,7 +301,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 1,
-            MaxDeliveryAttempts = 2,
+            OrderlyMaxReconsumeTimes = 1,
             OrderlySuspendDuration = TimeSpan.FromMilliseconds(10),
             LongPollingTimeout = TimeSpan.FromSeconds(1)
         }, (_, _, _) =>
@@ -287,10 +342,16 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
 
             Assert.Equal(2, calls);
             Assert.Equal(1, persistedOffset);
-            var sendBack = Assert.Single(
+            var retryMessage = Assert.Single(
                 remoting.Requests,
-                static request => request.Code == RequestCode.ConsumerSendMsgBack);
-            Assert.Equal(-1, Convert.ToInt32(sendBack.ExtFields["delayLevel"]));
+                static request => request.Code == RequestCode.SendMessage);
+            AssertOrderlyRetryMessage(
+                retryMessage,
+                "legacy-group",
+                "broadcast-terminal",
+                expectedReconsumeTimes: 2,
+                expectedMaxReconsumeTimes: 1,
+                expectedDelayLevel: 4);
         }
         finally
         {
@@ -299,11 +360,12 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
     }
 
     [Fact]
-    public async Task OrderlyConsumer_DeadLetterSendBackFails_RetriesCurrentMessageWithCallerDuration()
+    public async Task OrderlyConsumer_RetryMessageSendFails_RetriesCurrentMessageWithCallerDuration()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var secondAttempt = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var attempts = new List<long>();
+        var reconsumeTimes = new List<int>();
         var calls = 0;
         var sendBackCalls = 0;
         var delivered = 0;
@@ -319,7 +381,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
 
                 return await WaitForCanceledPullAsync(token);
             },
-            SendBackHandler = (_, _) => Interlocked.Increment(ref sendBackCalls) == 1
+            SendMessageHandler = (_, _) => Interlocked.Increment(ref sendBackCalls) <= 3
                 ? Task.FromException<RemotingCommand>(new IOException("send-back unavailable"))
                 : Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResSuccess })
         };
@@ -329,13 +391,14 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 1,
-            MaxDeliveryAttempts = 1,
+            OrderlyMaxReconsumeTimes = 0,
             RetryDelay = TimeSpan.FromMilliseconds(10),
             OrderlySuspendDuration = TimeSpan.FromMilliseconds(10),
             LongPollingTimeout = TimeSpan.FromSeconds(1)
-        }, (_, context, _) =>
+        }, (messages, context, _) =>
         {
             attempts.Add(Stopwatch.GetTimestamp());
+            reconsumeTimes.Add(Assert.Single(messages).ReconsumeTimes);
             context.SuspendCurrentQueueDuration = TimeSpan.FromMilliseconds(150);
             if (Interlocked.Increment(ref calls) == 2)
             {
@@ -361,7 +424,8 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
         await consumer.StopAsync(cancellationToken);
 
         Assert.Equal(2, calls);
-        Assert.Equal(2, sendBackCalls);
+        Assert.Equal(4, sendBackCalls);
+        Assert.Equal([0, 1], reconsumeTimes);
         Assert.True(
             Stopwatch.GetElapsedTime(attempts[0], attempts[1]) >= TimeSpan.FromMilliseconds(120),
             "The failed send-back did not retain the caller-selected orderly suspension duration.");
@@ -402,7 +466,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 2,
-            MaxDeliveryAttempts = 3,
+            OrderlyMaxReconsumeTimes = 2,
             OrderlySuspendDuration = TimeSpan.FromSeconds(30),
             LongPollingTimeout = TimeSpan.FromSeconds(1)
         }, (messages, context, _) =>
@@ -462,7 +526,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 1,
-            MaxDeliveryAttempts = 3,
+            OrderlyMaxReconsumeTimes = 2,
             OrderlySuspendDuration = TimeSpan.FromMilliseconds(10),
             LongPollingTimeout = TimeSpan.FromSeconds(1)
         }, (_, context, _) =>
@@ -859,7 +923,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
     }
 
     [Fact]
-    public async Task OrderlyConsumer_RetryAtDeliveryLimit_CommitsPastDeadLetteredMessage()
+    public async Task OrderlyConsumer_RetryAtReconsumeLimit_CommitsPastDeadLetteredMessage()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var delivered = 0;
@@ -883,7 +947,7 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             ConsumeOrderly = true,
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 1,
-            MaxDeliveryAttempts = 1,
+            OrderlyMaxReconsumeTimes = 0,
             PullMaxCachedMessages = 1,
             LongPollingTimeout = TimeSpan.FromSeconds(1),
         }, static (_, _, _) => ValueTask.FromResult(ConsumeResult.Retry));
@@ -895,17 +959,24 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             "orderly-dead-letter");
 
         await consumer.StartAsync(cancellationToken);
-        await remoting.WaitForRequestCountAsync(RequestCode.ConsumerSendMsgBack, 1, cancellationToken);
+        await remoting.WaitForRequestCountAsync(RequestCode.SendMessage, 1, cancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(3), cancellationToken);
         while (!remoting.UpdatedOffsets.Any(static update =>
                    update.Topic == "orders" && update.Offset == 1))
         {
             await Task.Delay(10, cancellationToken);
         }
 
-        var sendBack = Assert.Single(
+        var retryMessage = Assert.Single(
             remoting.Requests,
-            static request => request.Code == RequestCode.ConsumerSendMsgBack);
-        Assert.Equal(-1, Convert.ToInt32(sendBack.ExtFields["delayLevel"]));
+            static request => request.Code == RequestCode.SendMessage);
+        AssertOrderlyRetryMessage(
+            retryMessage,
+            "legacy-group",
+            "dead-letter",
+            expectedReconsumeTimes: 1,
+            expectedMaxReconsumeTimes: 0,
+            expectedDelayLevel: 3);
     }
 
     [Fact]
@@ -1244,7 +1315,6 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             InitialPosition = ConsumeFromPosition.Beginning,
             MaxConcurrency = 1,
             PullMaxCachedMessages = 1,
-            MaxDeliveryAttempts = 1,
             RetryDelay = TimeSpan.FromMilliseconds(1),
             LongPollingTimeout = TimeSpan.FromSeconds(1),
         }, (messages, context, _) =>
@@ -1333,5 +1403,29 @@ public sealed class RemotingPushConsumerOrderlyTests : RemotingPushConsumerTestS
             static request => request.Code == RequestCode.UnlockBatchMq &&
                               RequestContainsQueueTopic(request, "orders"),
             cancellationToken);
+    }
+
+    private static void AssertOrderlyRetryMessage(
+        RemotingCommand request,
+        string consumerGroup,
+        string messageId,
+        int expectedReconsumeTimes,
+        int expectedMaxReconsumeTimes,
+        int expectedDelayLevel)
+    {
+        Assert.Equal(RequestCode.SendMessage, request.Code);
+        Assert.Equal($"%RETRY%{consumerGroup}", Assert.IsType<string>(request.ExtFields["topic"]));
+        Assert.Equal("CLIENT_INNER_PRODUCER", Assert.IsType<string>(request.ExtFields["producerGroup"]));
+        Assert.Equal(expectedReconsumeTimes, Convert.ToInt32(request.ExtFields["reconsumeTimes"]));
+        Assert.Equal(expectedMaxReconsumeTimes, Convert.ToInt32(request.ExtFields["maxReconsumeTimes"]));
+        Assert.Equal(messageId, Encoding.UTF8.GetString(Assert.IsType<byte[]>(request.Body)));
+        var properties = MessagePropertyCodec.Deserialize(
+            Assert.IsType<string>(request.ExtFields["properties"]));
+        Assert.Equal("orders", properties["RETRY_TOPIC"]);
+        Assert.Equal(messageId, properties["ORIGIN_MESSAGE_ID"]);
+        Assert.Equal(expectedReconsumeTimes.ToString(), properties["RECONSUME_TIME"]);
+        Assert.Equal(expectedMaxReconsumeTimes.ToString(), properties["MAX_RECONSUME_TIMES"]);
+        Assert.Equal(expectedDelayLevel.ToString(), properties["DELAY"]);
+        Assert.DoesNotContain("TRAN_MSG", properties.Keys);
     }
 }

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumeContextTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/RemotingPushConsumeContextTests.cs
@@ -34,7 +34,9 @@ public sealed class RemotingPushConsumeContextTests
         var context = new RemotingPushConsumeContext();
 
         Assert.Null(context.SuspendCurrentQueueDuration);
-        Assert.Equal(TimeSpan.FromSeconds(1), new RemotingPushConsumerOptions().OrderlySuspendDuration);
+        var options = new RemotingPushConsumerOptions();
+        Assert.Equal(TimeSpan.FromSeconds(1), options.OrderlySuspendDuration);
+        Assert.Equal(-1, options.OrderlyMaxReconsumeTimes);
     }
 
     [Fact]

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/Support/RemotingPushConsumerTestSupport.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Push/Support/RemotingPushConsumerTestSupport.cs
@@ -490,6 +490,7 @@ public abstract class RemotingPushConsumerTestSupport
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? PopHandler { get; init; }
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? AckHandler { get; init; }
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? ChangeInvisibleHandler { get; init; }
+        public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? SendMessageHandler { get; init; }
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? SendBackHandler { get; init; }
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? UpdateOffsetHandler { get; init; }
         public Func<RemotingCommand, CancellationToken, Task<RemotingCommand>>? UnregisterHandler { get; init; }
@@ -668,6 +669,10 @@ public abstract class RemotingPushConsumerTestSupport
                     return ChangeInvisibleHandler is null
                         ? throw new InvalidOperationException("No POP invisibility response was configured.")
                         : await ChangeInvisibleHandler(request, cancellationToken);
+                case RequestCode.SendMessage:
+                    return SendMessageHandler is null
+                        ? Success()
+                        : await SendMessageHandler(request, cancellationToken);
                 case RequestCode.ConsumerSendMsgBack:
                     return SendBackHandler is null
                         ? Success()

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Settlement/RemotingSettlementClientTelemetryTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Consumer/Settlement/RemotingSettlementClientTelemetryTests.cs
@@ -18,6 +18,7 @@ using System.Net;
 using EventHorizon.RocketMQ.Remoting.Consumer;
 using EventHorizon.RocketMQ.Remoting.Consumer.Route;
 using EventHorizon.RocketMQ.Remoting.Consumer.Settlement;
+using EventHorizon.RocketMQ.Remoting.Exceptions;
 using EventHorizon.RocketMQ.Remoting.Instrumentation;
 using EventHorizon.RocketMQ.Remoting.Protocol;
 using EventHorizon.RocketMQ.Remoting.Protocol.Route;
@@ -97,6 +98,224 @@ public sealed class RemotingSettlementClientTelemetryTests
         telemetry.VerifyAll();
     }
 
+    [Fact]
+    public async Task SendOrderlyRetryAsync_BrokerAcceptsRetryTopicMessage_CompletesRejectTelemetry()
+    {
+        var operation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete());
+        operation.Setup(value => value.Dispose());
+        var telemetry = CreateSettlementTelemetry(operation, "reject");
+        var remoting = CreateRemotingClient(
+            _ => Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResSuccess }),
+            RequestCode.SendMessage,
+            request =>
+            {
+                Assert.Equal(7, Convert.ToInt32(request.ExtFields["flag"]));
+                var properties = MessagePropertyCodec.Deserialize(
+                    Assert.IsType<string>(request.ExtFields["properties"]));
+                Assert.Equal("message-1", properties["ORIGIN_MESSAGE_ID"]);
+            });
+        var client = CreateClient(remoting.Object, telemetry.Object);
+
+        await client.SendOrderlyRetryAsync(
+            Message,
+            maxReconsumeTimes: 0,
+            TestContext.Current.CancellationToken);
+
+        operation.VerifyAll();
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
+    public async Task SendOrderlyRetryAsync_RetryTopicHasNoWritableQueue_UsesDefaultTopicRoute()
+    {
+        var operation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete());
+        operation.Setup(value => value.Dispose());
+        var telemetry = CreateSettlementTelemetry(operation, "reject");
+        var remoting = CreateRemotingClient(
+            _ => Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResSuccess }),
+            RequestCode.SendMessage);
+        var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
+        routes
+            .Setup(value => value.GetAsync(
+                "%RETRY%orders-consumer",
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TopicRouteData());
+        routes
+            .Setup(value => value.GetAsync(
+                "TBW102",
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Route());
+        var client = CreateClient(remoting.Object, telemetry.Object, routes.Object);
+
+        await client.SendOrderlyRetryAsync(
+            Message,
+            maxReconsumeTimes: 0,
+            TestContext.Current.CancellationToken);
+
+        routes.VerifyAll();
+        operation.VerifyAll();
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
+    public async Task SendOrderlyRetryAsync_ThreeWireAttemptsFail_CompletesRejectTelemetryWithError()
+    {
+        var expected = new IOException("Broker connection failed.");
+        var operation = CreateFailedOperation(expected);
+        var telemetry = CreateSettlementTelemetry(operation, "reject");
+        var attempts = 0;
+        var remoting = CreateRemotingClient(
+            _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                return Task.FromException<RemotingCommand>(expected);
+            },
+            RequestCode.SendMessage);
+        var client = CreateClient(remoting.Object, telemetry.Object);
+
+        var exception = await Assert.ThrowsAsync<IOException>(() => client.SendOrderlyRetryAsync(
+            Message,
+            maxReconsumeTimes: 0,
+            TestContext.Current.CancellationToken));
+
+        Assert.Same(expected, exception);
+        Assert.Equal(3, attempts);
+        operation.VerifyAll();
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
+    public async Task SendOrderlyRetryAsync_FirstBrokerFails_RetriesAnotherBroker()
+    {
+        var operation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete());
+        operation.Setup(value => value.Dispose());
+        var telemetry = CreateSettlementTelemetry(operation, "reject");
+        var attempts = 0;
+        var brokers = new ConcurrentQueue<string>();
+        var remoting = CreateRemotingClient(
+            _ => Interlocked.Increment(ref attempts) == 1
+                ? Task.FromException<RemotingCommand>(new IOException("Broker connection failed."))
+                : Task.FromResult(new RemotingCommand { Code = ResponseCodes.ResSuccess }),
+            RequestCode.SendMessage,
+            request => brokers.Enqueue(Assert.IsType<string>(request.ExtFields["bname"])));
+        var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
+        routes
+            .Setup(value => value.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RouteWithMultipleBrokers());
+        var client = CreateClient(remoting.Object, telemetry.Object, routes.Object);
+
+        await client.SendOrderlyRetryAsync(
+            Message,
+            maxReconsumeTimes: 0,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, attempts);
+        var selectedBrokers = brokers.ToArray();
+        Assert.Equal(2, selectedBrokers.Length);
+        Assert.NotEqual(selectedBrokers[0], selectedBrokers[1]);
+        operation.VerifyAll();
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
+    public async Task SendOrderlyRetryAsync_NonRetryableBrokerRejection_DoesNotRetry()
+    {
+        var operation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete(It.Is<RemotingCommandException>(exception =>
+            exception.ResponseCode == ResponseCodes.ResRequestCodeNotSupported)));
+        operation.Setup(value => value.Dispose());
+        var telemetry = CreateSettlementTelemetry(operation, "reject");
+        var attempts = 0;
+        var remoting = CreateRemotingClient(
+            _ =>
+            {
+                Interlocked.Increment(ref attempts);
+                return Task.FromResult(new RemotingCommand
+                {
+                    Code = ResponseCodes.ResRequestCodeNotSupported,
+                    Remark = "Unsupported request."
+                });
+            },
+            RequestCode.SendMessage);
+        var client = CreateClient(remoting.Object, telemetry.Object);
+
+        var exception = await Assert.ThrowsAsync<RemotingCommandException>(() => client.SendOrderlyRetryAsync(
+            Message,
+            maxReconsumeTimes: 0,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal(ResponseCodes.ResRequestCodeNotSupported, exception.ResponseCode);
+        Assert.Equal(1, attempts);
+        operation.VerifyAll();
+        telemetry.VerifyAll();
+    }
+
+    [Theory]
+    [InlineData(ResponseCodes.ResTopicNotExist)]
+    [InlineData(ResponseCodes.ResServiceNotAvailable)]
+    [InlineData(ResponseCodes.ResError)]
+    [InlineData(ResponseCodes.ResSystemBusy)]
+    [InlineData(ResponseCodes.ResNoPermission)]
+    [InlineData(ResponseCodes.ResNoBuyerId)]
+    [InlineData(ResponseCodes.ResNotInCurrentUnit)]
+    [InlineData(ResponseCodes.ResGoAway)]
+    public async Task SendOrderlyRetryAsync_JavaRetryableBrokerRejection_Retries(int responseCode)
+    {
+        var operation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete());
+        operation.Setup(value => value.Dispose());
+        var telemetry = CreateSettlementTelemetry(operation, "reject");
+        var attempts = 0;
+        var remoting = CreateRemotingClient(
+            _ => Task.FromResult(new RemotingCommand
+            {
+                Code = Interlocked.Increment(ref attempts) == 1
+                    ? responseCode
+                    : ResponseCodes.ResSuccess
+            }),
+            RequestCode.SendMessage);
+        var client = CreateClient(remoting.Object, telemetry.Object);
+
+        await client.SendOrderlyRetryAsync(
+            Message,
+            maxReconsumeTimes: 0,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, attempts);
+        operation.VerifyAll();
+        telemetry.VerifyAll();
+    }
+
+    [Fact]
+    public async Task SendOrderlyRetryAsync_CanceledBeforeWireAttempt_CompletesRejectTelemetryWithCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var operation = new Mock<IRemotingRocketMQTelemetryOperation>(MockBehavior.Strict);
+        operation.Setup(value => value.Complete(It.Is<OperationCanceledException>(exception =>
+            exception.CancellationToken == cancellation.Token)));
+        operation.Setup(value => value.Dispose());
+        var telemetry = CreateSettlementTelemetry(operation, "reject");
+        var remoting = new Mock<IRemotingClient>(MockBehavior.Strict);
+        var client = CreateClient(remoting.Object, telemetry.Object);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.SendOrderlyRetryAsync(
+            Message,
+            maxReconsumeTimes: 0,
+            cancellation.Token));
+
+        operation.VerifyAll();
+        telemetry.VerifyAll();
+    }
+
     private static RemotingConsumerQueue Queue { get; } = new("orders", "broker-a", 0);
 
     private static RemotingMessageView Message { get; } = new(
@@ -106,7 +325,7 @@ public sealed class RemotingSettlementClientTelemetryTests
         "offset-message-1",
         "created",
         ["key-1"],
-        new Dictionary<string, string>(),
+        new Dictionary<string, string> { ["ORIGIN_MESSAGE_ID"] = " " },
         1,
         null,
         0,
@@ -114,7 +333,8 @@ public sealed class RemotingSettlementClientTelemetryTests
         7,
         1_000,
         DateTimeOffset.UnixEpoch,
-        DateTimeOffset.UnixEpoch);
+        DateTimeOffset.UnixEpoch,
+        flag: 7);
 
     private static Mock<IRemotingRocketMQTelemetryOperation> CreateFailedOperation(Exception expected)
     {
@@ -142,30 +362,42 @@ public sealed class RemotingSettlementClientTelemetryTests
     }
 
     private static Mock<IRemotingClient> CreateRemotingClient(
-        Func<CancellationToken, Task<RemotingCommand>> invoke)
+        Func<CancellationToken, Task<RemotingCommand>> invoke,
+        int requestCode = RequestCode.ConsumerSendMsgBack,
+        Action<RemotingCommand>? inspect = null)
     {
         var remoting = new Mock<IRemotingClient>(MockBehavior.Strict);
         remoting
             .Setup(value => value.InvokeAsync(
                 It.IsAny<EndPoint>(),
-                It.Is<RemotingCommand>(request => request.Code == RequestCode.ConsumerSendMsgBack),
+                It.Is<RemotingCommand>(request => request.Code == requestCode),
                 It.IsAny<TimeSpan>(),
                 It.IsAny<CancellationToken>()))
-            .Returns<EndPoint, RemotingCommand, TimeSpan, CancellationToken>((_, _, _, token) => invoke(token));
+            .Returns<EndPoint, RemotingCommand, TimeSpan, CancellationToken>((_, request, _, token) =>
+            {
+                inspect?.Invoke(request);
+                return invoke(token);
+            });
         return remoting;
     }
 
     private static RemotingSettlementClient CreateClient(
         IRemotingClient remoting,
-        IRemotingRocketMQTelemetry telemetry)
+        IRemotingRocketMQTelemetry telemetry,
+        ITopicRouteService? routeService = null)
     {
-        var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
-        routes
-            .Setup(value => value.GetAsync(
-                "orders",
-                It.IsAny<bool>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Route());
+        if (routeService is null)
+        {
+            var routes = new Mock<ITopicRouteService>(MockBehavior.Strict);
+            routes
+                .Setup(value => value.GetAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Route());
+            routeService = routes.Object;
+        }
+
         var clientOptions = new RemotingClientOptions { RequestTimeout = TimeSpan.FromSeconds(1) };
         return new RemotingSettlementClient(
             new RemotingConsumerSettings(
@@ -174,8 +406,9 @@ public sealed class RemotingSettlementClientTelemetryTests
                 32 * 1024 * 1024,
                 TimeSpan.FromSeconds(1)),
             clientOptions,
-            new RemotingConsumerRouteResolver(Options.Create(clientOptions), routes.Object),
+            new RemotingConsumerRouteResolver(Options.Create(clientOptions), routeService),
             remoting,
+            TimeProvider.System,
             telemetry);
     }
 
@@ -198,6 +431,42 @@ public sealed class RemotingSettlementClientTelemetryTests
                 BrokerName = "broker-a",
                 BrokerAddrs = new ConcurrentDictionary<long, string>(
                     [new KeyValuePair<long, string>(0, "127.0.0.1:10911")])
+            }
+        ]
+    };
+
+    private static TopicRouteData RouteWithMultipleBrokers() => new()
+    {
+        QueueDatas =
+        [
+            new QueueData
+            {
+                BrokerName = "broker-a",
+                ReadQueueNums = 3,
+                WriteQueueNums = 3,
+                Perm = 6
+            },
+            new QueueData
+            {
+                BrokerName = "broker-b",
+                ReadQueueNums = 1,
+                WriteQueueNums = 1,
+                Perm = 6
+            }
+        ],
+        BrokerDatas =
+        [
+            new BrokerData
+            {
+                BrokerName = "broker-a",
+                BrokerAddrs = new ConcurrentDictionary<long, string>(
+                    [new KeyValuePair<long, string>(0, "127.0.0.1:10911")])
+            },
+            new BrokerData
+            {
+                BrokerName = "broker-b",
+                BrokerAddrs = new ConcurrentDictionary<long, string>(
+                    [new KeyValuePair<long, string>(0, "127.0.0.2:10911")])
             }
         ]
     };

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/DependencyInjectionTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/DependencyInjectionTests.cs
@@ -950,6 +950,27 @@ public sealed class DependencyInjectionTests
         Assert.IsType<RemotingPushConsumer>(consumer);
     }
 
+    [Fact]
+    public async Task AddRemotingPushConsumer_OrderlyMaxReconsumeTimesBelowSentinel_RejectsRegistration()
+    {
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQRemoting(options => options.NamesrvAddr = "127.0.0.1:9876")
+            .AddRemotingPushConsumer<TestRemotingPushMessageHandler>(ServiceLifetime.Singleton, options =>
+            {
+                options.GroupName = "orders";
+                options.ConsumeOrderly = true;
+                options.OrderlyMaxReconsumeTimes = -2;
+                options.Subscribe("orders");
+            });
+        await using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            provider.GetRequiredService<IRemotingPushConsumer>);
+
+        Assert.Contains("orderly reconsume times", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(33)]

--- a/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/LegacyMessageDecoderTests.cs
+++ b/tests/ut/EventHorizon.RocketMQ.Remoting.Tests/Protocol/LegacyMessageDecoderTests.cs
@@ -69,6 +69,8 @@ public sealed class LegacyMessageDecoderTests
         Assert.Equal(new[] { "order-1", "order-2" }, message.Keys);
         Assert.Equal("customer-7", message.MessageGroup);
         Assert.Equal(3, message.DeliveryAttempt);
+        Assert.Equal(2, message.ReconsumeTimes);
+        Assert.Equal(7, message.Flag);
         Assert.Equal(42, message.QueueOffset);
         Assert.Equal(1234, message.CommitLogOffset);
         Assert.Equal("broker-a", message.BrokerName);


### PR DESCRIPTION
## Summary

- retry gRPC ACK, invisibility-change, suspension, and DLQ completion RPC failures at the released Java fixed one-second interval until success or lifecycle cancellation; keep invalid receipt terminal for ACK/invisibility, retry it for DLQ, and release FIFO successors after terminal completion failure
- align classic orderly PULL with released Java by defaulting to unlimited local reconsume, exposing zero-based `ReconsumeTimes`, and publishing exhausted messages to `%RETRY%<group>` through internal producer semantics so the Broker applies the DLQ threshold
- use Java-compatible retry metadata, blank-origin fallback, default-topic route fallback, retryable response codes, up to three sends, and alternate-Broker selection
- update protocol telemetry, focused unit coverage, fast DLQ integration coverage, package guides, architecture notes, testing docs, and samples in English and Simplified Chinese

## Released references

- `apache/rocketmq-clients` tag `java-5.2.1`
- `apache/rocketmq` tag `rocketmq-all-5.5.0`
- `apache/rocketmq-client-go` tag `v2.1.2` as secondary corroboration

## Verification

- `dotnet format EventHorizon.RocketMQ.slnx`
- `dotnet restore EventHorizon.RocketMQ.slnx`
- `dotnet build EventHorizon.RocketMQ.slnx --no-restore` (0 warnings, 0 errors)
- gRPC unit tests: 232 passed
- Remoting unit tests: 638 passed
- compatibility tests: 27 passed
- gRPC DLQ integration tests: 4 passed
- Remoting DLQ integration tests: 5 passed

Closes #25