### PR TITLE
feat(samples): add runtime LitePush subscriptions

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -77,13 +77,19 @@ server capabilities, and complete command.
 
 The LiteProducer and LitePushConsumer workflow requires a LITE parent topic, a bound consumer group, Broker LMQ
 support, and a cluster-mode Proxy that implements `SyncLiteSubscription`. Use its dedicated environment instead of
-the normal stack. Start the Consumer first, then start LiteProducer in a second terminal:
+the normal stack. Start the Consumer, add its runtime LiteTopic subscription, then send a matching message:
 
 ```shell
 docker compose -f test-environments/rocketmq-litepush/compose.yaml up -d --wait
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 # In another terminal:
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+# In a third terminal:
 dotnet run --project samples/grpc/GenericHost/LiteProducer
+# In a fourth terminal:
+curl --request POST http://localhost:5232/messages \
+  --header 'Content-Type: application/json' \
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
 ```
 
 For the observability workflow, run the normal RocketMQ environment together with
@@ -98,15 +104,15 @@ use their separate `OpenTelemetry` section.
 
 Every project includes runnable defaults in `appsettings.json`. Normal .NET configuration overrides apply, for
 example `RocketMQ__Client__Endpoint=proxy.example:8081` or
-`RocketMQ__Remoting__NamesrvAddr=nameserver.example:9876`. Producer and Admin Web API projects expose Swagger; their
-HTTP endpoints are application shells around the SDK workflows documented in their guides.
+`RocketMQ__Remoting__NamesrvAddr=nameserver.example:9876`. The Web API samples expose Swagger; their HTTP endpoints
+are application shells around the SDK workflows documented in their guides.
 
 ## Coverage boundaries
 
 Each project demonstrates one coherent end-to-end workflow, not every overload. Advanced paths that require different
 resources, a cooperating peer, or a real processing reason remain in the protocol guides until they justify a
-dedicated runnable sample. Examples include Producer transactions and request-reply, runtime subscription changes,
-LitePull manual assignment and seeking, and operator selection of Broker-side POP request mode.
+dedicated runnable sample. Examples include Producer transactions and request-reply, LitePull manual assignment and
+seeking, and operator selection of Broker-side POP request mode.
 
 See the [gRPC guide](../src/EventHorizon.RocketMQ.Grpc/README.md) and
 [Remoting guide](../src/EventHorizon.RocketMQ.Remoting/README.md) for the complete public APIs.

--- a/samples/README.zh-CN.md
+++ b/samples/README.zh-CN.md
@@ -68,14 +68,20 @@ dotnet run --project samples/grpc/GenericHost/SimpleConsumer
 将项目路径替换为任一普通示例即可。每个项目 README 会说明额外资源、权限、服务端能力和完整命令。
 
 LiteProducer 和 LitePushConsumer 工作流需要 LITE parent topic、绑定的 consumer group、Broker LMQ 能力，以及实现
-`SyncLiteSubscription` 的 cluster-mode Proxy。应使用专用环境，而不是通用 stack。先启动 Consumer，再在第二个终端启动
-LiteProducer：
+`SyncLiteSubscription` 的 cluster-mode Proxy。应使用专用环境，而不是通用 stack。先启动 Consumer，新增运行时 LiteTopic
+订阅，再发送相同 LiteTopic 的消息：
 
 ```shell
 docker compose -f test-environments/rocketmq-litepush/compose.yaml up -d --wait
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 # 在另一个终端：
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+# 在第三个终端：
 dotnet run --project samples/grpc/GenericHost/LiteProducer
+# 在第四个终端：
+curl --request POST http://localhost:5232/messages \
+  --header 'Content-Type: application/json' \
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
 ```
 
 可观测性工作流需要同时运行通用 RocketMQ 环境和 `test-environments/otel-lgtm/compose.yaml`，然后启动 OpenTelemetry
@@ -89,14 +95,14 @@ SDK 自己的连接与角色 options 使用协议专用的 `RocketMQ` 配置节�
 
 每个项目的 `appsettings.json` 都提供可运行默认值，也支持标准 .NET 配置覆盖，例如
 `RocketMQ__Client__Endpoint=proxy.example:8081` 或
-`RocketMQ__Remoting__NamesrvAddr=nameserver.example:9876`。Producer 与 Admin Web API 项目会提供 Swagger；其 HTTP
-端点只是对应指南中 SDK 工作流的应用外壳。
+`RocketMQ__Remoting__NamesrvAddr=nameserver.example:9876`。Web API 示例会提供 Swagger；其 HTTP 端点只是对应指南中 SDK
+工作流的应用外壳。
 
 ## 覆盖边界
 
 每个项目演示一条完整连贯的端到端工作流，而不是每个 overload。需要不同资源、协作端或真实处理时机的高级路径会先留在
-协议指南中，直到它们值得拥有独立的可运行示例，例如 Producer 事务与请求/响应、运行时订阅变更、LitePull 手工分配与
-seek，以及由运维选择 Broker 侧 POP 请求模式。
+协议指南中，直到它们值得拥有独立的可运行示例，例如 Producer 事务与请求/响应、LitePull 手工分配与 seek，以及由运维
+选择 Broker 侧 POP 请求模式。
 
 完整公共 API 请参阅 [gRPC 指南](../src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md)和
 [Remoting 指南](../src/EventHorizon.RocketMQ.Remoting/README.zh-CN.md)。

--- a/samples/grpc/GenericHost/LiteProducer/Program.cs
+++ b/samples/grpc/GenericHost/LiteProducer/Program.cs
@@ -45,8 +45,8 @@ app.UseSwaggerUI();
 
 app.MapPost("/messages", SendLiteMessageAsync)
     .WithName("SendLiteMessage")
-    .WithSummary("Sends a Lite message to the configured logical LiteTopic.")
-    .WithDescription("Uses the gRPC producer and the LITE parent topic prepared by the LitePush environment.")
+    .WithSummary("Sends a Lite message to the requested logical LiteTopic.")
+    .WithDescription("Uses the gRPC producer and the LITE parent topic prepared by the LitePush environment. LiteTopic names use letters, digits, hyphens, and underscores.")
     .Produces<SendLiteMessageResponse>(StatusCodes.Status200OK)
     .ProducesValidationProblem(StatusCodes.Status400BadRequest)
     .ProducesProblem(StatusCodes.Status503ServiceUnavailable);
@@ -62,16 +62,32 @@ static async Task<IResult> SendLiteMessageAsync(
     CancellationToken cancellationToken)
 {
     var messageBody = request?.Message;
-    if (string.IsNullOrWhiteSpace(messageBody))
+    var liteTopic = request?.LiteTopic;
+    if (string.IsNullOrWhiteSpace(messageBody) || string.IsNullOrWhiteSpace(liteTopic))
+    {
+        var errors = new Dictionary<string, string[]>();
+        if (string.IsNullOrWhiteSpace(messageBody))
+        {
+            errors["message"] = ["A message is required."];
+        }
+
+        if (string.IsNullOrWhiteSpace(liteTopic))
+        {
+            errors["liteTopic"] = ["A LiteTopic is required."];
+        }
+
+        return Results.ValidationProblem(errors);
+    }
+
+    if (!IsValidLiteTopic(liteTopic))
     {
         return Results.ValidationProblem(new Dictionary<string, string[]>
         {
-            ["message"] = ["A message is required."]
+            ["liteTopic"] = ["A LiteTopic may contain only letters, digits, hyphens, and underscores."]
         });
     }
 
     const string parentTopic = "eventhorizon-test-lite-parent-topic";
-    const string liteTopic = "eventhorizon-test-lite-topic";
     // LiteTopic selects a logical child of the LITE parent Topic. It is mutually exclusive with FIFO,
     // delayed, and priority message modes, and requires Broker and Proxy Lite support.
     var message = new Message(parentTopic, Encoding.UTF8.GetBytes(messageBody))
@@ -109,3 +125,7 @@ static async Task<IResult> SendLiteMessageAsync(
             statusCode: StatusCodes.Status503ServiceUnavailable);
     }
 }
+
+// Apache RocketMQ 5.5.0 (rocketmq-all-5.5.0) validates LiteTopic characters as [A-Za-z0-9_-].
+static bool IsValidLiteTopic(string liteTopic) =>
+    liteTopic.All(static character => char.IsAsciiLetterOrDigit(character) || character is '-' or '_');

--- a/samples/grpc/GenericHost/LiteProducer/README.md
+++ b/samples/grpc/GenericHost/LiteProducer/README.md
@@ -3,8 +3,8 @@
 [English](README.md) | [Simplified Chinese](README.zh-CN.md)
 
 `IGrpcProducer` sends a Lite message by publishing to a LITE parent topic and setting the message's `LiteTopic`.
-This Generic Host Web API sample publishes to `eventhorizon-test-lite-parent-topic` with the logical LiteTopic
-`eventhorizon-test-lite-topic`. Run it with the companion
+This Generic Host Web API sample keeps `eventhorizon-test-lite-parent-topic` fixed as its parent topic, while each
+`POST /messages` request supplies the logical LiteTopic. Run it with the companion
 [LitePushConsumer](../LitePushConsumer/README.md) to exercise the complete Lite publish-and-dispatch path.
 
 ## When to use it
@@ -25,15 +25,15 @@ shutdown. Application code injects and uses `IGrpcProducer`; it must not manuall
 
 ## Sending a Lite message
 
-The HTTP endpoint constructs a protocol-specific `Message` with the LITE parent topic, then sets `LiteTopic` before
-calling `SendAsync`:
+The HTTP endpoint validates the requested LiteTopic, constructs a protocol-specific `Message` with the LITE parent
+topic, then sets `LiteTopic` before calling `SendAsync`:
 
 ```csharp
 var message = new Message(
     "eventhorizon-test-lite-parent-topic",
     Encoding.UTF8.GetBytes(body))
 {
-    LiteTopic = "eventhorizon-test-lite-topic"
+    LiteTopic = liteTopic
 };
 
 GrpcSendReceipt receipt = await producer.SendAsync(message, cancellationToken);
@@ -56,18 +56,29 @@ docker compose -f test-environments/rocketmq-litepush/compose.yaml up -d --wait
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 ```
 
-In a second terminal, start this Web API and post a message:
+With the Consumer running, add the LiteTopic that will receive the message. The Consumer sample starts with no logical
+subscriptions, so this models a session or tenant becoming active:
+
+```shell
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+```
+
+In a third terminal, start this Web API. Then post a message for that same LiteTopic from a fourth terminal:
 
 ```shell
 dotnet run --project samples/grpc/GenericHost/LiteProducer
+```
+
+```shell
 curl --request POST http://localhost:5232/messages \
   --header 'Content-Type: application/json' \
-  --data '{"message":"hello Lite"}'
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
 ```
 
 The API returns the send receipt data. The LitePushConsumer logs the delivered message after its LiteTopic
 subscription is synchronized. The sample keeps only the Proxy connection settings in `appsettings.json`; the parent
-topic and LiteTopic remain next to the message construction so the Lite routing decision is visible.
+topic remains next to the message construction, and the logical destination remains visible in the API request.
+LiteTopic names use only letters, digits, hyphens, and underscores.
 
 For server capability requirements and the full Producer contract, see the
 [gRPC guide](../../../../src/EventHorizon.RocketMQ.Grpc/README.md) and the

--- a/samples/grpc/GenericHost/LiteProducer/README.zh-CN.md
+++ b/samples/grpc/GenericHost/LiteProducer/README.zh-CN.md
@@ -3,8 +3,8 @@
 [English](README.md) | [简体中文](README.zh-CN.md)
 
 `IGrpcProducer` 通过向 LITE parent topic 发布消息并设置消息的 `LiteTopic` 来发送 Lite message。这个 Generic Host Web API
-示例向 `eventhorizon-test-lite-parent-topic` 发布消息，并使用逻辑 LiteTopic `eventhorizon-test-lite-topic`。请与配套的
-[LitePushConsumer](../LitePushConsumer/README.zh-CN.md) 一起运行，以覆盖完整的 Lite 发布和分发路径。
+示例固定使用 `eventhorizon-test-lite-parent-topic` 作为 parent topic，而每次 `POST /messages` 请求都会提供逻辑 LiteTopic。
+请与配套的 [LitePushConsumer](../LitePushConsumer/README.zh-CN.md) 一起运行，以覆盖完整的 Lite 发布和分发路径。
 
 ## 适用场景
 
@@ -22,14 +22,15 @@ hosted service 会在应用启动时启动 Producer，并在 Host 关闭时停�
 
 ## 发送 Lite message
 
-HTTP endpoint 先用 LITE parent topic 创建协议专属的 `Message`，再在调用 `SendAsync` 前设置 `LiteTopic`：
+HTTP endpoint 会先校验请求中的 LiteTopic，用 LITE parent topic 创建协议专属的 `Message`，再在调用 `SendAsync` 前设置
+`LiteTopic`：
 
 ```csharp
 var message = new Message(
     "eventhorizon-test-lite-parent-topic",
     Encoding.UTF8.GetBytes(body))
 {
-    LiteTopic = "eventhorizon-test-lite-topic"
+    LiteTopic = liteTopic
 };
 
 GrpcSendReceipt receipt = await producer.SendAsync(message, cancellationToken);
@@ -50,17 +51,27 @@ docker compose -f test-environments/rocketmq-litepush/compose.yaml up -d --wait
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 ```
 
-在第二个终端启动此 Web API 并提交消息：
+Consumer 运行后，先新增将要接收消息的 LiteTopic。Consumer 示例初始没有逻辑订阅，因此这一步可表示一个会话或租户开始活跃：
+
+```shell
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+```
+
+在第三个终端启动此 Web API，再在第四个终端向同一个 LiteTopic 提交消息：
 
 ```shell
 dotnet run --project samples/grpc/GenericHost/LiteProducer
+```
+
+```shell
 curl --request POST http://localhost:5232/messages \
   --header 'Content-Type: application/json' \
-  --data '{"message":"hello Lite"}'
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
 ```
 
 API 会返回发送回执数据。LitePushConsumer 完成 LiteTopic 订阅同步后，会记录收到的消息。示例只在 `appsettings.json` 中保留
-Proxy 连接设置；parent topic 和 LiteTopic 保留在消息构造代码旁，使 Lite 路由决策清晰可见。
+Proxy 连接设置；parent topic 保留在消息构造代码旁，逻辑目标则直接体现在 API 请求中。
+LiteTopic 只能使用字母、数字、连字符和下划线。
 
 服务端能力要求和完整 Producer 契约请参阅
 [gRPC 指南](../../../../src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md)与

--- a/samples/grpc/GenericHost/LiteProducer/SendLiteMessageRequest.cs
+++ b/samples/grpc/GenericHost/LiteProducer/SendLiteMessageRequest.cs
@@ -17,5 +17,7 @@ namespace EventHorizon.RocketMQ.Samples.Grpc.LiteProducer;
 
 internal sealed class SendLiteMessageRequest
 {
+    public string? LiteTopic { get; init; }
+
     public string? Message { get; init; }
 }

--- a/samples/grpc/GenericHost/LitePushConsumer/EventHorizon.RocketMQ.Samples.Grpc.LitePushConsumer.csproj
+++ b/samples/grpc/GenericHost/LitePushConsumer/EventHorizon.RocketMQ.Samples.Grpc.LitePushConsumer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -10,11 +10,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <ProjectReference Include="../../../../src/EventHorizon.RocketMQ.Grpc/EventHorizon.RocketMQ.Grpc.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="../../../../src/EventHorizon.RocketMQ.Grpc/EventHorizon.RocketMQ.Grpc.csproj" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/grpc/GenericHost/LitePushConsumer/LitePushConsumerMessageHandler.cs
+++ b/samples/grpc/GenericHost/LitePushConsumer/LitePushConsumerMessageHandler.cs
@@ -26,9 +26,10 @@ internal sealed class LitePushConsumerMessageHandler(
     public ValueTask<ConsumeResult> HandleAsync(GrpcMessageView message, CancellationToken cancellationToken)
     {
         logger.LogInformation(
-            "Received message {MessageId} from {Topic}: {Body}",
+            "Received message {MessageId} from parent topic {Topic}, LiteTopic {LiteTopic}: {Body}",
             message.MessageId,
             message.Topic,
+            message.LiteTopic,
             Encoding.UTF8.GetString(message.Body));
         // The consumer acknowledges the message only after the handler returns Success.
         return ValueTask.FromResult(ConsumeResult.Success);

--- a/samples/grpc/GenericHost/LitePushConsumer/LitePushConsumerMessageHandler.cs
+++ b/samples/grpc/GenericHost/LitePushConsumer/LitePushConsumerMessageHandler.cs
@@ -16,7 +16,6 @@
 using System.Text;
 using EventHorizon.RocketMQ.Grpc.Consumer;
 using EventHorizon.RocketMQ.Grpc.Consumer.Push;
-using Microsoft.Extensions.Logging;
 
 namespace EventHorizon.RocketMQ.Samples.Grpc.LitePushConsumer;
 

--- a/samples/grpc/GenericHost/LitePushConsumer/Program.cs
+++ b/samples/grpc/GenericHost/LitePushConsumer/Program.cs
@@ -16,7 +16,6 @@
 using EventHorizon.RocketMQ.Grpc;
 using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Samples.Grpc.LitePushConsumer;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi;
 
 const string parentTopic = "eventhorizon-test-lite-parent-topic";

--- a/samples/grpc/GenericHost/LitePushConsumer/Program.cs
+++ b/samples/grpc/GenericHost/LitePushConsumer/Program.cs
@@ -14,23 +14,30 @@
 // limitations under the License.
 
 using EventHorizon.RocketMQ.Grpc;
+using EventHorizon.RocketMQ.Grpc.Consumer.LitePush;
 using EventHorizon.RocketMQ.Samples.Grpc.LitePushConsumer;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
 
-var builder = Host.CreateApplicationBuilder(
-    new HostApplicationBuilderSettings
+const string parentTopic = "eventhorizon-test-lite-parent-topic";
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(static options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
     {
-        Args = args,
-        ContentRootPath = AppContext.BaseDirectory
+        Title = "RocketMQ gRPC LitePushConsumer Sample API",
+        Version = "v1",
+        Description = "Adds and removes LiteTopic subscriptions beneath one LITE parent topic."
     });
+});
 var clientSection = builder.Configuration.GetRequiredSection("RocketMQ:Client");
 
 // The endpoint must target a RocketMQ Proxy; this transport does not connect directly to Brokers.
 // Lite Push uses client-initiated long polling.
 // Handler results drive automatic acknowledgement, retry, or DLQ forwarding.
-// ServiceLifetime.Scoped creates a fresh DI scope for each message handling attempt.
+// This role starts with no LiteTopic subscriptions. Application events add and remove them at runtime.
 builder.Services
     .AddRocketMQGrpc(clientSection.Bind)
     .AddGrpcLitePushConsumer<LitePushConsumerMessageHandler>(
@@ -38,8 +45,7 @@ builder.Services
         options =>
         {
             options.GroupName = "eventhorizon-test-lite-push-consumer";
-            options.BindTopic = "eventhorizon-test-lite-parent-topic";
-            options.LiteTopics.Add("eventhorizon-test-lite-topic");
+            options.BindTopic = parentTopic;
             options.BatchSize = 16;
             options.MaxConcurrency = 4;
             options.MaxDeliveryAttempts = 16;
@@ -49,6 +55,121 @@ builder.Services
             options.SubscriptionSyncInterval = TimeSpan.FromSeconds(30);
         });
 
+var app = builder.Build();
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapGet("/subscriptions", GetLiteTopicSubscriptions)
+    .WithName("GetLiteTopicSubscriptions")
+    .WithSummary("Lists LiteTopics currently subscribed by this consumer.")
+    .WithDescription("Returns the local subscription snapshot under the configured LITE parent topic.")
+    .Produces<string[]>(StatusCodes.Status200OK);
+app.MapPost("/subscriptions/{liteTopic}", SubscribeLiteTopicAsync)
+    .WithName("SubscribeLiteTopic")
+    .WithSummary("Adds a LiteTopic subscription at runtime.")
+    .WithDescription("Synchronizes the new LiteTopic with RocketMQ before returning. LiteTopic names use letters, digits, hyphens, and underscores.")
+    .Produces(StatusCodes.Status204NoContent)
+    .ProducesValidationProblem(StatusCodes.Status400BadRequest)
+    .ProducesProblem(StatusCodes.Status503ServiceUnavailable);
+app.MapDelete("/subscriptions/{liteTopic}", UnsubscribeLiteTopicAsync)
+    .WithName("UnsubscribeLiteTopic")
+    .WithSummary("Removes a LiteTopic subscription at runtime.")
+    .WithDescription("Synchronizes removal of the LiteTopic with RocketMQ before returning. LiteTopic names use letters, digits, hyphens, and underscores.")
+    .Produces(StatusCodes.Status204NoContent)
+    .ProducesValidationProblem(StatusCodes.Status400BadRequest)
+    .ProducesProblem(StatusCodes.Status503ServiceUnavailable);
+
 // RunAsync starts and stops the registered Lite Push role through its SDK hosted service.
-// Do not manually call IGrpcLitePushConsumer.StartAsync or StopAsync from this Host application.
-await builder.Build().RunAsync();
+// Application code changes subscriptions but does not manage the consumer lifecycle directly.
+await app.RunAsync();
+
+static IResult GetLiteTopicSubscriptions(IGrpcLitePushConsumer consumer) =>
+    Results.Ok(consumer.LiteTopics.OrderBy(static liteTopic => liteTopic, StringComparer.Ordinal).ToArray());
+
+static async Task<IResult> SubscribeLiteTopicAsync(
+    string liteTopic,
+    IGrpcLitePushConsumer consumer,
+    ILogger<Program> logger,
+    CancellationToken cancellationToken)
+{
+    if (string.IsNullOrWhiteSpace(liteTopic))
+    {
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["liteTopic"] = ["A LiteTopic is required."]
+        });
+    }
+
+    if (!IsValidLiteTopic(liteTopic))
+    {
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["liteTopic"] = ["A LiteTopic may contain only letters, digits, hyphens, and underscores."]
+        });
+    }
+
+    try
+    {
+        await consumer.SubscribeLiteAsync(liteTopic, cancellationToken: cancellationToken).ConfigureAwait(false);
+        logger.LogInformation("Subscribed to LiteTopic {LiteTopic}.", liteTopic);
+        return Results.NoContent();
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+        throw;
+    }
+    catch (Exception exception)
+    {
+        logger.LogError(exception, "Failed to subscribe to LiteTopic {LiteTopic}.", liteTopic);
+        return Results.Problem(
+            title: "RocketMQ LiteTopic subscription failed.",
+            detail: "The LiteTopic could not be synchronized with the RocketMQ service.",
+            statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+}
+
+static async Task<IResult> UnsubscribeLiteTopicAsync(
+    string liteTopic,
+    IGrpcLitePushConsumer consumer,
+    ILogger<Program> logger,
+    CancellationToken cancellationToken)
+{
+    if (string.IsNullOrWhiteSpace(liteTopic))
+    {
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["liteTopic"] = ["A LiteTopic is required."]
+        });
+    }
+
+    if (!IsValidLiteTopic(liteTopic))
+    {
+        return Results.ValidationProblem(new Dictionary<string, string[]>
+        {
+            ["liteTopic"] = ["A LiteTopic may contain only letters, digits, hyphens, and underscores."]
+        });
+    }
+
+    try
+    {
+        await consumer.UnsubscribeLiteAsync(liteTopic, cancellationToken).ConfigureAwait(false);
+        logger.LogInformation("Unsubscribed from LiteTopic {LiteTopic}.", liteTopic);
+        return Results.NoContent();
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+        throw;
+    }
+    catch (Exception exception)
+    {
+        logger.LogError(exception, "Failed to unsubscribe from LiteTopic {LiteTopic}.", liteTopic);
+        return Results.Problem(
+            title: "RocketMQ LiteTopic unsubscription failed.",
+            detail: "The LiteTopic could not be removed from the RocketMQ service.",
+            statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+}
+
+// Apache RocketMQ 5.5.0 (rocketmq-all-5.5.0) validates LiteTopic characters as [A-Za-z0-9_-].
+static bool IsValidLiteTopic(string liteTopic) =>
+    liteTopic.All(static character => char.IsAsciiLetterOrDigit(character) || character is '-' or '_');

--- a/samples/grpc/GenericHost/LitePushConsumer/Properties/launchSettings.json
+++ b/samples/grpc/GenericHost/LitePushConsumer/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5233",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/grpc/GenericHost/LitePushConsumer/README.md
+++ b/samples/grpc/GenericHost/LitePushConsumer/README.md
@@ -18,49 +18,46 @@ role through a client-side setting.
 
 ## SDK workflow
 
-Register the gRPC transport and a LitePush role. `BindTopic` identifies the LITE parent topic; `LiteTopics` is the
-initial complete logical subscription set:
+`BindTopic` identifies the one LITE parent topic. `LiteTopics` can provide an initial logical subscription set, but this
+sample deliberately starts with an empty set: a Web API represents application events such as a session connecting or
+disconnecting.
 
 ```csharp
-rocketMQ.AddGrpcLitePushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, options =>
+rocketMQ.AddGrpcLitePushConsumer<LitePushConsumerMessageHandler>(ServiceLifetime.Scoped, options =>
 {
-    options.GroupName = "orders-lite-push-consumer";
-    options.BindTopic = "orders-lite";
-    options.LiteTopics.Add("orders-us");
-    options.LiteTopics.Add("orders-eu");
-    options.MaxConcurrency = 8;
+    options.GroupName = "eventhorizon-test-lite-push-consumer";
+    options.BindTopic = "eventhorizon-test-lite-parent-topic";
+    options.MaxConcurrency = 4;
 });
 ```
 
-The same `AddRocketMQGrpc` registration may add multiple independently configured LitePush consumers while reusing
-its underlying gRPC channels. Consumers in the same group must use the same `BindTopic`; their LiteTopic sets may
-differ. Different groups receive independently.
+The API calls the public runtime subscription methods after the SDK-hosted service has started the consumer:
+
+```csharp
+await consumer.SubscribeLiteAsync(liteTopic, cancellationToken: cancellationToken);
+await consumer.UnsubscribeLiteAsync(liteTopic, cancellationToken);
+```
+
+`POST /subscriptions/{liteTopic}` adds a subscription, `DELETE /subscriptions/{liteTopic}` removes one, and
+`GET /subscriptions` returns the current local snapshot. LiteTopic names use only letters, digits, hyphens, and
+underscores, so `chat-session-123` is suitable for a session-oriented flow. Each successful mutation has already
+synchronized with RocketMQ; an invalid name such as `chat.session-123` returns HTTP 400, while an SDK failure becomes
+HTTP 503 and leaves the local set unchanged.
 
 Do not call the inherited `ConsumerOptions.Subscribe` for this role. LitePush receives through `BindTopic` and manages
 logical subscriptions with `LiteTopics`, `SubscribeLiteAsync`, and `UnsubscribeLiteAsync`; it does not accept ordinary
-topic filters.
+topic filters. The same `AddRocketMQGrpc` registration may add multiple independently configured LitePush consumers
+while reusing its underlying gRPC channels. Consumers in the same group must use the same `BindTopic`; their LiteTopic
+sets may differ. Different groups receive independently.
 
-The Generic Host integration starts the role, synchronizes the configured set, and stops it with the host. Outside a
-host, manage `StartAsync` and `StopAsync` through `IGrpcLitePushConsumer`. `LiteTopics` returns a snapshot of the current
-local set.
+The Generic Host starts and stops the consumer through its SDK-hosted service. The API changes subscriptions but does
+not manage that lifecycle. Runtime subscriptions are local application state, so establish them again after a Consumer
+restart. `LiteTopics` returns a snapshot of the current local set.
 
-At runtime, a new LiteTopic can include an initial offset selection:
-
-```csharp
-await consumer.SubscribeLiteAsync(
-    "orders-apac",
-    GrpcLiteOffsetOption.Last,
-    cancellationToken);
-```
-
-`GrpcLiteOffsetOption` supports the service-defined recent position (`Last`), earliest or latest available position
-(`Min` / `Max`), an exact non-negative queue offset (`AtOffset`), a recent message count (`Tail`), or the first stored
-message at or after a timestamp (`AtTimestamp`). The option applies when that LiteTopic subscription is created.
-
-The client sends the complete configured LiteTopic set at startup and reconciles it every
-`SubscriptionSyncInterval`. The service remains authoritative for name and quota rules. A rejected runtime change
-throws `GrpcServiceException` and does not update the local set. `SyncLiteSubscription` controls subscriptions; message
-delivery still uses client-initiated long polling.
+For a newly added LiteTopic, production code can select an initial offset with `GrpcLiteOffsetOption`, for example
+`GrpcLiteOffsetOption.Last`. The sample uses the service default to keep the session-subscription path focused. The
+client reconciles the complete local set every `SubscriptionSyncInterval`; `SyncLiteSubscription` controls
+subscriptions while delivery remains client-initiated long polling.
 
 ## Delivery and failure semantics
 
@@ -104,7 +101,7 @@ service with a Broker.
 | `GrpcClientOptions.Endpoint` | The RocketMQ Proxy endpoint; capability must include `SyncLiteSubscription`. |
 | `GrpcLitePushConsumerOptions.GroupName` | The consumer group bound to the LITE parent topic. |
 | `BindTopic` | The single parent topic used for assignment and message reception. |
-| `LiteTopics` | The complete initial logical LiteTopic set synchronized at startup. |
+| `LiteTopics` | Optional initial logical LiteTopic set synchronized at startup; this sample intentionally leaves it empty. |
 | `SubscriptionSyncInterval` | Periodic reconciliation interval for the complete LiteTopic set. |
 | `MaxConcurrency`, `BatchSize`, and cache limits | Local handler parallelism, receive batch size, and bounded buffering inherited from Push. |
 | `InvisibleDuration` / `ConsumeTimeout` | Initial invisibility and the non-FIFO handler timeout behavior inherited from Push. |
@@ -121,12 +118,31 @@ docker compose -f test-environments/rocketmq-litepush/compose.yaml up -d --wait
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 ```
 
-Only the Proxy connection settings are externalized in `appsettings.json`; the consumer role values remain visible
-beside its registration in `Program.cs`. The runnable code binds to `eventhorizon-test-lite-parent-topic` and
-subscribes to `eventhorizon-test-lite-topic`. Start the companion [LiteProducer](../LiteProducer/README.md) after
-this Consumer to publish a Lite message under that parent. The ordinary Producer sample does not populate LiteTopics.
-After the LiteProducer request is delivered, the handler logs the message and returns `Success`, so the SDK
-acknowledges it. The host continues running until Ctrl+C.
+The Consumer Web API runs at `http://localhost:5233`; Swagger is available at
+`http://localhost:5233/swagger`. In another terminal, add a session subscription before sending a matching message:
+
+```shell
+curl http://localhost:5233/subscriptions
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+curl http://localhost:5233/subscriptions
+```
+
+Start LiteProducer in a third terminal, then post the matching message from a fourth terminal:
+
+```shell
+dotnet run --project samples/grpc/GenericHost/LiteProducer
+```
+
+```shell
+curl --request POST http://localhost:5232/messages \
+  --header 'Content-Type: application/json' \
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
+```
+
+To end the session, call `curl --request DELETE http://localhost:5233/subscriptions/chat-session-123`.
+Only the Proxy connection settings are externalized in `appsettings.json`; the parent-topic binding remains visible
+beside its registration in `Program.cs`. The handler logs the parent topic and LiteTopic, then returns `Success`, so
+the SDK acknowledges the message after processing. The host continues running until Ctrl+C.
 
 For the complete API and deployment constraints, see the
 [gRPC guide](../../../../src/EventHorizon.RocketMQ.Grpc/README.md) and

--- a/samples/grpc/GenericHost/LitePushConsumer/README.zh-CN.md
+++ b/samples/grpc/GenericHost/LitePushConsumer/README.zh-CN.md
@@ -16,44 +16,42 @@ LiteTopic 自动分发到 handler 时，才适合使用 LitePushConsumer。
 
 ## SDK 工作流
 
-注册 gRPC 传输和 LitePush 角色。`BindTopic` 指定 LITE parent topic，`LiteTopics` 是初始的完整逻辑订阅集合：
+`BindTopic` 指向唯一的 LITE parent topic。`LiteTopics` 可以提供启动时的逻辑订阅集合，但本示例会刻意以空集合启动：Web
+API 用来承接应用中的会话连接、断开等事件。
 
 ```csharp
-rocketMQ.AddGrpcLitePushConsumer<OrderMessageHandler>(ServiceLifetime.Scoped, options =>
+rocketMQ.AddGrpcLitePushConsumer<LitePushConsumerMessageHandler>(ServiceLifetime.Scoped, options =>
 {
-    options.GroupName = "orders-lite-push-consumer";
-    options.BindTopic = "orders-lite";
-    options.LiteTopics.Add("orders-us");
-    options.LiteTopics.Add("orders-eu");
-    options.MaxConcurrency = 8;
+    options.GroupName = "eventhorizon-test-lite-push-consumer";
+    options.BindTopic = "eventhorizon-test-lite-parent-topic";
+    options.MaxConcurrency = 4;
 });
 ```
 
-同一个 `AddRocketMQGrpc` 注册可以添加多个配置彼此独立的 LitePush Consumer，并复用底层 gRPC channel。同一 group
-中的 Consumer 必须使用相同 `BindTopic`，但 LiteTopic 集合可以不同；不同 group 则会独立接收消息。
-
-不要为该角色调用继承的 `ConsumerOptions.Subscribe`。LitePush 通过 `BindTopic` 接收消息，并用 `LiteTopics`、
-`SubscribeLiteAsync` 和 `UnsubscribeLiteAsync` 管理逻辑订阅；它不接受普通 topic 过滤条件。
-
-Generic Host 集成会启动该角色、同步已配置的集合，并随 Host 停止该角色。不使用 Host 时，应通过
-`IGrpcLitePushConsumer` 管理 `StartAsync` 和 `StopAsync`。`LiteTopics` 返回当前本地集合的快照。
-
-在运行时，新 LiteTopic 可以附带一个初始 offset 选择：
+SDK 的 hosted service 启动 Consumer 后，API 会调用公开的运行时订阅方法：
 
 ```csharp
-await consumer.SubscribeLiteAsync(
-    "orders-apac",
-    GrpcLiteOffsetOption.Last,
-    cancellationToken);
+await consumer.SubscribeLiteAsync(liteTopic, cancellationToken: cancellationToken);
+await consumer.UnsubscribeLiteAsync(liteTopic, cancellationToken);
 ```
 
-`GrpcLiteOffsetOption` 支持服务端定义的最近位置（`Last`）、最早或最新可用位置（`Min` / `Max`）、明确的非负 queue
-offset（`AtOffset`）、最近若干条消息（`Tail`），或者该时间点或之后存储的第一条消息（`AtTimestamp`）。该选项在创建对应
-LiteTopic 订阅时生效。
+`POST /subscriptions/{liteTopic}` 新增订阅，`DELETE /subscriptions/{liteTopic}` 删除订阅，
+`GET /subscriptions` 返回当前本地快照。LiteTopic 只能使用字母、数字、连字符和下划线，因此
+`chat-session-123` 适合用来演示按会话管理 LiteTopic。接口成功返回前已经完成与 RocketMQ 的同步；
+`chat.session-123` 这类无效名称会返回 HTTP 400，SDK 调用失败会返回 HTTP 503，且不会修改本地集合。
 
-客户端会在启动时发送完整的已配置 LiteTopic 集合，并按 `SubscriptionSyncInterval` 定期协调。名称和配额规则仍由服务端
-决定。运行时变更被拒绝时会抛出 `GrpcServiceException`，且不会更新本地集合。`SyncLiteSubscription` 只负责订阅控制；
-消息投递仍然由客户端发起长轮询。
+不要为该角色调用继承的 `ConsumerOptions.Subscribe`。LitePush 通过 `BindTopic` 接收消息，并用 `LiteTopics`、
+`SubscribeLiteAsync` 和 `UnsubscribeLiteAsync` 管理逻辑订阅；它不接受普通 topic 过滤条件。同一个
+`AddRocketMQGrpc` 注册可以添加多个配置彼此独立的 LitePush Consumer，并复用底层 gRPC channel。同一 group 中的 Consumer
+必须使用相同 `BindTopic`，但 LiteTopic 集合可以不同；不同 group 则会独立接收消息。
+
+Generic Host 会通过 SDK 的 hosted service 启动和停止 Consumer。API 只修改订阅，不负责 Consumer 生命周期。运行时订阅是
+应用本地状态，Consumer 重启后应由应用事件重新建立。`LiteTopics` 返回当前本地集合的快照。
+
+生产代码可以在新增 LiteTopic 时通过 `GrpcLiteOffsetOption` 选择初始 offset，例如
+`GrpcLiteOffsetOption.Last`。本示例使用服务端默认值，避免把重点从会话订阅流程上移开。客户端会按
+`SubscriptionSyncInterval` 定期协调完整的本地集合；`SyncLiteSubscription` 只负责订阅控制，消息仍通过客户端发起的
+长轮询投递。
 
 ## 投递与失败语义
 
@@ -92,7 +90,7 @@ LitePush 要求客户端、Proxy、Broker、Topic 和 consumer group 的配置�
 | `GrpcClientOptions.Endpoint` | RocketMQ Proxy 端点；Proxy 必须支持 `SyncLiteSubscription`。 |
 | `GrpcLitePushConsumerOptions.GroupName` | 与 LITE parent topic 绑定的 consumer group。 |
 | `BindTopic` | 用于分配和消息接收的单一 parent topic。 |
-| `LiteTopics` | 启动时同步的完整初始逻辑 LiteTopic 集合。 |
+| `LiteTopics` | 可选的启动初始逻辑 LiteTopic 集合；本示例刻意保持为空。 |
 | `SubscriptionSyncInterval` | 定期协调完整 LiteTopic 集合的间隔。 |
 | `MaxConcurrency`、`BatchSize` 和缓存限制 | 从 Push 继承的本地 handler 并发、Receive 批量和有界缓冲。 |
 | `InvisibleDuration` / `ConsumeTimeout` | 从 Push 继承的初始不可见时长和非 FIFO handler 超时行为。 |
@@ -109,10 +107,30 @@ docker compose -f test-environments/rocketmq-litepush/compose.yaml up -d --wait
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 ```
 
-`appsettings.json` 只保存 Proxy 连接设置，Consumer 角色参数都直接写在 `Program.cs` 的注册旁。可运行代码绑定
-`eventhorizon-test-lite-parent-topic`，并订阅 `eventhorizon-test-lite-topic`。启动此 Consumer 后，可运行配套的
-[LiteProducer](../LiteProducer/README.zh-CN.md)，以在该 parent 下发送 Lite message；普通 Producer 示例不会写入 LiteTopic。
-LiteProducer 请求投递后，handler 会记录该消息并返回 `Success`，因此 SDK 会确认它。Host 会持续运行到按下 Ctrl+C。
+Consumer Web API 运行在 `http://localhost:5233`，Swagger 地址为 `http://localhost:5233/swagger`。在另一个终端先为
+会话新增订阅，再发送同一 LiteTopic 的消息：
+
+```shell
+curl http://localhost:5233/subscriptions
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+curl http://localhost:5233/subscriptions
+```
+
+在第三个终端启动 LiteProducer，再在第四个终端提交同一 LiteTopic 的消息：
+
+```shell
+dotnet run --project samples/grpc/GenericHost/LiteProducer
+```
+
+```shell
+curl --request POST http://localhost:5232/messages \
+  --header 'Content-Type: application/json' \
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
+```
+
+会话结束时，可调用 `curl --request DELETE http://localhost:5233/subscriptions/chat-session-123`。`appsettings.json`
+只保存 Proxy 连接设置，parent topic 绑定直接写在 `Program.cs` 的注册旁。handler 会记录 parent topic 和 LiteTopic，然后返回
+`Success`，由 SDK 在处理完成后确认消息。Host 会持续运行到按下 Ctrl+C。
 
 完整 API 和部署约束请参阅
 [gRPC 指南](../../../../src/EventHorizon.RocketMQ.Grpc/README.zh-CN.md)与

--- a/test-environments/rocketmq-litepush/README.md
+++ b/test-environments/rocketmq-litepush/README.md
@@ -24,10 +24,10 @@ creates or updates the following idempotently:
 | --- | --- | --- |
 | LITE parent Topic | `eventhorizon-test-lite-parent-topic` | `message.type=LITE` |
 | Consumer Group | `eventhorizon-test-lite-push-consumer` | `lite.bind.topic=eventhorizon-test-lite-parent-topic` |
-| LiteTopic used by the sample | `eventhorizon-test-lite-topic` | Synchronized by `IGrpcLitePushConsumer` through `SyncLiteSubscription` when the sample starts. |
 
-`eventhorizon-test-lite-topic` is a logical LiteTopic below the LITE parent Topic. It is not an independent ordinary
-Topic that `resource-init` needs to create.
+LiteTopics are logical children of the LITE parent Topic, not independent ordinary Topics that `resource-init` creates.
+The LitePushConsumer sample intentionally starts with none, then its HTTP API synchronizes current names through
+`IGrpcLitePushConsumer.SubscribeLiteAsync` and `UnsubscribeLiteAsync` at runtime.
 
 The Broker enables `enableLmq=true` and `enableMultiDispatch=true`. The Proxy starts separately with
 `mqproxy -pm cluster`; RocketMQ 5.5.0's Broker-integrated Proxy does not provide `SyncLiteSubscription`.
@@ -38,7 +38,7 @@ The Broker enables `enableLmq=true` and `enableMultiDispatch=true`. The Proxy st
 flowchart TB
     Host[Developer host]
     Producer[LiteProducer sample\nHTTP: localhost:5232]
-    Consumer[LitePushConsumer sample\ngRPC endpoint: localhost:8081]
+    Consumer[LitePushConsumer sample\nHTTP: localhost:5233]
     DashboardUi[Browser\nhttp://localhost:8082]
 
     subgraph Environment[test-environments/rocketmq-litepush]
@@ -106,26 +106,38 @@ Start the Consumer in one terminal:
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 ```
 
-Then start LiteProducer in a second terminal and post a message to its HTTP API:
+With the Consumer running, add a runtime subscription in another terminal. LiteTopic names use only letters, digits,
+hyphens, and underscores:
+
+```shell
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+curl http://localhost:5233/subscriptions
+```
+
+Start LiteProducer in a third terminal, then post a message to that same LiteTopic from a fourth terminal:
 
 ```shell
 dotnet run --project samples/grpc/GenericHost/LiteProducer
-curl --request POST http://localhost:5232/messages \
-  --header 'Content-Type: application/json' \
-  --data '{"message":"hello Lite"}'
 ```
 
-The Consumer synchronizes `eventhorizon-test-lite-topic` at startup. LiteProducer sends a Lite message under
-`eventhorizon-test-lite-parent-topic` with that LiteTopic, so it becomes eligible for that subscription. The standard
-Producer sample sends ordinary messages and therefore does not populate the LiteTopic. Both Lite samples run in a
-Generic Host, which owns their Producer or Consumer `StartAsync` and `StopAsync` lifecycle.
+```shell
+curl --request POST http://localhost:5232/messages \
+  --header 'Content-Type: application/json' \
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
+```
+
+LiteProducer sends a Lite message under `eventhorizon-test-lite-parent-topic` with the requested LiteTopic, so it
+becomes eligible for the current subscription. The standard Producer sample sends ordinary messages and therefore does
+not populate a LiteTopic. Both Lite samples run in a Generic Host, which owns their Producer or Consumer `StartAsync`
+and `StopAsync` lifecycle. Runtime subscriptions belong to the Consumer process, so recreate them after it restarts.
 
 ## Endpoints and limits
 
 | Purpose | Host endpoint | Notes |
 | --- | --- | --- |
 | gRPC Lite samples | `localhost:8081` | The default `RocketMQ:Client:Endpoint`. |
-| LiteProducer HTTP API | `http://localhost:5232/messages` | `POST` JSON such as `{"message":"hello Lite"}`. |
+| LitePushConsumer HTTP API | `http://localhost:5233/subscriptions` | `POST` or `DELETE /{liteTopic}` changes runtime subscriptions; `GET` returns the local snapshot. |
+| LiteProducer HTTP API | `http://localhost:5232/messages` | `POST` JSON such as `{"liteTopic":"chat-session-123","message":"hello Lite"}`. |
 | NameServer diagnostics | `localhost:19876` | Optional inspection endpoint, not the gRPC client endpoint. |
 | RocketMQ Dashboard | `http://localhost:8082` | Local management interface for the cluster. |
 | Broker | Not published | Reachable only as `broker:10911` inside the Compose network. |

--- a/test-environments/rocketmq-litepush/README.zh-CN.md
+++ b/test-environments/rocketmq-litepush/README.zh-CN.md
@@ -22,10 +22,9 @@ RocketMQ Dashboard 的访问地址为 `http://localhost:8082`。它的浏览器�
 | --- | --- | --- |
 | LITE parent Topic | `eventhorizon-test-lite-parent-topic` | `message.type=LITE` |
 | Consumer Group | `eventhorizon-test-lite-push-consumer` | `lite.bind.topic=eventhorizon-test-lite-parent-topic` |
-| 示例使用的 LiteTopic | `eventhorizon-test-lite-topic` | 示例启动时由 `IGrpcLitePushConsumer` 通过 `SyncLiteSubscription` 同步。 |
 
-`eventhorizon-test-lite-topic` 是 LITE parent Topic 下的逻辑 LiteTopic，并不是 `resource-init` 需要创建的独立普通
-Topic。
+LiteTopic 是 LITE parent Topic 下的逻辑子级，并不是 `resource-init` 需要创建的独立普通 Topic。LitePushConsumer 示例会刻意以
+空集合启动，再通过 HTTP API 在运行时调用 `IGrpcLitePushConsumer.SubscribeLiteAsync` 和 `UnsubscribeLiteAsync` 同步当前名称。
 
 Broker 已启用 `enableLmq=true` 和 `enableMultiDispatch=true`。Proxy 作为独立进程以 `mqproxy -pm cluster` 启动；
 RocketMQ 5.5.0 的 Broker-integrated Proxy 不支持 `SyncLiteSubscription` RPC。
@@ -36,7 +35,7 @@ RocketMQ 5.5.0 的 Broker-integrated Proxy 不支持 `SyncLiteSubscription` RPC�
 flowchart TB
     Host[开发者宿主机]
     Producer[LiteProducer 示例\nHTTP: localhost:5232]
-    Consumer[LitePushConsumer 示例\ngRPC endpoint: localhost:8081]
+    Consumer[LitePushConsumer 示例\nHTTP: localhost:5233]
     DashboardUi[浏览器\nhttp://localhost:8082]
 
     subgraph Environment[test-environments/rocketmq-litepush]
@@ -102,26 +101,36 @@ docker compose logs --no-color resource-init
 dotnet run --project samples/grpc/GenericHost/LitePushConsumer
 ```
 
-再在第二个终端启动 LiteProducer，并向其 HTTP API 提交消息：
+Consumer 运行后，在另一个终端新增运行时订阅。LiteTopic 只能使用字母、数字、连字符和下划线：
+
+```shell
+curl --request POST http://localhost:5233/subscriptions/chat-session-123
+curl http://localhost:5233/subscriptions
+```
+
+在第三个终端启动 LiteProducer，再在第四个终端向同一个 LiteTopic 提交消息：
 
 ```shell
 dotnet run --project samples/grpc/GenericHost/LiteProducer
-curl --request POST http://localhost:5232/messages \
-  --header 'Content-Type: application/json' \
-  --data '{"message":"hello Lite"}'
 ```
 
-Consumer 启动时会同步 `eventhorizon-test-lite-topic`。LiteProducer 会在
-`eventhorizon-test-lite-parent-topic` 下向该 LiteTopic 发送 Lite message，因此消息可由此订阅接收。标准 Producer 示例发送的是
-普通消息，不会写入 LiteTopic。两个 Lite 示例都运行在 Generic Host 中，由 Host 负责 Producer 或 Consumer 的
-`StartAsync` 和 `StopAsync` 生命周期。
+```shell
+curl --request POST http://localhost:5232/messages \
+  --header 'Content-Type: application/json' \
+  --data '{"liteTopic":"chat-session-123","message":"hello Lite"}'
+```
+
+LiteProducer 会在 `eventhorizon-test-lite-parent-topic` 下向请求指定的 LiteTopic 发送 Lite message，因此消息可由当前订阅
+接收。标准 Producer 示例发送的是普通消息，不会写入 LiteTopic。两个 Lite 示例都运行在 Generic Host 中，由 Host 负责
+Producer 或 Consumer 的 `StartAsync` 和 `StopAsync` 生命周期。运行时订阅属于 Consumer 进程，重启后需要重新建立。
 
 ## 端点与限制
 
 | 用途 | 宿主机端点 | 说明 |
 | --- | --- | --- |
 | gRPC Lite 示例 | `localhost:8081` | 默认的 `RocketMQ:Client:Endpoint`。 |
-| LiteProducer HTTP API | `http://localhost:5232/messages` | `POST` JSON，例如 `{"message":"hello Lite"}`。 |
+| LitePushConsumer HTTP API | `http://localhost:5233/subscriptions` | `POST` 或 `DELETE /{liteTopic}` 修改运行时订阅；`GET` 返回本地快照。 |
+| LiteProducer HTTP API | `http://localhost:5232/messages` | `POST` JSON，例如 `{"liteTopic":"chat-session-123","message":"hello Lite"}`。 |
 | NameServer 诊断 | `localhost:19876` | 可选的检查端点，不是 gRPC 客户端端点。 |
 | RocketMQ Dashboard | `http://localhost:8082` | 集群的本地管理界面。 |
 | Broker | 不公开 | 仅能在 Compose 网络内通过 `broker:10911` 访问。 |

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLiteIntegrationTests.cs
@@ -78,6 +78,79 @@ public sealed class RocketMQLiteIntegrationTests(RocketMQSingleBrokerContainerFi
 
     [Fact]
     [Trait("Category", "Integration")]
+    public async Task GrpcLitePushConsumer_EmptyInitialSubscriptions_RuntimeSubscriptionDispatchesAndUnsubscribes()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var fixture = await registry.GetFixtureAsync(cancellationToken);
+        var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Lite, cancellationToken);
+        var consumerGroup = await scope.CreateLiteConsumerGroupAsync(
+            "grpc-runtime-lite-push-consumer",
+            cancellationToken);
+        var liteTopic = $"lite-runtime-{Guid.NewGuid():N}";
+        var subscribedBody = $"grpc-lite-runtime-subscribed-{Guid.NewGuid():N}";
+        var unsubscribedBody = $"grpc-lite-runtime-unsubscribed-{Guid.NewGuid():N}";
+        var observation = new RuntimeLiteMessageObservation(liteTopic, subscribedBody, unsubscribedBody);
+        var services = new ServiceCollection();
+        services.AddSingleton(observation);
+        services
+            .AddRocketMQGrpc(options => options.Endpoint = fixture.GrpcEndpoint)
+            .AddGrpcProducer(options => options.Topics.Add(scope.Topic))
+            .AddGrpcLitePushConsumer<RuntimeLiteMessageHandler>(ServiceLifetime.Singleton, options =>
+            {
+                options.GroupName = consumerGroup;
+                options.BindTopic = scope.Topic;
+                options.LongPollingTimeout = TimeSpan.FromSeconds(1);
+            });
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IGrpcProducer>();
+        var consumer = provider.GetRequiredService<IGrpcLitePushConsumer>();
+        await producer.StartAsync(cancellationToken);
+        await consumer.StartAsync(cancellationToken);
+        try
+        {
+            Assert.Empty(consumer.LiteTopics);
+
+            await consumer.SubscribeLiteAsync(liteTopic, cancellationToken: cancellationToken);
+            Assert.Contains(liteTopic, consumer.LiteTopics);
+
+            var receipt = await producer.SendAsync(new Message(
+                scope.Topic,
+                Encoding.UTF8.GetBytes(subscribedBody))
+            {
+                LiteTopic = liteTopic
+            }, cancellationToken);
+
+            var messageId = await observation.SubscribedMessage.Task.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken);
+            Assert.Equal(receipt.MessageId, messageId);
+
+            await consumer.UnsubscribeLiteAsync(liteTopic, cancellationToken);
+            Assert.DoesNotContain(liteTopic, consumer.LiteTopics);
+
+            await producer.SendAsync(new Message(
+                scope.Topic,
+                Encoding.UTF8.GetBytes(unsubscribedBody))
+            {
+                LiteTopic = liteTopic
+            }, cancellationToken);
+
+            var completion = await Task.WhenAny(
+                observation.MessageAfterUnsubscribe.Task,
+                Task.Delay(TimeSpan.FromSeconds(3), cancellationToken));
+            if (ReferenceEquals(completion, observation.MessageAfterUnsubscribe.Task))
+            {
+                Assert.Fail($"Received message '{await observation.MessageAfterUnsubscribe.Task}' after unsubscribing from LiteTopic '{liteTopic}'.");
+            }
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
     public async Task GrpcLitePushConsumer_FifoSuspend_RedeliversAfterRequestedDuration()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -255,6 +328,46 @@ public sealed class RocketMQLiteIntegrationTests(RocketMQSingleBrokerContainerFi
 
             return ValueTask.FromResult(ConsumeResult.Success);
         }
+    }
+
+    private sealed class RuntimeLiteMessageObservation(
+        string liteTopic,
+        string subscribedBody,
+        string unsubscribedBody)
+    {
+        public TaskCompletionSource<string> SubscribedMessage { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<string> MessageAfterUnsubscribe { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask<ConsumeResult> HandleAsync(GrpcMessageView message)
+        {
+            if (!string.Equals(message.LiteTopic, liteTopic, StringComparison.Ordinal))
+            {
+                return ValueTask.FromResult(ConsumeResult.Success);
+            }
+
+            var body = Encoding.UTF8.GetString(message.Body);
+            if (string.Equals(body, subscribedBody, StringComparison.Ordinal))
+            {
+                SubscribedMessage.TrySetResult(message.MessageId);
+            }
+            else if (string.Equals(body, unsubscribedBody, StringComparison.Ordinal))
+            {
+                MessageAfterUnsubscribe.TrySetResult(message.MessageId);
+            }
+
+            return ValueTask.FromResult(ConsumeResult.Success);
+        }
+    }
+
+    private sealed class RuntimeLiteMessageHandler(RuntimeLiteMessageObservation observation)
+        : IGrpcPushMessageHandler
+    {
+        public ValueTask<ConsumeResult> HandleAsync(
+            GrpcMessageView message,
+            CancellationToken cancellationToken) => observation.HandleAsync(message);
     }
 
     private sealed class LiteSuspendObservation(string expectedBody, TimeSpan suspendDuration)


### PR DESCRIPTION
## Summary
- redesign the gRPC LitePushConsumer sample around a fixed LITE parent topic and runtime LiteTopic subscriptions
- update the LiteProducer sample and LitePush environment guides for dynamic LiteTopics
- add a real RocketMQ 5.5.0 integration test for empty-start, subscribe, dispatch, and unsubscribe behavior

## Validation
- `dotnet format tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj --no-restore --verify-no-changes`
- `dotnet build tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj --no-restore --tl:off -p:UseSharedCompilation=false`
- `dotnet test tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj --no-restore --tl:off -m:1 -p:UseSharedCompilation=false` (18 passed)