### PR TITLE
test(grpc): configure ordered group for FIFO dispatch

### DIFF
--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMessageTypesIntegrationTests.cs
@@ -35,7 +35,10 @@ public sealed class RocketMQMessageTypesIntegrationTests(RocketMQSingleBrokerCon
         var cancellationToken = TestContext.Current.CancellationToken;
         var fixture = await registry.GetFixtureAsync(cancellationToken);
         var scope = await fixture.CreateTestScopeAsync(RocketMQTestTopicType.Fifo, cancellationToken);
-        var consumerGroup = scope.CreateConsumerGroupName("grpc-fifo-consumer");
+        var consumerGroup = await scope.CreateOrderedConsumerGroupAsync(
+            "grpc-fifo-consumer",
+            retryMaxTimes: 16,
+            cancellationToken);
         var tag = $"fifo-{Guid.NewGuid():N}";
         var messageGroup = $"account-{Guid.NewGuid():N}";
         var received = new ConcurrentQueue<int>();


### PR DESCRIPTION
Configure the FIFO integration test consumer group as orderly so Broker-synchronized settings select the FIFO receive path.\n\nValidation: focused FIFO test passed three consecutive runs; full gRPC integration suite passed 18/18.