### PR TITLE
test(grpc): cover local and multi-proxy topologies

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -182,13 +182,19 @@ jobs:
       matrix:
         include:
           - protocol: gRPC
-            topology: single-Broker
+            topology: cluster-mode-single-Broker
             test_project: tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
-            test_filter: Topology!=MultiBroker
+            test_filter: Topology!=MultiBroker&Topology!=LocalProxy
             coverage_directory: grpc-single-broker-integration
             coverage_name: dotnet-grpc-single-broker-integration-tests
           - protocol: gRPC
-            topology: multi-Broker
+            topology: local-mode-Proxy
+            test_project: tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
+            test_filter: Topology=LocalProxy
+            coverage_directory: grpc-local-proxy-integration
+            coverage_name: dotnet-grpc-local-proxy-integration-tests
+          - protocol: gRPC
+            topology: multi-Broker-multi-Proxy
             test_project: tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/EventHorizon.RocketMQ.Grpc.IntegrationTests.csproj
             test_filter: Topology=MultiBroker
             coverage_directory: grpc-multi-broker-integration

--- a/docs/en-US/testing/local-and-integration-testing.md
+++ b/docs/en-US/testing/local-and-integration-testing.md
@@ -22,7 +22,8 @@ Unit and compatibility tests
 
 Integration tests
     -> protocol-isolated Testcontainers fixtures
-    -> single-Broker baseline and three-Broker route coverage
+    -> cluster-mode single-Broker baseline and three-Broker/two-Proxy failover coverage
+    -> Broker-integrated local-mode Proxy compatibility coverage
     -> protocol-specific integration test assemblies
 
 Manual samples
@@ -139,7 +140,17 @@ creates an isolated Docker network, starts an Apache RocketMQ 5.5.0 NameServer a
 starts a cluster-mode Proxy after the Broker registers. A lazy xUnit v3 assembly-fixture registry
 owns one baseline fixture per integration-test assembly, so independent test classes can share the
 same Docker stack without serializing the whole project. The runner permits up to four parallel test
-collections; a filtered multi-Broker job does not initialize the baseline fixture.
+collections; a filtered local-Proxy or multi-Broker job does not initialize the baseline fixture.
+
+[`RocketMQLocalProxyContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQLocalProxyContainerFixture.cs)
+uses the official released baseline tag `rocketmq-all-5.5.0`. Its `mqbroker --enable-proxy` command delegates to
+`ProxyStartup` with `-pm local` and embeds the Broker in the Proxy process. At that tag, local routes advertise the
+configured `grpcServerPort` directly, so the fixture uses the same dynamically reserved port inside the container and
+on the host. The test explicitly creates its unique consumer group before telemetry because local mode validates the
+group at that point. Its focused gRPC round-trip verifies route lookup, settings telemetry, publish, assignment,
+receive, and acknowledgement through the Broker-integrated deployment. The local-mode suite intentionally uses a
+normal topic: local mode at that release tag does not implement `SyncLiteSubscription`, so LitePush remains covered
+only through the cluster-mode fixtures.
 
 Each ordinary test scope receives a unique normal topic and consumer group. The fixture explicitly
 creates the topic before use because gRPC route lookup requires an existing route, while the Broker
@@ -224,9 +235,11 @@ The multi-Broker fixtures complement the baseline fixture:
   complete route and sends successfully. Finally it restarts A and waits for A to report all three Brokers and the complete
   nine-queue topic route before cleanup so the shared collection is not left degraded. The ten-consumer case confirms that
   consumers in excess of the nine queues remain unassigned without duplicate delivery.
-- [`RocketMQMultiBrokerGrpcContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerGrpcContainerFixture.cs)
-  starts a NameServer, three master Brokers, and a cluster-mode Proxy on an isolated Docker network. The gRPC test
-  sends through the Proxy and confirms that every Broker has stored messages.
+- [`RocketMQMultiBrokerClusterProxyContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerClusterProxyContainerFixture.cs)
+  starts a NameServer, three master Brokers, and two cluster-mode Proxies on an isolated Docker network. The ordinary
+  gRPC test sends through the semicolon-combined Proxy endpoints and confirms that every Broker has stored messages. A
+  focused failover test stops Proxy A before publishing, verifies that route lookup and send complete through Proxy B,
+  and restarts Proxy A before cleanup so the shared collection is not left degraded.
 
 The fixtures create the test topic on each Broker with `mqadmin updateTopic -b` and wait for the complete route.
 Do not assume that `updateTopic -c DefaultCluster` creates a topic on every master Broker.
@@ -249,14 +262,15 @@ run in parallel. Each unit-test job restores, builds and tests its `net10.0` pro
 report. Two additional non-coverage jobs install the .NET 8 runtime and run the protocol unit suites with
 `-p:TargetFramework=net8.0`; the solution build and release pack verify both target frameworks of each publishable
 library.
-After both stages complete, Docker-backed gRPC and Remoting integration tests run in four parallel `ubuntu-latest`
-matrix jobs: one single-Broker and one multi-Broker job for each protocol. A class-level `Topology=MultiBroker` trait
-selects the multi-Broker tests; the single-Broker jobs run the complementary set. Each job restores
+After both stages complete, Docker-backed gRPC and Remoting integration tests run in five parallel `ubuntu-latest`
+matrix jobs: cluster-mode single-Broker, local-mode Proxy, and multi-Broker/multi-Proxy jobs for gRPC, plus single-Broker
+and multi-Broker jobs for Remoting. Class-level `Topology=LocalProxy` and `Topology=MultiBroker` traits select the two
+specialized gRPC topologies; the ordinary single-Broker job excludes both. Each job restores
 and builds only its protocol-specific integration-test dependency graph, has its own timeout budget,
 and reuses the repository's NuGet package cache. Within a single-Broker job, isolated test classes
 run concurrently up to the runner limit; the legacy Remoting suite remains serial by design.
 Testcontainers still starts isolated Broker, NameServer, and Proxy fixtures for every job; the multi-Broker Remoting
-fixture includes two independent NameServers. All four
+fixture includes two independent NameServers. All five
 jobs collect Cobertura reports and upload them to Codecov with distinct upload names under the shared
 `integration-tests` flag. Codecov combines those reports with the `unit-tests` reports; the repository
 configuration continues to exclude `samples` from coverage.

--- a/docs/zh-CN/testing/local-and-integration-testing.md
+++ b/docs/zh-CN/testing/local-and-integration-testing.md
@@ -23,7 +23,7 @@ gRPC 的行为同时受 Proxy、Broker feature 与 protobuf API 影响。任一�
 | [`tests/ut/EventHorizon.RocketMQ.Grpc.Tests`](../../../tests/ut/EventHorizon.RocketMQ.Grpc.Tests) | 单元测试 | gRPC route、receipt、consumer 调度、DI 和错误处理。 |
 | [`tests/ut/EventHorizon.RocketMQ.Remoting.Tests`](../../../tests/ut/EventHorizon.RocketMQ.Remoting.Tests) | 单元测试 | frame、连接、路由、经典 Consumer/Producer 和 Admin 行为。 |
 | [`tests/ut/EventHorizon.RocketMQ.Compatibility.Tests`](../../../tests/ut/EventHorizon.RocketMQ.Compatibility.Tests) | 兼容性测试 | 同时引用两个协议 Project，验证两套公开 API、命名空间隔离与双 Package 共存。 |
-| [`tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests`](../../../tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests) | Docker 集成测试 | Proxy gRPC 的发送、消费、事务、Lite、死信和三 Broker route 写入路径。 |
+| [`tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests`](../../../tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests) | Docker 集成测试 | 覆盖 local 与 cluster mode Proxy gRPC 的发送、消费、事务、Lite、死信、多 Proxy 故障切换和三 Broker 路由写入。 |
 | [`tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests`](../../../tests/it/EventHorizon.RocketMQ.Remoting.IntegrationTests) | Docker 集成测试 | NameServer/Broker 的 Admin、LitePull、Push PULL/POP、发送、请求-响应、事务、撤回和三 Broker route 路径。 |
 | [`tests/it/EventHorizon.RocketMQ.Remoting.CrossProcessTestHost`](../../../tests/it/EventHorizon.RocketMQ.Remoting.CrossProcessTestHost) | 跨进程 IT 宿主 | 仅供 Remoting IT 启动独立 Push Consumer 进程，不包含测试断言且不打包。 |
 | [`tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure) | 测试基础设施库 | Testcontainers fixture 与可复用环境，不引用任一生产协议项目。 |
@@ -130,7 +130,15 @@ test 项目，而不是在 unit test 中偷偷连接本地 `localhost`。
 基础 fixture 创建隔离 Docker network，等待 NameServer 与 Broker 就绪，确认 Broker 已注册。每个 integration-test
 assembly 通过惰性的 xUnit v3 assembly-fixture registry 共享一套基础容器，因此独立测试类可以复用 Docker stack，
 而不必让整个项目串行。runner 最多并行四个 test collection；被筛选出的 multi-Broker job 不会初始化这套基础
-fixture。
+fixture；只运行 local-Proxy job 时同样不会初始化。
+
+[`RocketMQLocalProxyContainerFixture`](../../../tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQLocalProxyContainerFixture.cs)
+以官方正式版本标签 `rocketmq-all-5.5.0` 为行为基线。其 `mqbroker --enable-proxy` 命令会把启动委托给带
+`-pm local` 的 `ProxyStartup`，将 Broker 嵌入 Proxy 进程。该版本在 local mode 下会直接把配置中的
+`grpcServerPort` 写入返回路由，因此 fixture 在容器内和宿主机上使用同一个动态预留端口。local mode 还会在
+telemetry 阶段校验 consumer group，测试会在此之前显式创建唯一 group。这条 gRPC 往返流程完整验证路由查询、
+settings telemetry、消息发送、队列分配、接收与 ACK。测试只使用普通 Topic：该版本的 local mode 没有实现
+`SyncLiteSubscription`，LitePush 因此仍由 cluster-mode fixture 覆盖。
 
 普通测试 scope 会生成唯一的 normal topic 和 consumer group。fixture 会在使用前显式创建 topic，因为 gRPC 的
 route lookup 需要已有 route；普通 subscription group 则由 Broker 自动创建。事务、FIFO、延迟和 Lite topic 因为
@@ -198,8 +206,10 @@ Broker 与 cluster-mode Proxy 在同一容器中按顺序启动：Broker 先注�
   一次 route，再停止 A，等待 10 毫秒的 route cache 过期，确认客户端对 A 的尝试失败并切换到 B，随后仍能刷新完整 route 并成功
   发送消息。最后重启 A，等待 A 再次报告三台 Broker 和完整的九个队列 topic route，再完成清理，避免污染共享 collection。
   Consumer 多于九个队列时，多出的实例保持未分配，且不会产生重复投递。
-- gRPC fixture 在隔离 Docker network 中启动 NameServer、三个 master Broker 和 cluster-mode Proxy。测试通过 Proxy
-  发送消息，再查询每台 Broker 的 topic 状态，确认三台 Broker 都有实际写入。
+- gRPC fixture 在隔离 Docker network 中启动 NameServer、三个 master Broker 和两个 cluster-mode Proxy。常规测试使用
+  由分号连接的两个 Proxy endpoint 发送消息，再查询每台 Broker 的 topic 状态，确认三台 Broker 都有实际写入。专门的
+  故障切换测试会在发送前停止 Proxy A，验证路由查询与发送能够通过 Proxy B 完成，并在清理前重启 Proxy A，避免让
+  共享 collection 保持降级状态。
 
 创建多 Broker topic 时，fixture 会逐台 Broker 执行 `mqadmin updateTopic -b` 并等待完整 route。不能假定
 `updateTopic -c DefaultCluster` 会自动把 topic 创建到每台 master Broker。
@@ -247,14 +257,15 @@ Docker 不可用时，应报告没有运行哪一个 integration test 以及原�
 GitHub Actions 会在一个 job 中完成格式化和 solution 全量构建，同时并行运行三个按协议/兼容性拆分的单元测试
 job。每个单元测试 job 都会 restore、build、运行对应的 `net10.0` 测试项目并单独上传覆盖率报告；solution build
 另有两个不上传覆盖率的 job 会安装 .NET 8 runtime，并用 `-p:TargetFramework=net8.0` 运行两个协议的单元测试；
-solution build 和发版 pack 负责验证两个可发布库的全部目标框架。两层验证均通过后，再于四个
-并行的 `ubuntu-latest` matrix job 运行 Docker 驱动的 gRPC 与 Remoting integration test：每个协议各有一个
-single-Broker 与一个 multi-Broker job。类级别的 `Topology=MultiBroker` trait 选择 multi-Broker 测试；
-single-Broker job 运行其余测试。每个 job 只 restore
+solution build 和发版 pack 负责验证两个可发布库的全部目标框架。两层验证均通过后，再由五个并行的
+`ubuntu-latest` matrix job 运行 Docker 驱动的 gRPC 与 Remoting integration test：gRPC 拆成 cluster-mode 单
+Broker、local-mode Proxy 和多 Broker/多 Proxy 三个 job，Remoting 则保留单 Broker 与多 Broker 两个 job。类级别的
+`Topology=LocalProxy` 与 `Topology=MultiBroker` trait 分别选择两套专用 gRPC 拓扑，普通单 Broker job 排除二者。
+每个 job 只 restore
 和 build 对应协议的 integration-test 依赖图，使用独立超时预算，并复用仓库的 NuGet 包缓存。Testcontainers
 仍会在每个 job 内独立启动隔离的 Broker、NameServer 与 Proxy fixture；多 Broker Remoting fixture 包含两个相互独立的
 NameServer。single-Broker job 内，已经隔离的测试类
-会在 runner 上限内并发执行；legacy Remoting suite 则按设计保持串行。四个 job 都会生成 Cobertura 报告，以不同
+会在 runner 上限内并发执行；legacy Remoting suite 则按设计保持串行。五个 job 都会生成 Cobertura 报告，以不同
 的上传名称归入共享的 `integration-tests` flag；Codecov 会将其与 `unit-tests` 报告合并。仓库配置仍会排除
 `samples`，不会将 sample 计入覆盖率。
 

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLocalProxyCollection.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLocalProxyCollection.cs
@@ -16,5 +16,16 @@
 using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 using Xunit;
 
-// The registry defers the single-Broker topology so specialized-topology-only filtered runs do not start it.
-[assembly: AssemblyFixture(typeof(RocketMQSingleBrokerContainerFixtureRegistry))]
+namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
+
+/// <summary>
+/// Defines the test collection that owns the Broker-integrated local-mode Proxy topology.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class RocketMQLocalProxyCollection : ICollectionFixture<RocketMQLocalProxyContainerFixture>
+{
+    /// <summary>
+    /// Gets the xUnit collection name for local-mode Proxy integration tests.
+    /// </summary>
+    public const string Name = "RocketMQ gRPC local-mode Proxy integration";
+}

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLocalProxyIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQLocalProxyIntegrationTests.cs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using EventHorizon.RocketMQ.Grpc.Consumer;
+using EventHorizon.RocketMQ.Grpc.Consumer.Simple;
+using EventHorizon.RocketMQ.Grpc.Producer;
+using EventHorizon.RocketMQ.IntegrationTestInfrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
+
+[Collection(RocketMQLocalProxyCollection.Name)]
+[Trait("Topology", "LocalProxy")]
+public sealed class RocketMQLocalProxyIntegrationTests
+{
+    private readonly RocketMQLocalProxyContainerFixture _fixture;
+
+    public RocketMQLocalProxyIntegrationTests(RocketMQLocalProxyContainerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task LocalProxyProducerAndSimpleConsumer_MessageRoundTrip_Completes()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var consumerGroup = $"grpc-local-proxy-simple-consumer-{Guid.NewGuid():N}";
+        await _fixture.CreateConsumerGroupAsync(consumerGroup, cancellationToken);
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
+            .AddGrpcProducer()
+            .AddGrpcSimpleConsumer(options =>
+            {
+                options.GroupName = consumerGroup;
+                options.AwaitDuration = TimeSpan.FromSeconds(3);
+                options.Subscribe(RocketMQLocalProxyContainerFixture.TestTopic);
+            });
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IGrpcProducer>();
+        var consumer = provider.GetRequiredService<IGrpcSimpleConsumer>();
+        await producer.StartAsync(cancellationToken);
+        await consumer.StartAsync(cancellationToken);
+        try
+        {
+            var body = $"grpc-local-proxy-{Guid.NewGuid():N}";
+            var receipt = await producer.SendAsync(
+                new Message(
+                    RocketMQLocalProxyContainerFixture.TestTopic,
+                    Encoding.UTF8.GetBytes(body)),
+                cancellationToken);
+            Assert.NotEmpty(receipt.MessageId);
+
+            GrpcMessageView? received = null;
+            for (var attempt = 0; attempt < 10 && received is null; attempt++)
+            {
+                var messages = await consumer.ReceiveAsync(16, cancellationToken: cancellationToken);
+                received = messages.FirstOrDefault(message => Encoding.UTF8.GetString(message.Body) == body);
+                foreach (var message in messages)
+                {
+                    await consumer.AckAsync(message, cancellationToken);
+                }
+            }
+
+            Assert.NotNull(received);
+            Assert.Equal(body, Encoding.UTF8.GetString(received.Body));
+            Assert.Equal(receipt.MessageId, received.MessageId);
+        }
+        finally
+        {
+            await consumer.StopAsync(CancellationToken.None);
+            await producer.StopAsync(CancellationToken.None);
+        }
+    }
+}

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerCollection.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerCollection.cs
@@ -26,7 +26,7 @@ namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 /// required.
 /// </remarks>
 [CollectionDefinition(Name)]
-public sealed class RocketMQMultiBrokerCollection : ICollectionFixture<RocketMQMultiBrokerGrpcContainerFixture>
+public sealed class RocketMQMultiBrokerCollection : ICollectionFixture<RocketMQMultiBrokerClusterProxyContainerFixture>
 {
     public const string Name = "RocketMQ gRPC multi-Broker integration";
 }

--- a/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
+++ b/tests/it/EventHorizon.RocketMQ.Grpc.IntegrationTests/RocketMQMultiBrokerIntegrationTests.cs
@@ -25,9 +25,9 @@ namespace EventHorizon.RocketMQ.Grpc.IntegrationTests;
 [Trait("Topology", "MultiBroker")]
 public sealed class RocketMQMultiBrokerIntegrationTests
 {
-    private readonly RocketMQMultiBrokerGrpcContainerFixture _fixture;
+    private readonly RocketMQMultiBrokerClusterProxyContainerFixture _fixture;
 
-    public RocketMQMultiBrokerIntegrationTests(RocketMQMultiBrokerGrpcContainerFixture fixture)
+    public RocketMQMultiBrokerIntegrationTests(RocketMQMultiBrokerClusterProxyContainerFixture fixture)
     {
         _fixture = fixture;
     }
@@ -40,7 +40,7 @@ public sealed class RocketMQMultiBrokerIntegrationTests
         var cancellationToken = TestContext.Current.CancellationToken;
         var services = new ServiceCollection();
         services
-            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoint)
+            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoints)
             .AddGrpcProducer();
 
         await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
@@ -52,32 +52,98 @@ public sealed class RocketMQMultiBrokerIntegrationTests
             {
                 var receipt = await producer.SendAsync(
                     new Message(
-                        RocketMQMultiBrokerGrpcContainerFixture.TestTopic,
+                        RocketMQMultiBrokerClusterProxyContainerFixture.TestTopic,
                         Encoding.UTF8.GetBytes($"grpc-multi-broker-{index}-{Guid.NewGuid():N}")),
                     cancellationToken);
                 Assert.NotEmpty(receipt.MessageId);
             }
 
             var offsets = await _fixture.WaitForMessagesOnAllBrokersAsync(
-                RocketMQMultiBrokerGrpcContainerFixture.TestTopic,
+                RocketMQMultiBrokerClusterProxyContainerFixture.TestTopic,
                 TimeSpan.FromSeconds(15),
                 cancellationToken);
             Assert.True(
-                offsets.TryGetValue(RocketMQMultiBrokerGrpcContainerFixture.BrokerAName, out var brokerAOffset) &&
+                offsets.TryGetValue(RocketMQMultiBrokerClusterProxyContainerFixture.BrokerAName, out var brokerAOffset) &&
                 brokerAOffset > 0,
-                $"No gRPC message reached {RocketMQMultiBrokerGrpcContainerFixture.BrokerAName}. Offsets: {FormatOffsets(offsets)}");
+                $"No gRPC message reached {RocketMQMultiBrokerClusterProxyContainerFixture.BrokerAName}. Offsets: {FormatOffsets(offsets)}");
             Assert.True(
-                offsets.TryGetValue(RocketMQMultiBrokerGrpcContainerFixture.BrokerBName, out var brokerBOffset) &&
+                offsets.TryGetValue(RocketMQMultiBrokerClusterProxyContainerFixture.BrokerBName, out var brokerBOffset) &&
                 brokerBOffset > 0,
-                $"No gRPC message reached {RocketMQMultiBrokerGrpcContainerFixture.BrokerBName}. Offsets: {FormatOffsets(offsets)}");
+                $"No gRPC message reached {RocketMQMultiBrokerClusterProxyContainerFixture.BrokerBName}. Offsets: {FormatOffsets(offsets)}");
             Assert.True(
-                offsets.TryGetValue(RocketMQMultiBrokerGrpcContainerFixture.BrokerCName, out var brokerCOffset) &&
+                offsets.TryGetValue(RocketMQMultiBrokerClusterProxyContainerFixture.BrokerCName, out var brokerCOffset) &&
                 brokerCOffset > 0,
-                $"No gRPC message reached {RocketMQMultiBrokerGrpcContainerFixture.BrokerCName}. Offsets: {FormatOffsets(offsets)}");
+                $"No gRPC message reached {RocketMQMultiBrokerClusterProxyContainerFixture.BrokerCName}. Offsets: {FormatOffsets(offsets)}");
         }
         finally
         {
             await producer.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Producer_ProxyAUnavailable_FallsBackToProxyB()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services
+            .AddRocketMQGrpc(options => options.Endpoint = _fixture.GrpcEndpoints)
+            .AddGrpcProducer();
+
+        await using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true });
+        var producer = provider.GetRequiredService<IGrpcProducer>();
+        var proxyAStopped = false;
+        try
+        {
+            var beforeOffsets = await _fixture.GetBrokerMessageOffsetsAsync(
+                RocketMQMultiBrokerClusterProxyContainerFixture.TestTopic,
+                cancellationToken);
+            var beforeTotalOffset = beforeOffsets.Values.Sum();
+
+            proxyAStopped = true;
+            await _fixture.StopProxyAAsync(CancellationToken.None);
+            await producer.StartAsync(cancellationToken);
+            var receipt = await producer.SendAsync(
+                new Message(
+                    RocketMQMultiBrokerClusterProxyContainerFixture.TestTopic,
+                    Encoding.UTF8.GetBytes($"grpc-proxy-failover-{Guid.NewGuid():N}")),
+                cancellationToken);
+
+            Assert.NotEmpty(receipt.MessageId);
+            var offsets = beforeOffsets;
+            var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(15);
+            do
+            {
+                offsets = await _fixture.GetBrokerMessageOffsetsAsync(
+                    RocketMQMultiBrokerClusterProxyContainerFixture.TestTopic,
+                    cancellationToken);
+                if (offsets.Values.Sum() > beforeTotalOffset)
+                {
+                    break;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
+            }
+            while (DateTimeOffset.UtcNow < deadline);
+
+            Assert.True(
+                offsets.Values.Sum() > beforeTotalOffset,
+                $"The failover message was not stored by any Broker. Offsets: {FormatOffsets(offsets)}");
+        }
+        finally
+        {
+            try
+            {
+                await producer.StopAsync(CancellationToken.None);
+            }
+            finally
+            {
+                if (proxyAStopped)
+                {
+                    await _fixture.RestoreProxyAAsync(CancellationToken.None);
+                }
+            }
         }
     }
 

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQLocalProxyContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQLocalProxyContainerFixture.cs
@@ -1,0 +1,228 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"). You may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Networks;
+using Xunit;
+
+namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
+
+/// <summary>
+/// Provides a Broker-integrated local-mode Proxy topology for gRPC integration tests.
+/// </summary>
+/// <remarks>
+/// At the official <c>rocketmq-all-5.5.0</c> release tag, RocketMQ starts the local Proxy through
+/// <c>mqbroker --enable-proxy</c>. The Proxy embeds the Broker in the same process, while the NameServer remains an
+/// independent container on the test network. Local-mode routes advertise the configured gRPC port directly, so the
+/// fixture uses the same dynamically reserved port inside the container and on the host.
+/// </remarks>
+public sealed class RocketMQLocalProxyContainerFixture : IAsyncLifetime
+{
+    private const string Image = "apache/rocketmq:5.5.0";
+    private const string NameServerAlias = "nameserver";
+    private const int NameServerPort = 9876;
+    private const int BrokerPort = 10911;
+
+    /// <summary>
+    /// Gets the name of the embedded Broker.
+    /// </summary>
+    public const string BrokerName = "broker-a";
+
+    /// <summary>
+    /// Gets the normal topic created for the local-mode Proxy integration test.
+    /// </summary>
+    public const string TestTopic = "rocketmq-dotnet-grpc-local-proxy-it";
+
+    private readonly INetwork _network = new NetworkBuilder().Build();
+    private readonly IContainer _nameServer;
+    private readonly IContainer _broker;
+    private readonly RocketMQHostPortReservation _portReservation;
+    private readonly int _grpcHostPort;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RocketMQLocalProxyContainerFixture"/> class.
+    /// </summary>
+    public RocketMQLocalProxyContainerFixture()
+    {
+        _portReservation = RocketMQHostPortReservation.Reserve(1);
+        _grpcHostPort = _portReservation[0];
+
+        _nameServer = new ContainerBuilder(Image)
+            .WithNetwork(_network)
+            .WithNetworkAliases(NameServerAlias)
+            .WithEnvironment("JAVA_OPT_EXT", "-Duser.home=/home/rocketmq -Xms256m -Xmx256m")
+            .WithCommand("sh", "mqnamesrv")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(NameServerPort))
+            .Build();
+
+        var brokerConfiguration = Encoding.UTF8.GetBytes(
+            "brokerClusterName=DefaultCluster\n" +
+            $"brokerName={BrokerName}\n" +
+            "brokerId=0\n" +
+            "brokerIP1=127.0.0.1\n" +
+            $"namesrvAddr={NameServerAlias}:{NameServerPort}\n" +
+            $"listenPort={BrokerPort}\n" +
+            "autoCreateTopicEnable=true\n" +
+            "autoCreateSubscriptionGroup=true\n" +
+            "enablePropertyFilter=true\n" +
+            "timerWheelEnable=true\n" +
+            "serverLoadBalancerEnable=true\n" +
+            "defaultMessageRequestMode=PULL\n");
+        var proxyConfiguration = Encoding.UTF8.GetBytes(
+            "{\n" +
+            "  \"rocketMQClusterName\": \"DefaultCluster\",\n" +
+            "  \"proxyClusterName\": \"DefaultCluster\",\n" +
+            $"  \"grpcServerPort\": {_grpcHostPort}\n" +
+            "}\n");
+
+        _broker = new ContainerBuilder(Image)
+            .WithNetwork(_network)
+            .WithNetworkAliases("broker")
+            .WithPortBinding(_grpcHostPort, _grpcHostPort)
+            .WithEnvironment("NAMESRV_ADDR", $"{NameServerAlias}:{NameServerPort}")
+            .WithEnvironment("JAVA_OPT_EXT", "-Duser.home=/home/rocketmq -Xms512m -Xmx512m")
+            .WithResourceMapping(brokerConfiguration, "/tmp/broker.conf")
+            .WithResourceMapping(proxyConfiguration, "/home/rocketmq/rocketmq-5.5.0/conf/rmq-proxy.json")
+            .WithCommand(
+                "sh",
+                "mqbroker",
+                "--enable-proxy",
+                "-n",
+                $"{NameServerAlias}:{NameServerPort}",
+                "-c",
+                "/tmp/broker.conf")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilInternalTcpPortIsAvailable(BrokerPort)
+                .UntilInternalTcpPortIsAvailable(_grpcHostPort)
+                .UntilMessageIsLogged("rocketmq-proxy startup successfully"))
+            .Build();
+    }
+
+    /// <summary>
+    /// Gets the host-reachable gRPC endpoint of the Broker-integrated local-mode Proxy.
+    /// </summary>
+    public string GrpcEndpoint => $"{_broker.Hostname}:{_broker.GetMappedPublicPort(_grpcHostPort)}";
+
+    /// <summary>
+    /// Creates a consumer group for a local-mode gRPC integration test.
+    /// </summary>
+    /// <param name="group">The consumer group to create.</param>
+    /// <param name="cancellationToken">The token used to cancel the Broker administration request.</param>
+    /// <returns>A task that represents the asynchronous administration request.</returns>
+    public async Task CreateConsumerGroupAsync(string group, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(group);
+        var createGroup = await _broker.ExecAsync([
+            "sh", "mqadmin", "updateSubGroup",
+            "-n", $"{NameServerAlias}:{NameServerPort}",
+            "-c", "DefaultCluster",
+            "-g", group
+        ], cancellationToken).ConfigureAwait(false);
+        if (createGroup.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Unable to create local-mode integration-test consumer group '{group}'. " +
+                $"stdout: {createGroup.Stdout} stderr: {createGroup.Stderr}");
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask InitializeAsync()
+    {
+        await _network.CreateAsync().ConfigureAwait(false);
+        await _nameServer.StartAsync().ConfigureAwait(false);
+        await _broker.StartAsync().ConfigureAwait(false);
+
+        await WaitForBrokerRegistrationAsync().ConfigureAwait(false);
+        await CreateTopicAsync().ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await _broker.DisposeAsync().ConfigureAwait(false);
+            await _nameServer.DisposeAsync().ConfigureAwait(false);
+            await _network.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _portReservation.Dispose();
+        }
+    }
+
+    private async Task WaitForBrokerRegistrationAsync()
+    {
+        ExecResult clusterList = default;
+        for (var attempt = 0; attempt < 60; attempt++)
+        {
+            clusterList = await _broker.ExecAsync([
+                "sh", "mqadmin", "clusterList", "-n", $"{NameServerAlias}:{NameServerPort}"
+            ]).ConfigureAwait(false);
+            if (clusterList.ExitCode == 0 &&
+                clusterList.Stdout.Contains(BrokerName, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"Broker '{BrokerName}' did not register with NameServer. stdout: {clusterList.Stdout} " +
+            $"stderr: {clusterList.Stderr}");
+    }
+
+    private async Task CreateTopicAsync()
+    {
+        var createTopic = await _broker.ExecAsync([
+            "sh", "mqadmin", "updateTopic",
+            "-n", $"{NameServerAlias}:{NameServerPort}",
+            "-c", "DefaultCluster",
+            "-t", TestTopic,
+            "-a", "+message.type=NORMAL"
+        ]).ConfigureAwait(false);
+        if (createTopic.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Unable to create local-mode integration-test topic. stdout: {createTopic.Stdout} " +
+                $"stderr: {createTopic.Stderr}");
+        }
+
+        ExecResult topicRoute = default;
+        for (var attempt = 0; attempt < 60; attempt++)
+        {
+            topicRoute = await _broker.ExecAsync([
+                "sh", "mqadmin", "topicRoute",
+                "-n", $"{NameServerAlias}:{NameServerPort}",
+                "-t", TestTopic
+            ]).ConfigureAwait(false);
+            if (topicRoute.ExitCode == 0 &&
+                topicRoute.Stdout.Contains(BrokerName, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            $"Local-mode integration-test topic has no route. stdout: {topicRoute.Stdout} " +
+            $"stderr: {topicRoute.Stderr}");
+    }
+}

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerClusterProxyContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerClusterProxyContainerFixture.cs
@@ -23,7 +23,7 @@ using Xunit;
 namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 
 /// <summary>
-/// Provides a cluster-mode Proxy and three network-addressable Brokers for gRPC integration tests.
+/// Provides two cluster-mode Proxies and three network-addressable Brokers for gRPC integration tests.
 /// </summary>
 /// <remarks>
 /// The Brokers advertise Docker network aliases at a fixed internal port so the separate Proxy container can reach
@@ -31,12 +31,14 @@ namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 /// <see cref="RocketMQMultiBrokerRemotingContainerFixture"/>. xUnit owns this type directly as a collection fixture;
 /// an additional lazy registry would not extend its lifecycle.
 /// </remarks>
-public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
+public sealed class RocketMQMultiBrokerClusterProxyContainerFixture : IAsyncLifetime
 {
     private const string Image = "apache/rocketmq:5.5.0";
     private const int NameServerPort = 9876;
     private const int BrokerPort = 10911;
     private const int GrpcPort = 8081;
+    private const string ProxyAAlias = "proxy-a";
+    private const string ProxyBAlias = "proxy-b";
 
     /// <summary>
     /// Gets the name of the first Broker in the test cluster.
@@ -63,17 +65,20 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
     private readonly IContainer _brokerA;
     private readonly IContainer _brokerB;
     private readonly IContainer _brokerC;
-    private readonly IContainer _proxy;
+    private readonly IContainer _proxyA;
+    private readonly IContainer _proxyB;
     private readonly RocketMQHostPortReservation _portReservation;
-    private readonly int _proxyHostPort;
+    private readonly int _proxyAHostPort;
+    private readonly int _proxyBHostPort;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="RocketMQMultiBrokerGrpcContainerFixture"/> class.
+    /// Initializes a new instance of the <see cref="RocketMQMultiBrokerClusterProxyContainerFixture"/> class.
     /// </summary>
-    public RocketMQMultiBrokerGrpcContainerFixture()
+    public RocketMQMultiBrokerClusterProxyContainerFixture()
     {
-        _portReservation = RocketMQHostPortReservation.Reserve(1);
-        _proxyHostPort = _portReservation[0];
+        _portReservation = RocketMQHostPortReservation.Reserve(2);
+        _proxyAHostPort = _portReservation[0];
+        _proxyBHostPort = _portReservation[1];
         _nameServer = new ContainerBuilder(Image)
             .WithNetwork(_network)
             .WithNetworkAliases("nameserver")
@@ -86,39 +91,24 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
         _brokerB = CreateBroker(BrokerBName);
         _brokerC = CreateBroker(BrokerCName);
 
-        var proxyConfiguration = Encoding.UTF8.GetBytes(
-            "{\n" +
-            "  \"rocketMQClusterName\": \"DefaultCluster\",\n" +
-            "  \"proxyClusterName\": \"DefaultCluster\",\n" +
-            $"  \"grpcServerPort\": {GrpcPort},\n" +
-            "  \"useEndpointPortFromRequest\": true\n" +
-            "}\n");
-        _proxy = new ContainerBuilder(Image)
-            .WithNetwork(_network)
-            .WithNetworkAliases("proxy")
-            .WithPortBinding(_proxyHostPort, GrpcPort)
-            .WithEnvironment("NAMESRV_ADDR", $"nameserver:{NameServerPort}")
-            .WithEnvironment("JAVA_OPT_EXT", "-Duser.home=/home/rocketmq -Xms512m -Xmx512m")
-            .WithResourceMapping(proxyConfiguration, "/home/rocketmq/rocketmq-5.5.0/conf/rmq-proxy.json")
-            .WithCommand(
-                "sh",
-                "mqproxy",
-                "-pm",
-                "cluster",
-                "-n",
-                $"nameserver:{NameServerPort}",
-                "-pc",
-                "/home/rocketmq/rocketmq-5.5.0/conf/rmq-proxy.json")
-            .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilInternalTcpPortIsAvailable(GrpcPort)
-                .UntilMessageIsLogged("rocketmq-proxy startup successfully"))
-            .Build();
+        _proxyA = CreateProxy(ProxyAAlias, _proxyAHostPort);
+        _proxyB = CreateProxy(ProxyBAlias, _proxyBHostPort);
     }
 
     /// <summary>
-    /// Gets the host-reachable gRPC endpoint for the cluster-mode Proxy.
+    /// Gets the host-reachable gRPC endpoint for Proxy A.
     /// </summary>
-    public string GrpcEndpoint => $"{_proxy.Hostname}:{_proxy.GetMappedPublicPort(GrpcPort)}";
+    public string GrpcEndpointA => $"{_proxyA.Hostname}:{_proxyA.GetMappedPublicPort(GrpcPort)}";
+
+    /// <summary>
+    /// Gets the host-reachable gRPC endpoint for Proxy B.
+    /// </summary>
+    public string GrpcEndpointB => $"{_proxyB.Hostname}:{_proxyB.GetMappedPublicPort(GrpcPort)}";
+
+    /// <summary>
+    /// Gets both host-reachable gRPC endpoints as a semicolon-separated client setting.
+    /// </summary>
+    public string GrpcEndpoints => $"{GrpcEndpointA};{GrpcEndpointB}";
 
     /// <inheritdoc/>
     public async ValueTask InitializeAsync()
@@ -132,7 +122,9 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
 
         await WaitForClusterRegistrationAsync().ConfigureAwait(false);
         await CreateTopicAsync().ConfigureAwait(false);
-        await _proxy.StartAsync().ConfigureAwait(false);
+        await Task.WhenAll(
+            _proxyA.StartAsync(),
+            _proxyB.StartAsync()).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
@@ -140,7 +132,8 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
     {
         try
         {
-            await _proxy.DisposeAsync().ConfigureAwait(false);
+            await _proxyB.DisposeAsync().ConfigureAwait(false);
+            await _proxyA.DisposeAsync().ConfigureAwait(false);
             await _brokerC.DisposeAsync().ConfigureAwait(false);
             await _brokerB.DisposeAsync().ConfigureAwait(false);
             await _brokerA.DisposeAsync().ConfigureAwait(false);
@@ -152,6 +145,33 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
             _portReservation.Dispose();
         }
     }
+
+    /// <summary>
+    /// Stops Proxy A so a test can verify gRPC access-point failover to Proxy B.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel the stop operation.</param>
+    /// <returns>A task that represents the asynchronous stop operation.</returns>
+    public Task StopProxyAAsync(CancellationToken cancellationToken = default) =>
+        _proxyA.StopAsync(cancellationToken);
+
+    /// <summary>
+    /// Restarts Proxy A and waits for its gRPC service to become available again.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel recovery.</param>
+    /// <returns>A task that represents the asynchronous recovery operation.</returns>
+    public Task RestoreProxyAAsync(CancellationToken cancellationToken = default) =>
+        _proxyA.StartAsync(cancellationToken);
+
+    /// <summary>
+    /// Gets the current aggregate maximum queue offsets by Broker for <paramref name="topic"/>.
+    /// </summary>
+    /// <param name="topic">The topic whose queue offsets to inspect.</param>
+    /// <param name="cancellationToken">The token used to cancel the inspection.</param>
+    /// <returns>The aggregate maximum queue offsets by Broker.</returns>
+    public Task<IReadOnlyDictionary<string, long>> GetBrokerMessageOffsetsAsync(
+        string topic,
+        CancellationToken cancellationToken = default) =>
+        GetBrokerMaxOffsetsAsync(topic, cancellationToken);
 
     /// <summary>
     /// Waits until all three Brokers have stored at least one message in <paramref name="topic"/>.
@@ -181,6 +201,39 @@ public sealed class RocketMQMultiBrokerGrpcContainerFixture : IAsyncLifetime
         while (DateTimeOffset.UtcNow < deadline);
 
         return await GetBrokerMaxOffsetsAsync(topic, cancellationToken).ConfigureAwait(false);
+    }
+
+    private IContainer CreateProxy(string proxyName, int hostPort)
+    {
+        var proxyConfiguration = Encoding.UTF8.GetBytes(
+            "{\n" +
+            "  \"rocketMQClusterName\": \"DefaultCluster\",\n" +
+            "  \"proxyClusterName\": \"DefaultCluster\",\n" +
+            $"  \"proxyName\": \"{proxyName}\",\n" +
+            $"  \"grpcServerPort\": {GrpcPort},\n" +
+            "  \"useEndpointPortFromRequest\": true\n" +
+            "}\n");
+
+        return new ContainerBuilder(Image)
+            .WithNetwork(_network)
+            .WithNetworkAliases(proxyName)
+            .WithPortBinding(hostPort, GrpcPort)
+            .WithEnvironment("NAMESRV_ADDR", $"nameserver:{NameServerPort}")
+            .WithEnvironment("JAVA_OPT_EXT", "-Duser.home=/home/rocketmq -Xms512m -Xmx512m")
+            .WithResourceMapping(proxyConfiguration, "/home/rocketmq/rocketmq-5.5.0/conf/rmq-proxy.json")
+            .WithCommand(
+                "sh",
+                "mqproxy",
+                "-pm",
+                "cluster",
+                "-n",
+                $"nameserver:{NameServerPort}",
+                "-pc",
+                "/home/rocketmq/rocketmq-5.5.0/conf/rmq-proxy.json")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilInternalTcpPortIsAvailable(GrpcPort)
+                .UntilMessageIsLogged("rocketmq-proxy startup successfully"))
+            .Build();
     }
 
     private IContainer CreateBroker(string brokerName)

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQMultiBrokerRemotingContainerFixture.cs
@@ -27,7 +27,7 @@ namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 /// <remarks>
 /// Each Broker advertises loopback with a distinct dynamically allocated host port. A separate Proxy container would
 /// resolve loopback to itself rather than to these three Brokers, so this topology remains separate from
-/// <see cref="RocketMQMultiBrokerGrpcContainerFixture"/>. xUnit owns this type directly as a collection fixture; an
+/// <see cref="RocketMQMultiBrokerClusterProxyContainerFixture"/>. xUnit owns this type directly as a collection fixture; an
 /// additional lazy registry would not extend its lifecycle.
 /// </remarks>
 public sealed class RocketMQMultiBrokerRemotingContainerFixture : IAsyncLifetime

--- a/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixtureRegistry.cs
+++ b/tests/it/EventHorizon.RocketMQ.IntegrationTestInfrastructure/RocketMQSingleBrokerContainerFixtureRegistry.cs
@@ -22,8 +22,8 @@ namespace EventHorizon.RocketMQ.IntegrationTestInfrastructure;
 /// </summary>
 /// <remarks>
 /// Registering this holder instead of the container fixture keeps xUnit assembly initialization inexpensive and avoids
-/// starting the baseline topology for a multi-Broker-only filtered run. Multi-Broker collection fixtures do not need
-/// this indirection because xUnit already creates them only when their collection runs.
+/// starting the baseline topology for a specialized-topology-only filtered run. Specialized collection fixtures do
+/// not need this indirection because xUnit already creates them only when their collection runs.
 /// </remarks>
 public sealed class RocketMQSingleBrokerContainerFixtureRegistry : IAsyncLifetime
 {

--- a/tests/it/README.md
+++ b/tests/it/README.md
@@ -10,7 +10,7 @@ production client code.
 
 | Project | Responsibility |
 | --- | --- |
-| `EventHorizon.RocketMQ.Grpc.IntegrationTests` | Exercises the gRPC client through a real cluster-mode Proxy. |
+| `EventHorizon.RocketMQ.Grpc.IntegrationTests` | Exercises the gRPC client through real local-mode and cluster-mode Proxies. |
 | `EventHorizon.RocketMQ.Remoting.IntegrationTests` | Exercises classic NameServer and Broker Remoting behavior. |
 | `EventHorizon.RocketMQ.IntegrationTestInfrastructure` | Owns reusable Testcontainers topologies, host-port allocation, and test resource names. |
 | `EventHorizon.RocketMQ.Remoting.CrossProcessTestHost` | Runs test-only Remoting consumers in separate operating-system processes for cross-process Rebalance coverage. |
@@ -37,7 +37,7 @@ test topology and CI policy.
 
 ## Infrastructure structure
 
-`EventHorizon.RocketMQ.IntegrationTestInfrastructure` has six public top-level types and one internal helper.
+`EventHorizon.RocketMQ.IntegrationTestInfrastructure` has seven public top-level types and one internal helper.
 
 | Type | Responsibility |
 | --- | --- |
@@ -46,7 +46,8 @@ test topology and CI policy.
 | `RocketMQTestScope` | Produces test-specific topic and producer or consumer group names. |
 | `RocketMQTestTopicType` | Selects normal, transaction, FIFO, delay, or Lite topic provisioning. |
 | `RocketMQHostPortReservation` | Coordinates dynamic host-port choices within the current test process. |
-| `RocketMQMultiBrokerGrpcContainerFixture` | Runs three Docker-network Brokers behind a cluster-mode Proxy. |
+| `RocketMQLocalProxyContainerFixture` | Runs a Broker-integrated local-mode Proxy for focused gRPC compatibility coverage. |
+| `RocketMQMultiBrokerClusterProxyContainerFixture` | Runs three Docker-network Brokers behind two cluster-mode Proxies. |
 | `RocketMQMultiBrokerRemotingContainerFixture` | Runs two independent NameServers and three host-reachable classic Remoting Brokers; every Broker registers with both. |
 
 The internal type dependencies are:
@@ -59,7 +60,10 @@ RocketMQSingleBrokerContainerFixtureRegistry
                            `-- creates --> RocketMQTestScope
                                               `-- calls back --> RocketMQSingleBrokerContainerFixture
 
-RocketMQMultiBrokerGrpcContainerFixture
+RocketMQLocalProxyContainerFixture
+    `-- uses --> RocketMQHostPortReservation
+
+RocketMQMultiBrokerClusterProxyContainerFixture
     `-- uses --> RocketMQHostPortReservation
 
 RocketMQMultiBrokerRemotingContainerFixture
@@ -98,13 +102,24 @@ Test assembly finishes
 
 `GetFixtureAsync` uses a semaphore and double-checked access so parallel test classes initialize exactly one fixture.
 If initialization fails, the registry disposes the partially initialized fixture before propagating the failure. A
-multi-Broker-only filtered run still creates the inexpensive assembly registry, but never starts the single-Broker
-topology because it does not call `GetFixtureAsync`.
+local-Proxy-only or multi-Broker-only filtered run still creates the inexpensive assembly registry, but never starts
+the single-Broker topology because it does not call `GetFixtureAsync`.
 
 `RocketMQSingleBrokerContainerFixture` provisions a unique normal topic for each scope. Transaction, FIFO, delay, and Lite topics
 are predefined because their Broker semantics require configuration, but every scope still receives a unique suffix
 for group and message identity isolation. Broker administration is limited to four concurrent operations to match the
 parallel integration-test workload without serializing the entire assembly.
+
+### Local Proxy collection
+
+`RocketMQLocalProxyContainerFixture` is a dedicated gRPC collection fixture. It starts a NameServer and invokes
+`mqbroker --enable-proxy` in a second container. At the official released baseline tag `rocketmq-all-5.5.0`, that
+command starts `ProxyStartup` with `-pm local` and embeds the Broker in the Proxy process. Local routes advertise the
+configured gRPC port directly, so the fixture uses the same dynamically reserved port inside the container and on the
+host. The fixture creates one normal topic after the Broker registers. Before telemetry starts, the focused test
+explicitly creates its unique consumer group because local mode validates the group during telemetry, then completes
+a producer/SimpleConsumer send, receive, and acknowledgement round-trip. It does not exercise LitePush because local
+mode at that release tag does not implement `SyncLiteSubscription`.
 
 ### Multi-Broker collections
 
@@ -112,7 +127,7 @@ The multi-Broker fixtures are registered directly as xUnit collection fixtures:
 
 ```text
 gRPC multi-Broker collection
-    `-- RocketMQMultiBrokerGrpcContainerFixture
+    `-- RocketMQMultiBrokerClusterProxyContainerFixture
 
 Remoting multi-Broker collection
     `-- RocketMQMultiBrokerRemotingContainerFixture
@@ -125,14 +140,16 @@ not add laziness or sharing because the collection fixture already provides both
 The gRPC multi-Broker initialization order is:
 
 ```text
-reserve one Proxy host port
+reserve two Proxy host ports
     -> network -> NameServer -> Broker A/B/C in parallel
     -> wait for all Broker registrations
     -> create the topic on every Broker and wait for the complete route
-    -> start Proxy
+    -> start Proxy A/B in parallel
 ```
 
-Disposal runs in the reverse ownership direction: Proxy, Brokers, NameServer, network, then the port reservation.
+Clients use both Proxy addresses as one semicolon-separated endpoint setting. A focused failover test stops Proxy A,
+publishes through Proxy B, and restores Proxy A before cleanup. Disposal runs in the reverse ownership direction:
+Proxy B/A, Brokers, NameServer, network, then the port reservation.
 
 The Remoting multi-Broker initialization order is:
 
@@ -180,8 +197,8 @@ The multi-Broker topologies have incompatible Broker address-advertisement requi
 | Client entry point | Proxy | NameServer and Brokers |
 | Advertised Broker host | Docker alias such as `broker-a` | `127.0.0.1` |
 | Broker ports | Fixed `10911` in separate containers | Distinct dynamically allocated host ports |
-| Host mappings | Proxy only | NameServer A/B and every Broker |
-| Additional behavior | Proxy startup and per-Broker offset inspection | Explicit queue counts, independent NameServer routes, and host-reachable addresses |
+| Host mappings | Proxy A/B only | NameServer A/B and every Broker |
+| Additional behavior | Proxy failover and per-Broker offset inspection | Explicit queue counts, independent NameServer routes, and host-reachable addresses |
 
 A separate Proxy container can resolve `broker-a`, `broker-b`, and `broker-c`, while a host Remoting client cannot. If
 the Brokers advertise `127.0.0.1`, the host can reach them through distinct mapped ports, but `127.0.0.1` inside the

--- a/tests/it/README.zh-CN.md
+++ b/tests/it/README.zh-CN.md
@@ -9,7 +9,7 @@
 
 | 项目 | 职责 |
 | --- | --- |
-| `EventHorizon.RocketMQ.Grpc.IntegrationTests` | 通过真实的 cluster-mode Proxy 验证 gRPC 客户端。 |
+| `EventHorizon.RocketMQ.Grpc.IntegrationTests` | 通过真实的 local-mode 与 cluster-mode Proxy 验证 gRPC 客户端。 |
 | `EventHorizon.RocketMQ.Remoting.IntegrationTests` | 验证经典 NameServer 和 Broker Remoting 行为。 |
 | `EventHorizon.RocketMQ.IntegrationTestInfrastructure` | 管理可复用的 Testcontainers 拓扑、主机端口分配和测试资源名称。 |
 | `EventHorizon.RocketMQ.Remoting.CrossProcessTestHost` | 在独立操作系统进程中运行测试专用 Remoting consumer，用于跨进程 Rebalance 覆盖。 |
@@ -34,7 +34,7 @@ IntegrationTestInfrastructure --> Testcontainers
 
 ## 基础设施结构
 
-`EventHorizon.RocketMQ.IntegrationTestInfrastructure` 包含六个 public 顶层类型和一个 internal 辅助类型。
+`EventHorizon.RocketMQ.IntegrationTestInfrastructure` 包含七个 public 顶层类型和一个 internal 辅助类型。
 
 | 类型 | 职责 |
 | --- | --- |
@@ -43,7 +43,8 @@ IntegrationTestInfrastructure --> Testcontainers
 | `RocketMQTestScope` | 生成测试专用 topic 以及 producer 或 consumer group 名称。 |
 | `RocketMQTestTopicType` | 选择普通、事务、FIFO、延时或 Lite topic 的预配方式。 |
 | `RocketMQHostPortReservation` | 在当前测试进程内协调动态主机端口选择。 |
-| `RocketMQMultiBrokerGrpcContainerFixture` | 运行位于 cluster-mode Proxy 后面的三个 Docker 网络 Broker。 |
+| `RocketMQLocalProxyContainerFixture` | 运行 Broker 内嵌的 local-mode Proxy，提供专门的 gRPC 兼容性覆盖。 |
+| `RocketMQMultiBrokerClusterProxyContainerFixture` | 运行位于两个 cluster-mode Proxy 后面的三个 Docker 网络 Broker。 |
 | `RocketMQMultiBrokerRemotingContainerFixture` | 运行两个相互独立的 NameServer 和三个可从主机访问的经典 Remoting Broker；每台 Broker 都向两个 NameServer 注册。 |
 
 内部类型依赖如下：
@@ -56,7 +57,10 @@ RocketMQSingleBrokerContainerFixtureRegistry
                          `-- 创建 --> RocketMQTestScope
                                           `-- 回调 --> RocketMQSingleBrokerContainerFixture
 
-RocketMQMultiBrokerGrpcContainerFixture
+RocketMQLocalProxyContainerFixture
+    `-- 使用 --> RocketMQHostPortReservation
+
+RocketMQMultiBrokerClusterProxyContainerFixture
     `-- 使用 --> RocketMQHostPortReservation
 
 RocketMQMultiBrokerRemotingContainerFixture
@@ -93,12 +97,21 @@ Registry 刻意设计为惰性持有者，而不是通用的 Fixture 目录：
 ```
 
 `GetFixtureAsync` 使用 semaphore 和双重检查，确保并行测试类只初始化一套 Fixture。初始化失败时，Registry
-会先释放部分初始化的 Fixture，再向上传递异常。只筛选 multi-Broker 测试时，xUnit 仍会创建开销很小的
-assembly Registry，但由于没有调用 `GetFixtureAsync`，单 Broker 拓扑不会启动。
+会先释放部分初始化的 Fixture，再向上传递异常。只筛选 local-Proxy 或 multi-Broker 测试时，xUnit 仍会创建开销
+很小的 assembly Registry，但由于没有调用 `GetFixtureAsync`，单 Broker 拓扑不会启动。
 
 `RocketMQSingleBrokerContainerFixture` 会为每个 scope 预配唯一的普通 topic。事务、FIFO、延时和 Lite topic 因 Broker
 语义需要配置而预先创建，但每个 scope 仍通过唯一 suffix 隔离 group 和消息标识。Broker 管理操作的并发数
 限制为四，与集成测试的并行负载一致，同时避免串行化整个测试程序集。
+
+### Local Proxy collection
+
+`RocketMQLocalProxyContainerFixture` 是 gRPC 专用的 collection fixture。它启动一个 NameServer，并在第二个容器中执行
+`mqbroker --enable-proxy`。在官方正式版本标签 `rocketmq-all-5.5.0` 中，该命令会以 `-pm local` 启动
+`ProxyStartup`，将 Broker 嵌入 Proxy 进程。local mode 返回的路由会直接使用配置中的 gRPC 端口，因此 fixture 在
+容器内和宿主机上使用同一个动态预留端口。Broker 注册后，fixture 创建一个普通 Topic；telemetry 启动前，测试会
+显式创建唯一 consumer group，然后由 Producer 和 SimpleConsumer 完成发送、接收与 ACK。该版本的 local mode 没有
+实现 `SyncLiteSubscription`，因此这里不运行 LitePush。
 
 ### 多 Broker collection
 
@@ -106,7 +119,7 @@ assembly Registry，但由于没有调用 `GetFixtureAsync`，单 Broker 拓扑�
 
 ```text
 gRPC multi-Broker collection
-    `-- RocketMQMultiBrokerGrpcContainerFixture
+    `-- RocketMQMultiBrokerClusterProxyContainerFixture
 
 Remoting multi-Broker collection
     `-- RocketMQMultiBrokerRemotingContainerFixture
@@ -119,14 +132,15 @@ Remoting multi-Broker collection
 gRPC 多 Broker 初始化顺序为：
 
 ```text
-预留一个 Proxy 主机端口
+预留两个 Proxy 主机端口
     -> network -> NameServer -> 并行启动 Broker A/B/C
     -> 等待全部 Broker 注册
     -> 在每个 Broker 上创建 topic 并等待完整路由
-    -> 启动 Proxy
+    -> 并行启动 Proxy A/B
 ```
 
-释放按所有权的反方向执行：Proxy、各 Broker、NameServer、network，最后释放端口记录。
+客户端把两个 Proxy 地址作为一个分号分隔的 endpoint 配置。聚焦的故障切换测试会停止 Proxy A、通过 Proxy B 发送，
+并在清理前恢复 Proxy A。释放按所有权的反方向执行：Proxy B/A、各 Broker、NameServer、network，最后释放端口记录。
 
 Remoting 多 Broker 初始化顺序为：
 
@@ -171,8 +185,8 @@ Fixture 暴露的所有 endpoint 在整个生命周期内都有效。两个协�
 | 客户端入口 | Proxy | NameServer 和 Broker |
 | Broker 通告主机 | `broker-a` 等 Docker alias | `127.0.0.1` |
 | Broker 端口 | 各容器固定使用 `10911` | 各自使用动态分配的主机端口 |
-| 主机端口映射 | 只映射 Proxy | 映射 NameServer A/B 和每个 Broker |
-| 附加行为 | 启动 Proxy 并检查各 Broker offset | 显式队列数、独立 NameServer route 和主机可达地址 |
+| 主机端口映射 | 只映射 Proxy A/B | 映射 NameServer A/B 和每个 Broker |
+| 附加行为 | Proxy 故障切换并检查各 Broker offset | 显式队列数、独立 NameServer route 和主机可达地址 |
 
 独立 Proxy 容器可以解析 `broker-a`、`broker-b` 和 `broker-c`，但主机上的 Remoting client 无法解析这些
 地址。如果 Broker 通告 `127.0.0.1`，主机可以通过不同的映射端口访问它们，但 Proxy 容器中的


### PR DESCRIPTION
## Summary

- add a Broker-integrated local-mode Proxy fixture and Producer/SimpleConsumer round-trip IT
- run two cluster-mode Proxies for the multi-Broker topology and verify failover from Proxy A to Proxy B
- split gRPC CI into cluster single-Broker, local Proxy, and multi-Broker/multi-Proxy jobs and synchronize testing docs

The local fixture follows the official `rocketmq-all-5.5.0` behavior: local routes advertise `grpcServerPort` directly, so the same dynamically reserved port is used inside the container and on the host.

## Validation

- `dotnet format EventHorizon.RocketMQ.slnx --no-restore --verify-no-changes`
- `dotnet build EventHorizon.RocketMQ.slnx --no-restore --tl:off -m:1 -p:UseSharedCompilation=false`
- Release gRPC IT `Topology=LocalProxy`: 1 passed
- Release gRPC IT `Topology=MultiBroker`: 2 passed
- Release gRPC IT `Topology!=MultiBroker&Topology!=LocalProxy`: 17 passed